### PR TITLE
fix expose port to 80

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,5 +50,5 @@ WORKDIR /app
 COPY --from=build /app/backend/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 
-EXPOSE $BACKEND_PORT
+EXPOSE 80
 CMD ["node", "dist/backend/src/index.js"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,5 +29,5 @@ FROM nginx:stable-alpine
 
 COPY --from=build /app/frontend/dist /usr/share/nginx/html
 
-EXPOSE $FRONTEND_PORT
+EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
**Issue(s)**

N/A
____

**Description**

fix expose port to 80, it has to be hardcoded somewhere since the build doesn't happen on the hosting server. can still be mapped as desired in docker compose so there's no loss of flexibility.

____

**Sources**

N/A
