### PR TITLE
Feat/frontend helpers

### DIFF
--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -34,7 +34,7 @@ async function waitForDB() {
  */
 export async function migrate(
   target: string | undefined = undefined,
-  migrationsPath: string | undefined = undefined
+  migrationsPath: string | undefined = undefined,
 ) {
   const client = new pg.Client({
     connectionString: process.env["DATABASE_URL"],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "check": "pnpm run build && pnpm run test && pnpm run lint"
   },
   "dependencies": {
+    "@viernulvier/shared": "workspace:*",
     "vue": "^3.5.25"
   },
   "devDependencies": {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,173 @@
+/**
+ * @file Core API layer — the single fetch wrapper used by all resource services.
+ *
+ * Every call to the backend goes through {@link apiFetch}. This gives us one
+ * place to handle credentials, JSON serialisation, and error normalisation.
+ *
+ * Usage:
+ * ```ts
+ * import { apiFetch, ApiError } from "@/services/api";
+ *
+ * const productions = await apiFetch<Production[]>("/production");
+ * ```
+ */
+
+/** Root path prepended to every {@link apiFetch} call. */
+const API_BASE = "/api/v1";
+
+// ---------------------------------------------------------------------------
+// ApiError
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by {@link apiFetch} whenever the server returns a non-2xx status.
+ *
+ * Typed convenience getters make it easy to branch on common error codes
+ * without comparing magic numbers:
+ *
+ * ```ts
+ * try {
+ *   await login({ username: "admin", password: "wrong" });
+ * } catch (err) {
+ *   if (err instanceof ApiError && err.isUnauthorized) {
+ *     showMessage("Wrong username or password.");
+ *   }
+ * }
+ * ```
+ */
+export class ApiError extends Error {
+  /** HTTP status code returned by the server (e.g. 401, 404, 422). */
+  readonly status: number;
+
+  /**
+   * Per-field validation errors keyed by field name.
+   * Only present when the server returns structured field errors (e.g. 422).
+   *
+   * @example
+   * { username: ["Too long", "Already taken"] }
+   */
+  readonly fields?: Record<string, string[]>;
+
+  constructor(
+    status: number,
+    message: string,
+    fields?: Record<string, string[]>,
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.fields = fields;
+  }
+
+  /** `true` when the session is missing or expired (HTTP 401). */
+  get isUnauthorized(): boolean {
+    return this.status === 401;
+  }
+
+  /** `true` when the session is valid but the user lacks permission (HTTP 403). */
+  get isForbidden(): boolean {
+    return this.status === 403;
+  }
+
+  /** `true` when the requested resource does not exist (HTTP 404). */
+  get isNotFound(): boolean {
+    return this.status === 404;
+  }
+
+  /** `true` when a uniqueness constraint was violated (HTTP 409). */
+  get isConflict(): boolean {
+    return this.status === 409;
+  }
+
+  /** `true` when the server rejected the request body as invalid (HTTP 422). */
+  get isUnprocessable(): boolean {
+    return this.status === 422;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// apiFetch
+// ---------------------------------------------------------------------------
+
+/**
+ * `RequestInit` extended with a typed `body` that is automatically serialised
+ * to JSON. The native `body: BodyInit` is replaced so callers can pass any
+ * value without manual `JSON.stringify`.
+ */
+type ApiFetchOptions = Omit<RequestInit, "body"> & {
+  /**
+   * Request payload — serialised with `JSON.stringify` before sending.
+   * Omit this field entirely for requests without a body (GET, DELETE, …).
+   */
+  body?: unknown;
+};
+
+/**
+ * Fetch wrapper for all `/api/v1/*` calls.
+ *
+ * - Sends cookies with every request (`credentials: "same-origin"`).
+ * - Sets `Content-Type: application/json` automatically.
+ * - Serialises `options.body` with `JSON.stringify`.
+ * - On non-ok responses, parses the error body and throws an {@link ApiError}.
+ * - Returns `undefined` (cast to `T`) for `204 No Content` responses.
+ *
+ * @param path    Path relative to `/api/v1`, e.g. `"/production"` or `"/production/42"`.
+ * @param options Standard fetch options plus an optional typed `body`.
+ * @returns       The parsed JSON response body cast to `T`.
+ * @throws        {@link ApiError} on any non-2xx response.
+ *
+ * @example
+ * // GET
+ * const productions = await apiFetch<Production[]>("/production");
+ *
+ * // POST with body
+ * const created = await apiFetch<Production>("/production", {
+ *   method: "POST",
+ *   body: { title: { nl: "Hamlet" }, artist: { nl: "Shakespeare" }, … },
+ * });
+ *
+ * // DELETE (no response body)
+ * await apiFetch<void>("/production/42", { method: "DELETE" });
+ */
+export async function apiFetch<T>(
+  path: string,
+  options: ApiFetchOptions = {},
+): Promise<T> {
+  const { body, headers, ...rest } = options;
+
+  const response = await fetch(`${API_BASE}${path}`, {
+    credentials: "same-origin",
+    headers: {
+      "Content-Type": "application/json",
+      ...(headers as Record<string, string>),
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    ...rest,
+  });
+
+  if (!response.ok) {
+    let message = response.statusText;
+    let fields: Record<string, string[]> | undefined;
+
+    try {
+      const errorBody = (await response.json()) as {
+        error?: string;
+        message?: string;
+        fields?: Record<string, string[]>;
+      };
+      message = errorBody.error ?? errorBody.message ?? message;
+      fields = errorBody.fields;
+    } catch {
+      // JSON parsing failed — keep the statusText as the message.
+    }
+
+    throw new ApiError(response.status, message, fields);
+  }
+
+  // 204 No Content — nothing to parse.
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,223 @@
+/**
+ * @file Auth & Admin API — login/logout and CRUD for admin accounts.
+ *
+ * Authentication uses an httpOnly `session` cookie set by the server on login.
+ * The cookie is sent automatically with every subsequent request thanks to
+ * `credentials: "same-origin"` in {@link apiFetch}.
+ *
+ * Because the cookie is httpOnly, the frontend cannot read it directly. Any
+ * call to a protected endpoint will throw an {@link ApiError} with
+ * `isUnauthorized === true` when the session has expired.
+ *
+ * > **Note:** a `GET /api/v1/auth/me` endpoint would allow proper session
+ * > checks without knowing the admin's ID. Consider adding it to the backend.
+ *
+ * Usage:
+ * ```ts
+ * import { login, logout, ApiError } from "@/services/auth";
+ *
+ * try {
+ *   await login({ username: "admin", password: "secret" });
+ * } catch (err) {
+ *   if (err instanceof ApiError && err.isUnauthorized) {
+ *     showError("Wrong credentials.");
+ *   }
+ * }
+ * ```
+ */
+
+import type { Admin, AdminWithMeta } from "@viernulvier/shared";
+import { apiFetch, ApiError } from "./api";
+
+// Re-export ApiError so callers only need to import from this module.
+export { ApiError };
+
+// ---------------------------------------------------------------------------
+// Input types
+// ---------------------------------------------------------------------------
+
+/** Payload for the login endpoint. */
+export interface LoginCredentials {
+  username: string;
+  password: string;
+}
+
+/** Payload for creating a new admin account. */
+export interface CreateAdminInput {
+  username: string;
+  password: string;
+  profile_picture?: string | null;
+}
+
+/**
+ * Payload for fully replacing an admin account (PUT semantics).
+ * All fields are required.
+ */
+export interface ReplaceAdminInput {
+  username: string;
+  password: string;
+  profile_picture: string | null;
+}
+
+/**
+ * Payload for partially updating an admin account (PATCH semantics).
+ * Only include the fields you want to change.
+ */
+export type UpdateAdminInput = Partial<ReplaceAdminInput>;
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+
+/**
+ * Logs in with the given credentials.
+ *
+ * On success the server sets an httpOnly `session` cookie that is sent
+ * automatically with every subsequent request.
+ *
+ * @throws {ApiError} 401 — wrong username or password.
+ *
+ * @example
+ * await login({ username: "admin", password: "secret" });
+ */
+export async function login(credentials: LoginCredentials): Promise<void> {
+  await apiFetch("/auth/login", { method: "POST", body: credentials });
+}
+
+/**
+ * Logs out the current session. The server clears the `session` cookie.
+ *
+ * @example
+ * await logout();
+ */
+export async function logout(): Promise<void> {
+  await apiFetch("/auth/logout", { method: "POST" });
+}
+
+/**
+ * Wraps an async operation and calls `onUnauthorized` when the session has
+ * expired (HTTP 401). All other errors are re-thrown unchanged.
+ *
+ * Useful for protecting form submissions or data-loading actions in components
+ * without repeating auth-error handling logic everywhere.
+ *
+ * @param fn             The async operation to execute.
+ * @param onUnauthorized Called when the session is missing or expired.
+ *                       Typically navigates to the login page.
+ * @returns              The result of `fn` when it succeeds.
+ * @throws               Any non-401 error thrown by `fn`.
+ *
+ * @example
+ * const production = await withAuth(
+ *   () => getProductionWithMeta(42),
+ *   () => router.push("/login"),
+ * );
+ */
+export async function withAuth<T>(
+  fn: () => Promise<T>,
+  onUnauthorized: () => void,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof ApiError && err.isUnauthorized) {
+      onUnauthorized();
+    }
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Admin CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches a single admin by ID.
+ *
+ * @param id The admin's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — admin not found.
+ *
+ * @example
+ * const admin = await getAdmin(1);
+ * console.log(admin.username);
+ */
+export async function getAdmin(id: number): Promise<Admin> {
+  return apiFetch<Admin>(`/auth/${id}`);
+}
+
+/**
+ * Fetches a single admin including audit metadata
+ * (`created_at`, `created_by`, `updated_at`, `updated_by`).
+ *
+ * @param id The admin's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — admin not found.
+ */
+export async function getAdminWithMeta(id: number): Promise<AdminWithMeta> {
+  return apiFetch<AdminWithMeta>(`/auth/${id}/meta`);
+}
+
+/**
+ * Creates a new admin account.
+ *
+ * @param data Username, plain-text password, and optional profile picture URL.
+ * @returns    The newly created admin (without the password).
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 409 — username already taken.
+ *
+ * @example
+ * const admin = await createAdmin({
+ *   username: "maria",
+ *   password: "correct-horse-battery-staple",
+ *   profile_picture: null,
+ * });
+ */
+export async function createAdmin(data: CreateAdminInput): Promise<Admin> {
+  return apiFetch<Admin>("/auth", { method: "POST", body: data });
+}
+
+/**
+ * Replaces an admin account entirely (PUT semantics — all fields required).
+ *
+ * @param id   The admin's primary key.
+ * @param data Full replacement payload including the new password.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — admin not found.
+ */
+export async function replaceAdmin(
+  id: number,
+  data: ReplaceAdminInput,
+): Promise<Admin> {
+  return apiFetch<Admin>(`/auth/${id}`, { method: "PUT", body: data });
+}
+
+/**
+ * Partially updates an admin account (PATCH semantics — only send changed fields).
+ *
+ * @param id   The admin's primary key.
+ * @param data Only the fields that should change.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — admin not found.
+ *
+ * @example
+ * // Only update the profile picture
+ * await updateAdmin(1, { profile_picture: "https://example.com/avatar.jpg" });
+ */
+export async function updateAdmin(
+  id: number,
+  data: UpdateAdminInput,
+): Promise<Admin> {
+  return apiFetch<Admin>(`/auth/${id}`, { method: "PATCH", body: data });
+}
+
+/**
+ * Permanently deletes an admin account.
+ *
+ * @param id The admin's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — admin not found.
+ */
+export async function deleteAdmin(id: number): Promise<void> {
+  await apiFetch<void>(`/auth/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/services/eventPrices.ts
+++ b/frontend/src/services/eventPrices.ts
@@ -1,0 +1,158 @@
+/**
+ * @file EventPrice API — CRUD for price tiers attached to events.
+ *
+ * > **⚠ Backend bug:** the event price routes are currently registered with an
+ * > incorrect prefix (`/event_price/api/v1/...` instead of
+ * > `/api/v1/event_price/...`). The functions below use the *intended* correct
+ * > paths. They will work once the backend prefix is fixed.
+ *
+ * Public endpoints (no session required):
+ *   - {@link getEventPrices} — list all event prices
+ *   - {@link getEventPrice}  — fetch one event price by ID
+ *
+ * Protected endpoints (active session required):
+ *   - {@link getEventPriceWithMeta}, {@link createEventPrice},
+ *     {@link replaceEventPrice}, {@link updateEventPrice},
+ *     {@link deleteEventPrice}
+ *
+ * Usage:
+ * ```ts
+ * import { getEventPrice, createEventPrice } from "@/services/eventPrices";
+ * ```
+ */
+
+import type { EventPrice, EventPriceWithMeta } from "@viernulvier/shared";
+import { apiFetch } from "./api";
+
+// ---------------------------------------------------------------------------
+// Input types
+// ---------------------------------------------------------------------------
+
+/** Payload for creating a new price tier for an event. */
+export interface CreateEventPriceInput {
+  /** ID of the event this price tier belongs to. */
+  event: number;
+  /** Price amount (non-negative, in the currency used by the system). */
+  amount: number;
+}
+
+/**
+ * Payload for fully replacing an event price (PUT semantics).
+ * Identical shape to {@link CreateEventPriceInput}.
+ */
+export type ReplaceEventPriceInput = CreateEventPriceInput;
+
+/**
+ * Payload for partially updating an event price (PATCH semantics).
+ * Only include the fields that should change.
+ */
+export type UpdateEventPriceInput = Partial<CreateEventPriceInput>;
+
+// ---------------------------------------------------------------------------
+// Public endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches all event price tiers (public — no session required).
+ *
+ * @example
+ * const prices = await getEventPrices();
+ */
+export async function getEventPrices(): Promise<EventPrice[]> {
+  return apiFetch<EventPrice[]>("/event_price");
+}
+
+/**
+ * Fetches a single event price tier by ID (public — no session required).
+ *
+ * @param id The event price's primary key.
+ * @throws {ApiError} 404 — event price not found.
+ */
+export async function getEventPrice(id: number): Promise<EventPrice> {
+  return apiFetch<EventPrice>(`/event_price/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Protected endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches a single event price tier including audit metadata.
+ *
+ * @param id The event price's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — event price not found.
+ */
+export async function getEventPriceWithMeta(
+  id: number,
+): Promise<EventPriceWithMeta> {
+  return apiFetch<EventPriceWithMeta>(`/event_price/${id}/meta`);
+}
+
+/**
+ * Creates a new price tier for an event.
+ *
+ * @param data Event ID and price amount.
+ * @returns    The newly created event price.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 422 — validation failed (check `err.fields`).
+ *
+ * @example
+ * const price = await createEventPrice({ event: 7, amount: 18.50 });
+ */
+export async function createEventPrice(
+  data: CreateEventPriceInput,
+): Promise<EventPrice> {
+  return apiFetch<EventPrice>("/event_price", { method: "POST", body: data });
+}
+
+/**
+ * Replaces an event price tier entirely (PUT semantics — all fields required).
+ *
+ * @param id   The event price's primary key.
+ * @param data Full replacement payload.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — event price not found.
+ */
+export async function replaceEventPrice(
+  id: number,
+  data: ReplaceEventPriceInput,
+): Promise<EventPrice> {
+  return apiFetch<EventPrice>(`/event_price/${id}`, {
+    method: "PUT",
+    body: data,
+  });
+}
+
+/**
+ * Partially updates an event price tier (PATCH semantics — only send changed fields).
+ *
+ * @param id   The event price's primary key.
+ * @param data Only the fields that should change.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — event price not found.
+ *
+ * @example
+ * // Adjust the price without changing the event
+ * await updateEventPrice(5, { amount: 20.00 });
+ */
+export async function updateEventPrice(
+  id: number,
+  data: UpdateEventPriceInput,
+): Promise<EventPrice> {
+  return apiFetch<EventPrice>(`/event_price/${id}`, {
+    method: "PATCH",
+    body: data,
+  });
+}
+
+/**
+ * Permanently deletes an event price tier.
+ *
+ * @param id The event price's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — event price not found.
+ */
+export async function deleteEventPrice(id: number): Promise<void> {
+  await apiFetch<void>(`/event_price/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/services/events.ts
+++ b/frontend/src/services/events.ts
@@ -1,0 +1,193 @@
+/**
+ * @file Event API — CRUD for events (specific occurrences of a production).
+ *
+ * Public endpoints (no session required):
+ *   - {@link getEvents} — list all events
+ *   - {@link getEvent}  — fetch one event by ID
+ *
+ * Protected endpoints (active session required):
+ *   - {@link getEventWithMeta}, {@link createEvent}, {@link replaceEvent},
+ *     {@link updateEvent}, {@link bulkUpdateEvents}, {@link deleteEvent}
+ *
+ * Usage:
+ * ```ts
+ * import { getEvents } from "@/services/events";
+ *
+ * const events = await getEvents();
+ * ```
+ */
+
+import type { Event, EventWithMeta } from "@viernulvier/shared";
+import { apiFetch } from "./api";
+import type { LanguageMap } from "../utils/i18n";
+
+// ---------------------------------------------------------------------------
+// Input types
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload for creating a new event.
+ * Dates can be ISO 8601 strings — the backend coerces them.
+ */
+export interface CreateEventInput {
+  /** ID of the production this event belongs to. */
+  production: number;
+  /** ID of the hall (venue) where the event takes place. */
+  hall: number;
+  /** Start date/time of the performance. ISO 8601 string or Date. */
+  starts_at: string | Date;
+  /** End date/time of the performance. ISO 8601 string or Date. */
+  ends_at: string | Date;
+  /** Time doors open. ISO 8601 string or Date. */
+  doors_at: string | Date;
+  /** External vendor ID. */
+  vendor_id: number;
+  /** Additional info text shown to the public. */
+  info: LanguageMap;
+}
+
+/**
+ * Payload for fully replacing an event (PUT semantics).
+ * Identical shape to {@link CreateEventInput}.
+ */
+export type ReplaceEventInput = CreateEventInput;
+
+/**
+ * Payload for partially updating an event (PATCH semantics).
+ * Only include the fields that should change.
+ */
+export type UpdateEventInput = Partial<CreateEventInput>;
+
+// ---------------------------------------------------------------------------
+// Public endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches all events (public — no session required).
+ *
+ * @returns Array of events, each including a reference to its production,
+ *          hall, and price tiers.
+ *
+ * @example
+ * const events = await getEvents();
+ */
+export async function getEvents(): Promise<Event[]> {
+  return apiFetch<Event[]>("/event");
+}
+
+/**
+ * Fetches a single event by ID (public — no session required).
+ *
+ * @param id The event's primary key.
+ * @throws {ApiError} 404 — event not found.
+ *
+ * @example
+ * const event = await getEvent(7);
+ * console.log(event.starts_at);
+ */
+export async function getEvent(id: number): Promise<Event> {
+  return apiFetch<Event>(`/event/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Protected endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches a single event including audit metadata
+ * (`created_at`, `created_by`, `updated_at`, `updated_by`).
+ *
+ * @param id The event's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — event not found.
+ */
+export async function getEventWithMeta(id: number): Promise<EventWithMeta> {
+  return apiFetch<EventWithMeta>(`/event/${id}/meta`);
+}
+
+/**
+ * Creates a new event.
+ *
+ * @param data All required fields for a new event.
+ * @returns    The newly created event.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 422 — validation failed (check `err.fields`).
+ *
+ * @example
+ * const event = await createEvent({
+ *   production: 42,
+ *   hall: 1,
+ *   starts_at: "2025-04-12T20:00:00",
+ *   ends_at:   "2025-04-12T22:00:00",
+ *   doors_at:  "2025-04-12T19:30:00",
+ *   vendor_id: 999,
+ *   info: { nl: "Uitverkocht" },
+ * });
+ */
+export async function createEvent(data: CreateEventInput): Promise<Event> {
+  return apiFetch<Event>("/event", { method: "POST", body: data });
+}
+
+/**
+ * Replaces an event entirely (PUT semantics — all fields required).
+ *
+ * @param id   The event's primary key.
+ * @param data Full replacement payload.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — event not found.
+ */
+export async function replaceEvent(
+  id: number,
+  data: ReplaceEventInput,
+): Promise<Event> {
+  return apiFetch<Event>(`/event/${id}`, { method: "PUT", body: data });
+}
+
+/**
+ * Partially updates an event (PATCH semantics — only send changed fields).
+ *
+ * @param id   The event's primary key.
+ * @param data Only the fields that should change.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — event not found.
+ *
+ * @example
+ * // Mark an event as sold out
+ * await updateEvent(7, { info: { nl: "Uitverkocht", en: "Sold out" } });
+ */
+export async function updateEvent(
+  id: number,
+  data: UpdateEventInput,
+): Promise<Event> {
+  return apiFetch<Event>(`/event/${id}`, { method: "PATCH", body: data });
+}
+
+/**
+ * Applies the same partial update to multiple events in a single request.
+ *
+ * @param data Array of partial updates, each containing the event `id` and
+ *             the fields to change.
+ * @throws {ApiError} 401 — unauthenticated.
+ *
+ * @example
+ * await bulkUpdateEvents([
+ *   { id: 1, info: { nl: "Uitverkocht" } },
+ *   { id: 2, info: { nl: "Uitverkocht" } },
+ * ]);
+ */
+export async function bulkUpdateEvents(
+  data: Array<UpdateEventInput & { id: number }>,
+): Promise<Event[]> {
+  return apiFetch<Event[]>("/event", { method: "PATCH", body: data });
+}
+
+/**
+ * Permanently deletes an event.
+ *
+ * @param id The event's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — event not found.
+ */
+export async function deleteEvent(id: number): Promise<void> {
+  await apiFetch<void>(`/event/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/services/halls.ts
+++ b/frontend/src/services/halls.ts
@@ -1,0 +1,155 @@
+/**
+ * @file Hall API — CRUD for halls (venue locations).
+ *
+ * Public endpoints (no session required):
+ *   - {@link getHalls} — list all halls
+ *   - {@link getHall}  — fetch one hall by ID
+ *
+ * Protected endpoints (active session required):
+ *   - {@link getHallWithMeta}, {@link createHall}, {@link replaceHall},
+ *     {@link updateHall}, {@link deleteHall}
+ *
+ * Usage:
+ * ```ts
+ * import { getHalls } from "@/services/halls";
+ *
+ * const halls = await getHalls();
+ * ```
+ */
+
+import type { Hall, HallWithMeta } from "@viernulvier/shared";
+import { apiFetch } from "./api";
+import type { LanguageMap } from "../utils/i18n";
+
+// ---------------------------------------------------------------------------
+// Input types
+// ---------------------------------------------------------------------------
+
+/** Payload for creating a new hall. */
+export interface CreateHallInput {
+  /** External vendor ID. */
+  vendor_id: number;
+  /** Physical address of the venue. */
+  address: string;
+  /** Localised name of the hall (at least one language required). */
+  name: LanguageMap;
+}
+
+/**
+ * Payload for fully replacing a hall (PUT semantics).
+ * Identical shape to {@link CreateHallInput}.
+ */
+export type ReplaceHallInput = CreateHallInput;
+
+/**
+ * Payload for partially updating a hall (PATCH semantics).
+ * Only include the fields that should change.
+ */
+export type UpdateHallInput = Partial<CreateHallInput>;
+
+// ---------------------------------------------------------------------------
+// Public endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches all halls (public — no session required).
+ *
+ * @example
+ * const halls = await getHalls();
+ */
+export async function getHalls(): Promise<Hall[]> {
+  return apiFetch<Hall[]>("/hall");
+}
+
+/**
+ * Fetches a single hall by ID (public — no session required).
+ *
+ * @param id The hall's primary key.
+ * @throws {ApiError} 404 — hall not found.
+ *
+ * @example
+ * const hall = await getHall(1);
+ * console.log(hall.address);
+ */
+export async function getHall(id: number): Promise<Hall> {
+  return apiFetch<Hall>(`/hall/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Protected endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches a single hall including audit metadata
+ * (`created_at`, `created_by`, `updated_at`, `updated_by`).
+ *
+ * @param id The hall's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — hall not found.
+ */
+export async function getHallWithMeta(id: number): Promise<HallWithMeta> {
+  return apiFetch<HallWithMeta>(`/hall/${id}/meta`);
+}
+
+/**
+ * Creates a new hall.
+ *
+ * @param data All required fields.
+ * @returns    The newly created hall.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 422 — validation failed (check `err.fields`).
+ *
+ * @example
+ * const hall = await createHall({
+ *   vendor_id: 1,
+ *   address: "Sint-Pietersnieuwstraat 23, 9000 Gent",
+ *   name: { nl: "Grote Zaal", en: "Main Hall" },
+ * });
+ */
+export async function createHall(data: CreateHallInput): Promise<Hall> {
+  return apiFetch<Hall>("/hall", { method: "POST", body: data });
+}
+
+/**
+ * Replaces a hall entirely (PUT semantics — all fields required).
+ *
+ * @param id   The hall's primary key.
+ * @param data Full replacement payload.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — hall not found.
+ */
+export async function replaceHall(
+  id: number,
+  data: ReplaceHallInput,
+): Promise<Hall> {
+  return apiFetch<Hall>(`/hall/${id}`, { method: "PUT", body: data });
+}
+
+/**
+ * Partially updates a hall (PATCH semantics — only send changed fields).
+ *
+ * @param id   The hall's primary key.
+ * @param data Only the fields that should change.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — hall not found.
+ *
+ * @example
+ * await updateHall(1, { address: "Nieuw adres 1, 9000 Gent" });
+ */
+export async function updateHall(
+  id: number,
+  data: UpdateHallInput,
+): Promise<Hall> {
+  return apiFetch<Hall>(`/hall/${id}`, { method: "PATCH", body: data });
+}
+
+/**
+ * Permanently deletes a hall.
+ *
+ * @param id The hall's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — hall not found.
+ */
+export async function deleteHall(id: number): Promise<void> {
+  await apiFetch<void>(`/hall/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/services/productions.ts
+++ b/frontend/src/services/productions.ts
@@ -1,0 +1,223 @@
+/**
+ * @file Production API — CRUD for productions.
+ *
+ * Public endpoints (no session required):
+ *   - {@link getProductions} — list all productions
+ *   - {@link getProduction}  — fetch one production by ID
+ *
+ * Protected endpoints (active session required):
+ *   - {@link getProductionWithMeta}, {@link createProduction},
+ *     {@link replaceProduction}, {@link updateProduction},
+ *     {@link bulkUpdateProductions}, {@link deleteProduction}
+ *
+ * Usage:
+ * ```ts
+ * import { getProductions, createProduction } from "@/services/productions";
+ *
+ * const list = await getProductions();
+ * ```
+ */
+
+import type { Production, ProductionWithMeta } from "@viernulvier/shared";
+import { apiFetch } from "./api";
+import type { LanguageMap } from "../utils/i18n";
+
+// ---------------------------------------------------------------------------
+// Input types
+// ---------------------------------------------------------------------------
+
+/**
+ * Payload for creating a new production.
+ * Required fields match the backend schema — all multilingual content fields
+ * that are optional default to `null` on the server.
+ */
+export interface CreateProductionInput {
+  vendor_id: number;
+  box_office_id: number;
+  /** Main title of the production (at least one language required). */
+  title: LanguageMap;
+  /** Performing artist or company. */
+  artist: LanguageMap;
+  /** Short tagline shown in listings. */
+  tagline: LanguageMap;
+  /** Short teaser text shown on overview pages. */
+  teaser: LanguageMap;
+  supertitle?: LanguageMap | null;
+  description?: LanguageMap | null;
+  description_extra?: LanguageMap | null;
+  description_2?: LanguageMap | null;
+  video_1?: LanguageMap | null;
+  video_2?: LanguageMap | null;
+  quote?: LanguageMap | null;
+  quote_source?: LanguageMap | null;
+  programme?: LanguageMap | null;
+  info?: LanguageMap | null;
+}
+
+/**
+ * Payload for fully replacing a production (PUT semantics).
+ * Identical shape to {@link CreateProductionInput}.
+ */
+export type ReplaceProductionInput = CreateProductionInput;
+
+/**
+ * Payload for partially updating a production (PATCH semantics).
+ * Only include the fields that should change.
+ */
+export type UpdateProductionInput = Partial<CreateProductionInput>;
+
+/**
+ * Payload for the bulk-update endpoint.
+ * Applies the same partial update to every production in `ids`.
+ */
+export interface BulkUpdateProductionsInput {
+  /** IDs of the productions to update. */
+  ids: number[];
+  /** Fields to change on every production in the list. */
+  data: UpdateProductionInput;
+}
+
+// ---------------------------------------------------------------------------
+// Public endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches all productions (public — no session required).
+ *
+ * @returns Array of productions, possibly including nested tags and events.
+ *
+ * @example
+ * const productions = await getProductions();
+ */
+export async function getProductions(): Promise<Production[]> {
+  return apiFetch<Production[]>("/production");
+}
+
+/**
+ * Fetches a single production by ID (public — no session required).
+ *
+ * @param id The production's primary key.
+ * @throws {ApiError} 404 — production not found.
+ *
+ * @example
+ * const production = await getProduction(42);
+ * console.log(production.title);
+ */
+export async function getProduction(id: number): Promise<Production> {
+  return apiFetch<Production>(`/production/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Protected endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches a single production including audit metadata
+ * (`created_at`, `created_by`, `updated_at`, `updated_by`).
+ *
+ * @param id The production's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — production not found.
+ */
+export async function getProductionWithMeta(
+  id: number,
+): Promise<ProductionWithMeta> {
+  return apiFetch<ProductionWithMeta>(`/production/${id}/meta`);
+}
+
+/**
+ * Creates a new production.
+ *
+ * @param data All required fields for a new production.
+ * @returns    The newly created production.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 422 — validation failed (check `err.fields`).
+ *
+ * @example
+ * const production = await createProduction({
+ *   vendor_id: 1,
+ *   box_office_id: 100,
+ *   title: { nl: "Hamlet" },
+ *   artist: { nl: "William Shakespeare" },
+ *   tagline: { nl: "To be or not to be." },
+ *   teaser: { nl: "Een tijdloos drama." },
+ * });
+ */
+export async function createProduction(
+  data: CreateProductionInput,
+): Promise<Production> {
+  return apiFetch<Production>("/production", { method: "POST", body: data });
+}
+
+/**
+ * Replaces a production entirely (PUT semantics — all fields required).
+ *
+ * @param id   The production's primary key.
+ * @param data Full replacement payload.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — production not found.
+ */
+export async function replaceProduction(
+  id: number,
+  data: ReplaceProductionInput,
+): Promise<Production> {
+  return apiFetch<Production>(`/production/${id}`, {
+    method: "PUT",
+    body: data,
+  });
+}
+
+/**
+ * Partially updates a production (PATCH semantics — only send changed fields).
+ *
+ * @param id   The production's primary key.
+ * @param data Only the fields that should change.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — production not found.
+ *
+ * @example
+ * // Only update the Dutch title
+ * await updateProduction(42, { title: { nl: "Nieuwe titel" } });
+ */
+export async function updateProduction(
+  id: number,
+  data: UpdateProductionInput,
+): Promise<Production> {
+  return apiFetch<Production>(`/production/${id}`, {
+    method: "PATCH",
+    body: data,
+  });
+}
+
+/**
+ * Applies the same partial update to multiple productions in a single request.
+ *
+ * @param input Object containing the list of IDs and the fields to update.
+ * @throws {ApiError} 401 — unauthenticated.
+ *
+ * @example
+ * // Translate the tagline of productions 1, 2 and 3 in one call
+ * await bulkUpdateProductions({
+ *   ids: [1, 2, 3],
+ *   data: { tagline: { en: "A timeless classic." } },
+ * });
+ */
+export async function bulkUpdateProductions(
+  input: BulkUpdateProductionsInput,
+): Promise<Production[]> {
+  return apiFetch<Production[]>("/production/bulk", {
+    method: "PATCH",
+    body: input,
+  });
+}
+
+/**
+ * Permanently deletes a production.
+ *
+ * @param id The production's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — production not found.
+ */
+export async function deleteProduction(id: number): Promise<void> {
+  await apiFetch<void>(`/production/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/services/tags.ts
+++ b/frontend/src/services/tags.ts
@@ -1,0 +1,303 @@
+/**
+ * @file Tag & TagType API — CRUD for tags and tag types.
+ *
+ * Tags are labels attached to productions (e.g. genre, age category).
+ * Every tag belongs to a {@link TagType} (e.g. "Genre", "Leeftijd").
+ *
+ * Tags have a `public` flag. The public endpoints only expose visible tags;
+ * the admin endpoints expose all tags regardless of visibility.
+ *
+ * Public endpoints:
+ *   - {@link getTags}, {@link getTag}
+ *   - {@link getTagTypes}, {@link getTagType}
+ *
+ * Protected endpoints:
+ *   - {@link getAllTags}, {@link getTagAdmin}, {@link getTagWithMeta},
+ *     {@link createTag}, {@link replaceTag}, {@link updateTag}, {@link deleteTag}
+ *   - {@link getTagTypeWithMeta}, {@link createTagType}, {@link replaceTagType},
+ *     {@link updateTagType}, {@link deleteTagType}
+ *
+ * Usage:
+ * ```ts
+ * import { getTags, createTag } from "@/services/tags";
+ *
+ * const tags = await getTags();
+ * ```
+ */
+
+import type { Tag, TagWithMeta, TagType, TagTypeWithMeta } from "@viernulvier/shared";
+import { apiFetch } from "./api";
+import type { LanguageMap } from "../utils/i18n";
+
+// ---------------------------------------------------------------------------
+// Input types — Tag
+// ---------------------------------------------------------------------------
+
+/** Payload for creating a new tag. */
+export interface CreateTagInput {
+  /** Localised display name of the tag. */
+  name: LanguageMap;
+  /** ID of the tag type this tag belongs to. */
+  type: number;
+  /** Whether this tag is visible to the public. */
+  public: boolean;
+}
+
+/**
+ * Payload for fully replacing a tag (PUT semantics).
+ * Identical shape to {@link CreateTagInput}.
+ */
+export type ReplaceTagInput = CreateTagInput;
+
+/**
+ * Payload for partially updating a tag (PATCH semantics).
+ * Only include the fields that should change.
+ */
+export type UpdateTagInput = Partial<CreateTagInput>;
+
+// ---------------------------------------------------------------------------
+// Input types — TagType
+// ---------------------------------------------------------------------------
+
+/** Payload for creating a new tag type. */
+export interface CreateTagTypeInput {
+  /** Localised display name of the tag type. */
+  name: LanguageMap;
+}
+
+/**
+ * Payload for fully replacing a tag type (PUT semantics).
+ * Identical shape to {@link CreateTagTypeInput}.
+ */
+export type ReplaceTagTypeInput = CreateTagTypeInput;
+
+/**
+ * Payload for partially updating a tag type (PATCH semantics).
+ * Only include the fields that should change.
+ */
+export type UpdateTagTypeInput = Partial<CreateTagTypeInput>;
+
+// ---------------------------------------------------------------------------
+// Tag — public endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches all publicly visible tags (public — no session required).
+ *
+ * Only tags with `public: true` are returned.
+ *
+ * @example
+ * const tags = await getTags();
+ */
+export async function getTags(): Promise<Tag[]> {
+  return apiFetch<Tag[]>("/tags");
+}
+
+/**
+ * Fetches a single publicly visible tag by ID (public — no session required).
+ *
+ * @param id The tag's primary key.
+ * @throws {ApiError} 404 — tag not found or not public.
+ */
+export async function getTag(id: number): Promise<Tag> {
+  return apiFetch<Tag>(`/tags/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Tag — protected endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches all tags, including hidden ones (public: false).
+ *
+ * @throws {ApiError} 401 — unauthenticated.
+ *
+ * @example
+ * const allTags = await getAllTags();
+ */
+export async function getAllTags(): Promise<Tag[]> {
+  return apiFetch<Tag[]>("/tags/all");
+}
+
+/**
+ * Fetches any tag by ID, regardless of its `public` flag.
+ *
+ * @param id The tag's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — tag not found.
+ */
+export async function getTagAdmin(id: number): Promise<Tag> {
+  return apiFetch<Tag>(`/tags/${id}/all`);
+}
+
+/**
+ * Fetches a single tag including audit metadata.
+ *
+ * @param id The tag's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — tag not found.
+ */
+export async function getTagWithMeta(id: number): Promise<TagWithMeta> {
+  return apiFetch<TagWithMeta>(`/tags/${id}/meta`);
+}
+
+/**
+ * Creates a new tag.
+ *
+ * @param data Tag name, type ID, and visibility.
+ * @returns    The newly created tag.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 422 — validation failed (check `err.fields`).
+ *
+ * @example
+ * const tag = await createTag({
+ *   name: { nl: "Drama", en: "Drama", fr: "Drame" },
+ *   type: 1,
+ *   public: true,
+ * });
+ */
+export async function createTag(data: CreateTagInput): Promise<Tag> {
+  return apiFetch<Tag>("/tags", { method: "POST", body: data });
+}
+
+/**
+ * Replaces a tag entirely (PUT semantics — all fields required).
+ *
+ * @param id   The tag's primary key.
+ * @param data Full replacement payload.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — tag not found.
+ */
+export async function replaceTag(
+  id: number,
+  data: ReplaceTagInput,
+): Promise<Tag> {
+  return apiFetch<Tag>(`/tags/${id}`, { method: "PUT", body: data });
+}
+
+/**
+ * Partially updates a tag (PATCH semantics — only send changed fields).
+ *
+ * @param id   The tag's primary key.
+ * @param data Only the fields that should change.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — tag not found.
+ *
+ * @example
+ * // Hide a tag without changing anything else
+ * await updateTag(3, { public: false });
+ */
+export async function updateTag(
+  id: number,
+  data: UpdateTagInput,
+): Promise<Tag> {
+  return apiFetch<Tag>(`/tags/${id}`, { method: "PATCH", body: data });
+}
+
+/**
+ * Permanently deletes a tag.
+ *
+ * @param id The tag's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — tag not found.
+ */
+export async function deleteTag(id: number): Promise<void> {
+  await apiFetch<void>(`/tags/${id}`, { method: "DELETE" });
+}
+
+// ---------------------------------------------------------------------------
+// TagType — public endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches all tag types (public — no session required).
+ *
+ * @example
+ * const types = await getTagTypes();
+ */
+export async function getTagTypes(): Promise<TagType[]> {
+  return apiFetch<TagType[]>("/tags/type");
+}
+
+/**
+ * Fetches a single tag type by ID (public — no session required).
+ *
+ * @param id The tag type's primary key.
+ * @throws {ApiError} 404 — tag type not found.
+ */
+export async function getTagType(id: number): Promise<TagType> {
+  return apiFetch<TagType>(`/tags/type/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// TagType — protected endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches a single tag type including audit metadata.
+ *
+ * @param id The tag type's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — tag type not found.
+ */
+export async function getTagTypeWithMeta(id: number): Promise<TagTypeWithMeta> {
+  return apiFetch<TagTypeWithMeta>(`/tags/type/${id}/meta`);
+}
+
+/**
+ * Creates a new tag type.
+ *
+ * @param data Localised name for the new type.
+ * @returns    The newly created tag type.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 422 — validation failed (check `err.fields`).
+ *
+ * @example
+ * const type = await createTagType({ name: { nl: "Genre", en: "Genre", fr: "Genre" } });
+ */
+export async function createTagType(
+  data: CreateTagTypeInput,
+): Promise<TagType> {
+  return apiFetch<TagType>("/tags/type", { method: "POST", body: data });
+}
+
+/**
+ * Replaces a tag type entirely (PUT semantics — all fields required).
+ *
+ * @param id   The tag type's primary key.
+ * @param data Full replacement payload.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — tag type not found.
+ */
+export async function replaceTagType(
+  id: number,
+  data: ReplaceTagTypeInput,
+): Promise<TagType> {
+  return apiFetch<TagType>(`/tags/type/${id}`, { method: "PUT", body: data });
+}
+
+/**
+ * Partially updates a tag type (PATCH semantics — only send changed fields).
+ *
+ * @param id   The tag type's primary key.
+ * @param data Only the fields that should change.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — tag type not found.
+ */
+export async function updateTagType(
+  id: number,
+  data: UpdateTagTypeInput,
+): Promise<TagType> {
+  return apiFetch<TagType>(`/tags/type/${id}`, { method: "PATCH", body: data });
+}
+
+/**
+ * Permanently deletes a tag type.
+ *
+ * @param id The tag type's primary key.
+ * @throws {ApiError} 401 — unauthenticated.
+ * @throws {ApiError} 404 — tag type not found.
+ */
+export async function deleteTagType(id: number): Promise<void> {
+  await apiFetch<void>(`/tags/type/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,0 +1,246 @@
+/**
+ * @file Date & time formatting utilities.
+ *
+ * All functions are pure — they take a `Date` (or date string) and return a
+ * formatted string. No side effects, no global state.
+ *
+ * The default locale is `"nl-BE"` (Belgian Dutch), matching the primary
+ * language of the archive. Every function accepts an optional `locale`
+ * parameter so the caller can override this.
+ *
+ * Usage:
+ * ```ts
+ * import { formatDate, formatTime, formatDateRange } from "@/utils/date";
+ *
+ * formatDate(event.starts_at);                        // "zaterdag 12 april 2025"
+ * formatTime(event.starts_at);                        // "20:00"
+ * formatDateRange(event.starts_at, event.ends_at);    // "za 12 apr – zo 13 apr 2025"
+ * ```
+ */
+
+const DEFAULT_LOCALE = "nl-BE";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensures `value` is a `Date` instance.
+ * Accepts `Date`, ISO 8601 strings, and timestamps.
+ */
+function toDate(value: Date | string | number): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats a date as a long, human-readable string including the weekday.
+ *
+ * @param date   The date to format.
+ * @param locale BCP 47 locale string (defaults to `"nl-BE"`).
+ * @returns      E.g. `"zaterdag 12 april 2025"`.
+ *
+ * @example
+ * formatDate(new Date("2025-04-12")); // → "zaterdag 12 april 2025"
+ */
+export function formatDate(
+  date: Date | string | number,
+  locale: string = DEFAULT_LOCALE,
+): string {
+  return toDate(date).toLocaleDateString(locale, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+/**
+ * Formats a date as a short string without the weekday.
+ *
+ * @param date   The date to format.
+ * @param locale BCP 47 locale string (defaults to `"nl-BE"`).
+ * @returns      E.g. `"12 apr. 2025"`.
+ *
+ * @example
+ * formatShortDate(new Date("2025-04-12")); // → "12 apr. 2025"
+ */
+export function formatShortDate(
+  date: Date | string | number,
+  locale: string = DEFAULT_LOCALE,
+): string {
+  return toDate(date).toLocaleDateString(locale, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+/**
+ * Formats only the time portion of a date.
+ *
+ * @param date The date/time to format.
+ * @returns    Zero-padded 24-hour time, e.g. `"20:00"` or `"09:30"`.
+ *
+ * @example
+ * formatTime(new Date("2025-04-12T20:00:00")); // → "20:00"
+ */
+export function formatTime(date: Date | string | number): string {
+  return toDate(date).toLocaleTimeString("nl-BE", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+/**
+ * Formats the doors-open time in a natural sentence.
+ *
+ * @param date   The doors-open date/time.
+ * @param locale BCP 47 locale string (defaults to `"nl-BE"`).
+ * @returns      E.g. `"Deuren open om 19:30"`.
+ *
+ * @example
+ * formatDoors(new Date("2025-04-12T19:30:00")); // → "Deuren open om 19:30"
+ */
+export function formatDoors(
+  date: Date | string | number,
+  locale: string = DEFAULT_LOCALE,
+): string {
+  const labels: Record<string, string> = {
+    "nl-BE": "Deuren open om",
+    nl: "Deuren open om",
+    en: "Doors open at",
+    fr: "Portes ouvertes à",
+  };
+  const label = labels[locale] ?? labels["nl-BE"];
+  return `${label} ${formatTime(date)}`;
+}
+
+/**
+ * Formats a start/end pair as a concise range string.
+ *
+ * - **Same day:** shows only the times, e.g. `"20:00 – 22:30"`.
+ * - **Different days:** shows short dates with the year on the last item,
+ *   e.g. `"za 12 apr – zo 13 apr 2025"`.
+ *
+ * @param start  Start date/time.
+ * @param end    End date/time.
+ * @param locale BCP 47 locale string (defaults to `"nl-BE"`).
+ * @returns      A formatted range string.
+ *
+ * @example
+ * // Same day
+ * formatDateRange(
+ *   new Date("2025-04-12T20:00:00"),
+ *   new Date("2025-04-12T22:00:00"),
+ * ); // → "20:00 – 22:00"
+ *
+ * // Different days
+ * formatDateRange(
+ *   new Date("2025-04-12T20:00:00"),
+ *   new Date("2025-04-13T00:30:00"),
+ * ); // → "za 12 apr – zo 13 apr 2025"
+ */
+export function formatDateRange(
+  start: Date | string | number,
+  end: Date | string | number,
+  locale: string = DEFAULT_LOCALE,
+): string {
+  const s = toDate(start);
+  const e = toDate(end);
+
+  const sameDay =
+    s.getFullYear() === e.getFullYear() &&
+    s.getMonth() === e.getMonth() &&
+    s.getDate() === e.getDate();
+
+  if (sameDay) {
+    return `${formatTime(s)} – ${formatTime(e)}`;
+  }
+
+  const formatShort = (d: Date) =>
+    d.toLocaleDateString(locale, {
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+    });
+
+  const endYear = e.toLocaleDateString(locale, { year: "numeric" });
+  return `${formatShort(s)} – ${formatShort(e)} ${endYear}`;
+}
+
+/**
+ * Formats a full event block: date, time range, and doors.
+ * Useful when you want to show all event timing in one string.
+ *
+ * @param startsAt The performance start time.
+ * @param endsAt   The performance end time.
+ * @param doorsAt  The doors-open time.
+ * @param locale   BCP 47 locale string (defaults to `"nl-BE"`).
+ * @returns        E.g. `"zaterdag 12 april 2025 · 20:00 – 22:00 · Deuren open om 19:30"`.
+ *
+ * @example
+ * formatEventBlock(event.starts_at, event.ends_at, event.doors_at);
+ */
+export function formatEventBlock(
+  startsAt: Date | string | number,
+  endsAt: Date | string | number,
+  doorsAt: Date | string | number,
+  locale: string = DEFAULT_LOCALE,
+): string {
+  const date = formatDate(startsAt, locale);
+  const range = formatDateRange(startsAt, endsAt, locale);
+  const doors = formatDoors(doorsAt, locale);
+  return `${date} · ${range} · ${doors}`;
+}
+
+// ---------------------------------------------------------------------------
+// Predicates
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when the date is in the future relative to the current time.
+ * Useful for filtering upcoming events out of a list.
+ *
+ * @param date The date to check.
+ *
+ * @example
+ * const upcoming = events.filter((e) => isUpcoming(e.starts_at));
+ */
+export function isUpcoming(date: Date | string | number): boolean {
+  return toDate(date).getTime() > Date.now();
+}
+
+/**
+ * Returns `true` when the date is in the past relative to the current time.
+ *
+ * @param date The date to check.
+ *
+ * @example
+ * const past = events.filter((e) => isPast(e.ends_at));
+ */
+export function isPast(date: Date | string | number): boolean {
+  return toDate(date).getTime() < Date.now();
+}
+
+/**
+ * Returns `true` when the current time falls between `start` and `end`.
+ * Useful for marking an event as "happening now".
+ *
+ * @param start The start date/time.
+ * @param end   The end date/time.
+ *
+ * @example
+ * const live = events.filter((e) => isOngoing(e.starts_at, e.ends_at));
+ */
+export function isOngoing(
+  start: Date | string | number,
+  end: Date | string | number,
+): boolean {
+  const now = Date.now();
+  return toDate(start).getTime() <= now && now <= toDate(end).getTime();
+}

--- a/frontend/src/utils/form.ts
+++ b/frontend/src/utils/form.ts
@@ -1,0 +1,198 @@
+/**
+ * @file Form validation utilities.
+ *
+ * Thin wrappers around Zod's `safeParse` API that return a consistent result
+ * shape and make it easy to display per-field error messages in templates.
+ *
+ * The helpers use structural typing (duck-typing) so they work with any Zod
+ * schema without importing Zod directly — useful when Zod is not listed as an
+ * explicit dependency of the frontend package.
+ *
+ * Usage:
+ * ```ts
+ * import { validateForm, getFieldError } from "@/utils/form";
+ * import { AdminSchema } from "@viernulvier/shared";
+ *
+ * const result = validateForm(AdminSchema, formData);
+ * if (!result.success) {
+ *   const usernameError = getFieldError(result.errors, "username");
+ * }
+ * ```
+ */
+
+// ---------------------------------------------------------------------------
+// Structural types (compatible with Zod v4)
+// ---------------------------------------------------------------------------
+
+/** A single validation issue as returned by Zod. */
+interface ValidationIssue {
+  /** Dot-notation path to the failing field, e.g. `["title", "nl"]`. */
+  path: Array<string | number | symbol>;
+  /** Human-readable error message. */
+  message: string;
+}
+
+/** The object returned by a Zod schema's `safeParse` on failure. */
+interface ZodLikeError {
+  issues: ValidationIssue[];
+}
+
+/** Structural interface satisfied by any Zod schema's `safeParse` return type. */
+type SafeParseReturn<T> =
+  | { success: true; data: T; error?: never }
+  | { success: false; data?: never; error: ZodLikeError };
+
+/** Structural interface satisfied by any Zod schema. */
+interface ValidatableSchema<T> {
+  safeParse(data: unknown): SafeParseReturn<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalised result returned by {@link validateForm}.
+ *
+ * - On success: `{ success: true, data: T }`.
+ * - On failure: `{ success: false, errors: ValidationIssue[] }`.
+ */
+export type FormValidationResult<T> =
+  | { success: true; data: T; errors?: never }
+  | { success: false; data?: never; errors: ValidationIssue[] };
+
+// ---------------------------------------------------------------------------
+// Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates `data` against the given Zod schema and returns a normalised
+ * {@link FormValidationResult}.
+ *
+ * Unlike calling `schema.parse()` directly, this never throws — validation
+ * errors are returned as structured data so templates can display them.
+ *
+ * @param schema Any Zod schema (or any object with a `safeParse` method).
+ * @param data   Raw form data to validate (typically the reactive form state).
+ * @returns      `{ success: true, data }` or `{ success: false, errors }`.
+ *
+ * @example
+ * const result = validateForm(AdminSchema, { username: "", password: "x" });
+ * if (result.success) {
+ *   await createAdmin(result.data);
+ * } else {
+ *   console.log(result.errors);
+ * }
+ */
+export function validateForm<T>(
+  schema: ValidatableSchema<T>,
+  data: unknown,
+): FormValidationResult<T> {
+  const result = schema.safeParse(data);
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+  return { success: false, errors: result.error.issues };
+}
+
+/**
+ * Extracts the first error message for a specific field path from a
+ * {@link FormValidationResult} errors array.
+ *
+ * Matches both top-level fields (`"username"`) and nested paths
+ * (`"title.nl"` matches path `["title", "nl"]`).
+ *
+ * @param errors The `errors` array from a failed {@link FormValidationResult}.
+ * @param field  Dot-notation field path, e.g. `"username"` or `"title.nl"`.
+ * @returns      The first matching error message, or `null` if none.
+ *
+ * @example
+ * const error = getFieldError(result.errors, "username");
+ * // → "String must contain at most 32 character(s)"
+ */
+export function getFieldError(
+  errors: ValidationIssue[],
+  field: string,
+): string | null {
+  const segments = field.split(".");
+
+  const match = errors.find((issue) => {
+    if (issue.path.length !== segments.length) return false;
+    return issue.path.every(
+      (segment, i) => String(segment) === segments[i],
+    );
+  });
+
+  return match?.message ?? null;
+}
+
+/**
+ * Returns `true` when the given field has at least one validation error.
+ * Convenient for toggling error classes on input elements.
+ *
+ * @param errors The `errors` array from a failed {@link FormValidationResult}.
+ * @param field  Dot-notation field path.
+ *
+ * @example
+ * // In a Vue template:
+ * // :class="{ 'input-error': hasFieldError(errors, 'username') }"
+ * hasFieldError(errors, "username"); // → true / false
+ */
+export function hasFieldError(
+  errors: ValidationIssue[],
+  field: string,
+): boolean {
+  return getFieldError(errors, field) !== null;
+}
+
+/**
+ * Collects all error messages for a specific field into an array.
+ * Useful when you want to display multiple errors per field.
+ *
+ * @param errors The `errors` array from a failed {@link FormValidationResult}.
+ * @param field  Dot-notation field path.
+ * @returns      All matching error messages (empty array if none).
+ *
+ * @example
+ * getFieldErrors(errors, "password");
+ * // → ["Too short", "Must contain a number"]
+ */
+export function getFieldErrors(
+  errors: ValidationIssue[],
+  field: string,
+): string[] {
+  const segments = field.split(".");
+
+  return errors
+    .filter((issue) => {
+      if (issue.path.length !== segments.length) return false;
+      return issue.path.every(
+        (segment, i) => String(segment) === segments[i],
+      );
+    })
+    .map((issue) => issue.message);
+}
+
+/**
+ * Converts a flat errors array into a record keyed by dot-notation field path.
+ * Useful for passing a single error map to a form component.
+ *
+ * @param errors The `errors` array from a failed {@link FormValidationResult}.
+ * @returns      `Record<string, string>` — one entry per field, first error only.
+ *
+ * @example
+ * errorsToRecord(result.errors);
+ * // → { "username": "Too long", "title.nl": "Required" }
+ */
+export function errorsToRecord(
+  errors: ValidationIssue[],
+): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const issue of errors) {
+    const key = issue.path.map(String).join(".");
+    if (!(key in record)) {
+      record[key] = issue.message;
+    }
+  }
+  return record;
+}

--- a/frontend/src/utils/i18n.ts
+++ b/frontend/src/utils/i18n.ts
@@ -1,0 +1,138 @@
+/**
+ * @file Multilingual text utilities (i18n helpers).
+ *
+ * All multi-language text fields in the API are stored as a {@link LanguageMap}
+ * — a plain object where each key is a language code and the value is the text
+ * in that language, e.g. `{ nl: "Welkom", en: "Welcome" }`.
+ *
+ * Usage:
+ * ```ts
+ * import { localize, fillLanguageMap } from "@/utils/i18n";
+ *
+ * const title = localize(production.title, "nl"); // "Hamlet"
+ * ```
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The three supported language codes. */
+export type Language = "nl" | "en" | "fr";
+
+/**
+ * A partial record mapping language codes to strings.
+ * At least one language must be present (enforced by the API schema).
+ *
+ * @example
+ * const title: LanguageMap = { nl: "Romeo en Julia", fr: "Roméo et Juliette" };
+ */
+export type LanguageMap = Partial<Record<Language, string>>;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** All supported languages in display order. */
+export const ALL_LANGUAGES: Language[] = ["nl", "en", "fr"];
+
+/**
+ * Default fallback chain used by {@link localize} when the preferred language
+ * is not available: Dutch → English → French.
+ */
+const FALLBACK_ORDER: Language[] = ["nl", "en", "fr"];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the text for the preferred language, falling back through
+ * `nl → en → fr` when the requested language is absent.
+ *
+ * @param map  A `LanguageMap` from the API.
+ * @param lang The preferred language code.
+ * @returns    The best available string, or `null` if the map is empty.
+ *
+ * @example
+ * localize({ nl: "Welkom" }, "en");       // → "Welkom"  (nl fallback)
+ * localize({ en: "Welcome" }, "en");      // → "Welcome"
+ * localize({}, "nl");                     // → null
+ */
+export function localize(map: LanguageMap, lang: Language): string | null {
+  if (map[lang] !== undefined) return map[lang] as string;
+
+  for (const fallback of FALLBACK_ORDER) {
+    if (fallback !== lang && map[fallback] !== undefined) {
+      return map[fallback] as string;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Like {@link localize}, but returns an empty string instead of `null` when no
+ * text is available. Useful for binding directly to template attributes that
+ * expect a `string`.
+ *
+ * @param map  A `LanguageMap` from the API.
+ * @param lang The preferred language code.
+ *
+ * @example
+ * localizeOrEmpty({ nl: "Welkom" }, "fr"); // → "Welkom"  (fallback)
+ * localizeOrEmpty({}, "nl");               // → ""
+ */
+export function localizeOrEmpty(map: LanguageMap, lang: Language): string {
+  return localize(map, lang) ?? "";
+}
+
+/**
+ * Creates a {@link LanguageMap} with the same string set for all three
+ * languages. Useful for initialising multilingual form fields with a default
+ * or copied value.
+ *
+ * @param value The string to assign to every language.
+ *
+ * @example
+ * fillLanguageMap("Nieuwe productie");
+ * // → { nl: "Nieuwe productie", en: "Nieuwe productie", fr: "Nieuwe productie" }
+ */
+export function fillLanguageMap(value: string): LanguageMap {
+  return { nl: value, en: value, fr: value };
+}
+
+/**
+ * Creates an empty {@link LanguageMap} with every language key set to `""`.
+ * Useful for initialising blank multilingual form fields.
+ *
+ * @example
+ * emptyLanguageMap(); // → { nl: "", en: "", fr: "" }
+ */
+export function emptyLanguageMap(): LanguageMap {
+  return { nl: "", en: "", fr: "" };
+}
+
+/**
+ * Returns `true` when the given language has a non-empty value in the map.
+ *
+ * @example
+ * hasLanguage({ nl: "Welkom" }, "en"); // → false
+ * hasLanguage({ nl: "Welkom" }, "nl"); // → true
+ */
+export function hasLanguage(map: LanguageMap, lang: Language): boolean {
+  const value = map[lang];
+  return value !== undefined && value.trim().length > 0;
+}
+
+/**
+ * Returns all language codes that have a non-empty value in the map,
+ * in the canonical order (`nl`, `en`, `fr`).
+ *
+ * @example
+ * availableLanguages({ nl: "Welkom", fr: "" }); // → ["nl"]
+ * availableLanguages({ nl: "Welkom", en: "Welcome", fr: "Bienvenue" }); // → ["nl", "en", "fr"]
+ */
+export function availableLanguages(map: LanguageMap): Language[] {
+  return ALL_LANGUAGES.filter((lang) => hasLanguage(map, lang));
+}

--- a/frontend/src/utils/misc.ts
+++ b/frontend/src/utils/misc.ts
@@ -1,0 +1,212 @@
+/**
+ * @file Miscellaneous utilities — general-purpose helpers that don't belong
+ * to a specific domain (i18n, dates, forms).
+ *
+ * All functions are pure or side-effect-free unless otherwise noted.
+ *
+ * Usage:
+ * ```ts
+ * import { debounce, groupBy, buildQueryString } from "@/utils/misc";
+ * ```
+ */
+
+// ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a URL query string from a plain object, omitting keys whose value
+ * is `null`, `undefined`, or an empty string.
+ *
+ * Returns the string **without** a leading `?` so it can be used with both
+ * `fetch` and `URL` construction.
+ *
+ * @param params Object of query parameters.
+ * @returns      URL-encoded query string, or `""` when all values are empty.
+ *
+ * @example
+ * buildQueryString({ page: 1, q: "hamlet", lang: null });
+ * // → "page=1&q=hamlet"
+ *
+ * // Using with apiFetch:
+ * const qs = buildQueryString({ tag: 3, year: 2025 });
+ * const url = qs ? `/production?${qs}` : "/production";
+ * const productions = await apiFetch<Production[]>(url);
+ */
+export function buildQueryString(
+  params: Record<string, string | number | boolean | null | undefined>,
+): string {
+  const entries = Object.entries(params).filter(
+    ([, v]) => v !== null && v !== undefined && v !== "",
+  );
+  return new URLSearchParams(
+    entries.map(([k, v]) => [k, String(v)]),
+  ).toString();
+}
+
+// ---------------------------------------------------------------------------
+// Function utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a debounced version of `fn` that delays invocation until `delay`
+ * milliseconds have passed since the last call.
+ *
+ * Useful for search inputs and resize handlers where you want to avoid
+ * firing on every keystroke.
+ *
+ * @param fn    The function to debounce.
+ * @param delay Delay in milliseconds.
+ * @returns     A debounced wrapper. Call `.cancel()` to cancel a pending call.
+ *
+ * @example
+ * const search = debounce(async (query: string) => {
+ *   results.value = await searchProductions(query);
+ * }, 300);
+ *
+ * // In a Vue template:
+ * // <input @input="search($event.target.value)" />
+ */
+export function debounce<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  delay: number,
+): ((...args: Args) => void) & { cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const debounced = (...args: Args): void => {
+    if (timer !== undefined) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+      fn(...args);
+    }, delay);
+  };
+
+  debounced.cancel = (): void => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  return debounced;
+}
+
+// ---------------------------------------------------------------------------
+// Array utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Groups an array of objects by the value of a specific key, returning a
+ * `Map` that preserves insertion order.
+ *
+ * @param items Array of objects to group.
+ * @param key   The key to group by.
+ * @returns     `Map<KeyType, Item[]>` — one entry per distinct key value.
+ *
+ * @example
+ * // Group events by production ID
+ * const byProduction = groupBy(events, "production");
+ * byProduction.get(42); // → [Event, Event, …]
+ *
+ * // Group tags by their type ID
+ * const byType = groupBy(tags, "type");
+ */
+export function groupBy<T, K extends keyof T>(
+  items: T[],
+  key: K,
+): Map<T[K], T[]> {
+  const map = new Map<T[K], T[]>();
+  for (const item of items) {
+    const k = item[key];
+    const group = map.get(k);
+    if (group !== undefined) {
+      group.push(item);
+    } else {
+      map.set(k, [item]);
+    }
+  }
+  return map;
+}
+
+/**
+ * Returns a new array with duplicate values removed, preserving the first
+ * occurrence of each value.
+ *
+ * @param items Array that may contain duplicates.
+ * @returns     Array with unique values only.
+ *
+ * @example
+ * unique([1, 2, 2, 3, 1]); // → [1, 2, 3]
+ */
+export function unique<T>(items: T[]): T[] {
+  return [...new Set(items)];
+}
+
+/**
+ * Returns a new array with duplicate objects removed, comparing by the value
+ * of a specific key.
+ *
+ * @param items Array of objects that may contain duplicates.
+ * @param key   The key whose value is used for uniqueness comparison.
+ * @returns     Array containing only the first object for each distinct key value.
+ *
+ * @example
+ * // Deduplicate productions by ID
+ * uniqueBy(productions, "id");
+ */
+export function uniqueBy<T, K extends keyof T>(items: T[], key: K): T[] {
+  const seen = new Set<T[K]>();
+  return items.filter((item) => {
+    if (seen.has(item[key])) return false;
+    seen.add(item[key]);
+    return true;
+  });
+}
+
+/**
+ * Sorts an array of objects by a numeric or string key in ascending order.
+ * Returns a **new array** — the original is not mutated.
+ *
+ * @param items Array of objects to sort.
+ * @param key   The key to sort by.
+ * @returns     A new sorted array.
+ *
+ * @example
+ * sortBy(events, "starts_at");
+ * sortBy(productions, "vendor_id");
+ */
+export function sortBy<T>(items: T[], key: keyof T): T[] {
+  return [...items].sort((a, b) => {
+    const av = a[key];
+    const bv = b[key];
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+    return 0;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Object utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a lookup map (`Record<id, T>`) from an array of objects that have
+ * a numeric `id` field. This allows O(1) lookups instead of repeated
+ * `Array.find()` calls.
+ *
+ * @param items Array of objects with a numeric `id` field.
+ * @returns     Record keyed by `id`.
+ *
+ * @example
+ * const hallMap = indexById(halls);
+ * const hall = hallMap[event.hall]; // O(1)
+ */
+export function indexById<T extends { id: number }>(
+  items: T[],
+): Record<number, T> {
+  const record: Record<number, T> = {};
+  for (const item of items) {
+    record[item.id] = item;
+  }
+  return record;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
 
   frontend:
     dependencies:
+      '@viernulvier/shared':
+        specifier: workspace:*
+        version: link:../shared
       vue:
         specifier: ^3.5.25
         version: 3.5.28(typescript@5.9.3)


### PR DESCRIPTION
**Issue(s)**

...

____

**Description**

Introduces a structured two-layer helper system that sits between Vue components and the backend API, so UI logic stays readable and API calls don't have to be reinvented every time.

frontend/src/services/ — API layer

api.ts — single apiFetch<T>() wrapper around fetch: handles credentials, JSON serialisation, and error normalisation. Introduces a typed ApiError class with convenience getters (isUnauthorized, isNotFound, isConflict, …) so components can branch on error types without comparing status codes.
auth.ts — login, logout, a withAuth guard helper, and full admin CRUD.
productions.ts / events.ts / halls.ts / tags.ts / eventPrices.ts — typed CRUD functions for every resource (GET, POST, PUT, PATCH, bulk PATCH, DELETE), split into public vs. protected endpoints. Every function is fully typed against the shared Zod schemas from @viernulvier/shared.
frontend/src/utils/ — Pure utilities (no side effects, no API calls)

i18n.ts — localize, localizeOrEmpty, fillLanguageMap, emptyLanguageMap, hasLanguage, availableLanguages for working with the LanguageMap type ({ nl?, en?, fr? }) that all multilingual fields use.
date.ts — formatDate, formatShortDate, formatTime, formatDoors, formatDateRange, formatEventBlock, plus predicates isUpcoming, isPast, isOngoing. Defaults to nl-BE locale, overridable per call.
form.ts — Zod-compatible validateForm / getFieldError / hasFieldError / getFieldErrors / errorsToRecord helpers that return structured results instead of throwing, making it easy to show per-field errors in templates.
misc.ts — debounce (with .cancel()), buildQueryString, groupBy, unique, uniqueBy, sortBy, indexById.
Also adds @viernulvier/shared as a workspace:* dependency to frontend/package.json.

____

**Sources**

N/A
