### PR TITLE
add support for authorization header usage

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,7 @@
     "start": "node dist/index.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "check": "pnpm run build && pnpm run test && pnpm run lint",
+    "check": "pnpm run build && pnpm run coverage && pnpm run lint",
     "create-admin": "tsx scripts/create-admin.ts"
   },
   "keywords": [],

--- a/backend/src/plugins/authorize.ts
+++ b/backend/src/plugins/authorize.ts
@@ -2,9 +2,9 @@ import fp from "fastify-plugin";
 import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 
 /**
- * Decorates the Fastify instance with an `authorize` hook that verifies the JWT session cookie.
- * Attach this as a `preHandler` on routes that require authentication.
- * Returns a `401 Unauthorized` response if the token is missing or invalid.
+ * Decorates the Fastify instance with an `authorize` hook that verifies the JWT session cookie or
+ * `Authorization: Bearer <token>` header. Attach this as a `preHandler` on routes that require authentication.
+ * Returns a `401` response if the token is missing, invalid, or has been revoked.
  *
  * @param server - The Fastify instance to decorate.
  */
@@ -12,6 +12,12 @@ export default fp(function authorizePlugin(server: FastifyInstance) {
   server.decorate("authorize", async function (request: FastifyRequest, reply: FastifyReply) {
     try {
       await request.jwtVerify();
+
+      const payload = request.user as { jti?: string };
+
+      if (payload.jti && server.tokenDenylist.has(payload.jti)) {
+        return await reply.status(401).send({ error: "Token has been revoked" });
+      }
     } catch {
       reply.status(401).send({ error: "Unauthorized" });
     }

--- a/backend/src/plugins/jwt.ts
+++ b/backend/src/plugins/jwt.ts
@@ -2,11 +2,18 @@ import fp from "fastify-plugin";
 import type { FastifyInstance } from "fastify";
 import fastifyJwt from "@fastify/jwt";
 import fastifyCookie from "@fastify/cookie";
+import { randomUUID } from "crypto";
+
+const denylist = new Set<string>();
 
 /**
  * Registers JWT and cookie plugins on the Fastify instance.
  * The JWT secret is read from the `JWT_SECRET` environment variable.
  * Sessions are stored in an `httpOnly` cookie named `session`.
+ *
+ * Also decorates the server with:
+ * - `tokenDenylist` — a Set of revoked JWT IDs (`jti` claims) that are rejected on each request.
+ * - `generateJti` — a function that generates a unique JWT ID for each token.
  *
  * @param server - The Fastify instance to register the plugins on.
  */
@@ -26,4 +33,14 @@ export default fp(async function jwtPlugin(server: FastifyInstance) {
       signed: false,
     },
   });
+
+  server.decorate("tokenDenylist", denylist);
+  server.decorate("generateJti", () => randomUUID());
 });
+
+declare module "fastify" {
+  interface FastifyInstance {
+    tokenDenylist: Set<string>;
+    generateJti: () => string;
+  }
+}

--- a/backend/src/routes/auth/auth.ts
+++ b/backend/src/routes/auth/auth.ts
@@ -27,5 +27,5 @@ export default function authRoutes(server: FastifyInstance) {
   server.patch("/api/v1/auth/:id", protect, replyHandler(server, editAdmin));
   server.delete("/api/v1/auth/:id", protect, replyHandler(server, deleteAdmin));
   server.post("/api/v1/auth/login", replyHandler(server, login));
-  server.post("/api/v1/auth/logout", replyHandler(server, logout));
+  server.post("/api/v1/auth/logout", protect, replyHandler(server, logout));
 }

--- a/backend/src/routes/auth/handlers/login.ts
+++ b/backend/src/routes/auth/handlers/login.ts
@@ -25,12 +25,14 @@ const fetchAdminCredentials = (server: FastifyInstance) =>
 const DUMMY_HASH = "$2b$12$invalidhashvaluethatwillnevermatchangything";
 
 /**
- * Authenticates an admin by username and password and sets a session cookie.
+ * Authenticates an admin by username and password, sets a session cookie, and returns a signed JWT.
+ * The token contains the admin's `id`, `username`, and a unique `jti` claim used for revocation on logout.
+ * Clients that cannot use cookies should store the returned token and pass it via the `Authorization: Bearer <token>` header.
  *
  * @param server - The Fastify instance, used for database access and logging.
  * @param request - The Fastify request, expected to contain `username` and `password` in its body.
  * @param reply - The Fastify reply, used to set the session cookie.
- * @returns An object indicating success.
+ * @returns The signed JWT token.
  * @throws `HttpError` With status 401 if the username is not found or the password is incorrect.
  */
 export async function login(server: FastifyInstance, request: FastifyRequest, reply: FastifyReply) {
@@ -38,13 +40,12 @@ export async function login(server: FastifyInstance, request: FastifyRequest, re
 
   const rows = await fetchAdminCredentials(server)(username);
 
-  // always compare hash to prevent a timing attack
   const valid = await comparePassword(password, rows[0]?.password ?? DUMMY_HASH);
 
   if (!valid || rows.length == 0) throw new HttpError(401, "Invalid credentials");
 
   const token = server.jwt.sign(
-    { id: rows[0]!.id, username },
+    { id: rows[0]!.id, username, jti: server.generateJti() },
     { expiresIn: "24h" },
   );
 
@@ -55,5 +56,5 @@ export async function login(server: FastifyInstance, request: FastifyRequest, re
     path: "/",
   });
 
-  return { success: true };
+  return { token };
 }

--- a/backend/src/routes/auth/handlers/logout.ts
+++ b/backend/src/routes/auth/handlers/logout.ts
@@ -1,14 +1,32 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 
 /**
- * Logs out the current admin by clearing the session cookie.
+ * Logs out the current admin by revoking the session token and clearing the session cookie.
+ * The token's `jti` claim is added to the server denylist, rejecting any further requests made with it
+ * until it naturally expires. Works for both cookie-based and `Authorization` header-based sessions.
  *
- * @param _server - Unused.
- * @param _request - Unused.
+ * @param server - The Fastify instance, used to access the token denylist.
+ * @param request - The Fastify request, used to extract and verify the session token.
  * @param reply - The Fastify reply, used to clear the session cookie.
  * @returns An object indicating success.
  */
-export async function logout(_server: FastifyInstance, _request: FastifyRequest, reply: FastifyReply) {
+export async function logout(server: FastifyInstance, request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const payload = await request.jwtVerify() as { jti?: string; exp?: number };
+
+    if (payload.jti) {
+      server.tokenDenylist.add(payload.jti);
+
+      if (payload.exp) {
+        const msUntilExpiry = payload.exp * 1000 - Date.now();
+        setTimeout(() => server.tokenDenylist.delete(payload.jti!), msUntilExpiry);
+      }
+    }
+  } catch {
+    // token is invalid
+  }
+
+  // always clear the cookie, even if the token is invalid
   reply.clearCookie("session", { path: "/" });
   return { success: true };
 }

--- a/backend/test/routes/auth/integration.test.ts
+++ b/backend/test/routes/auth/integration.test.ts
@@ -152,7 +152,7 @@ describe("Auth route integration", () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ success: true });
+    expect(response.json()).toEqual({ token: expect.any(String) });
 
     const cookie = response.cookies.find((c) => c.name === "session");
     expect(cookie).toBeDefined();

--- a/backend/test/routes/auth/login.test.ts
+++ b/backend/test/routes/auth/login.test.ts
@@ -29,7 +29,7 @@ describe("Login on auth route", () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ success: true });
+    expect(response.json()).toEqual({ token: expect.any(String) });
     expect(response.cookies).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "session", httpOnly: true }),

--- a/backend/test/routes/auth/logout.test.ts
+++ b/backend/test/routes/auth/logout.test.ts
@@ -3,19 +3,28 @@ import { buildServer } from "@/server.js";
 import type { FastifyInstance } from "fastify";
 
 let server: FastifyInstance;
+let sessionCookie: string;
 
 beforeAll(async () => {
   server = await buildServer();
+  sessionCookie = server.jwt.sign({ id: 404, username: "Karel", jti: server.generateJti() });
 });
 
 afterAll(async () => {
   await server.close();
 });
 
-describe("Logout on auth route", () => {
-  test("POST /api/v1/auth/logout — clears session cookie and returns success", async () => {
-    const sessionCookie = server.jwt.sign({ id: 404, username: "Karel" });
+describe("Logout", () => {
+  test("POST /api/v1/auth/logout — returns 401 without a session", async () => {
+    const response = await server.inject({
+      method: "POST",
+      url: "/api/v1/auth/logout",
+    });
 
+    expect(response.statusCode).toBe(401);
+  });
+
+  test("POST /api/v1/auth/logout — clears session cookie and returns success", async () => {
     const response = await server.inject({
       method: "POST",
       url: "/api/v1/auth/logout",
@@ -31,10 +40,44 @@ describe("Logout on auth route", () => {
     );
   });
 
-  test("POST /api/v1/auth/logout — succeeds without session cookie (just does nothing)", async () => {
+  test("POST /api/v1/auth/logout — returns 401 when token is revoked", async () => {
+    // sessionCookie was already revoked in the previous test
     const response = await server.inject({
       method: "POST",
       url: "/api/v1/auth/logout",
+      cookies: { session: sessionCookie },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  test("POST /api/v1/auth/logout — evicts jti from denylist after token expiry", async () => {
+    const jti = server.generateJti();
+    const shortLivedCookie = server.jwt.sign(
+      { id: 404, username: "Karel", jti },
+      { expiresIn: "1s" },
+    );
+
+    await server.inject({
+      method: "POST",
+      url: "/api/v1/auth/logout",
+      cookies: { session: shortLivedCookie },
+    });
+
+    expect(server.tokenDenylist.has(jti)).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    expect(server.tokenDenylist.has(jti)).toBe(false);
+  });
+
+  test("POST /api/v1/auth/logout — handles token without jti", async () => {
+    const cookie = server.jwt.sign({ id: 404, username: "Karel" }); // no jti
+
+    const response = await server.inject({
+      method: "POST",
+      url: "/api/v1/auth/logout",
+      cookies: { session: cookie },
     });
 
     expect(response.statusCode).toBe(200);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
-    "check": "pnpm run build && pnpm run test && pnpm run lint"
+    "check": "pnpm run build && pnpm run coverage && pnpm run lint"
   },
   "dependencies": {
     "vue": "^3.5.25"


### PR DESCRIPTION
**Issue(s)**

closes #177 
due to the way I changed the logout I also resolved #203, it now revokes the token when doing logout, instead of only clearing the session cookie locally.

____

**Description**

Implemented the authorization header.

You can test it with curl (after setting up docker and running migrate + create-admin scripts):

Login:
```sh
curl -X POST http://localhost:5173/api/v1/auth/login -H "Content-Type: application/json" -d '{"username":"admin","password":"password"}'
```
That will output a token, store it in a shell variable:
```sh
TOKEN=<copy paste>
```
Fetch mock admin to see if it works:
```sh
curl -H "Authorization: Bearer $TOKEN" http://localhost:5173/api/v1/auth/1
```
Logout:
```sh
curl -X POST -H "Authorization: Bearer $TOKEN" http://localhost:5173/api/v1/auth/logout
```
Fetch mock admin should say "Token has been revoked":
```sh
curl -H "Authorization: Bearer $TOKEN" http://localhost:5173/api/v1/auth/1
```

____

**Sources**

<!-- If applicable, add sources (e.g. links, screenshots ...) to show your work. -->
