### PR TITLE
Feat/productions references

### DIFF
--- a/backend/src/routes/production/handlers/bulk-edit.ts
+++ b/backend/src/routes/production/handlers/bulk-edit.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
-import type { Production } from "@viernulvier/shared/index.js";
+import type { ProductionWithBackwardsRefs } from "@viernulvier/shared/index.js";
 import { HttpClientError, HttpError, getMetadata, parseSchema } from "@/routes/helpers.js";
 import z from "zod";
 import { getProductionsByIds } from "./fetch.js";
@@ -38,7 +38,7 @@ const NullableBulkEditColumns = [
  * @param request - The Fastify request, expected to contain `ids` and `data` in its body.
  * @returns The updated productions array (can be empty), or `null` if parsing failed.
  */
-export async function bulkEditProductions(server: FastifyInstance, request: FastifyRequest): Promise<Production[] | null> {
+export async function bulkEditProductions(server: FastifyInstance, request: FastifyRequest): Promise<ProductionWithBackwardsRefs[] | null> {
   const body = parseSchema(server, BulkEditProductionsBodySchema, request.body);
   const { ids, data } = body;
 

--- a/backend/src/routes/production/handlers/create.ts
+++ b/backend/src/routes/production/handlers/create.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
-import type { Production } from "@viernulvier/shared/index.js";
+import type { ProductionWithBackwardsRefs } from "@viernulvier/shared/index.js";
 import { getMetadata, parseSchema } from "@/routes/helpers.js";
 import { getProductionById } from "./fetch.js";
 import { CreateProductionBodySchema } from "./body-schema.js";
@@ -31,7 +31,7 @@ const NullableCreateColumns = [
  * @param request - The Fastify request, expected to contain a production body.
  * @returns The created production, or `null` if the insert failed or parsing failed.
  */
-export async function createProduction(server: FastifyInstance, request: FastifyRequest): Promise<Production | null> {
+export async function createProduction(server: FastifyInstance, request: FastifyRequest): Promise<ProductionWithBackwardsRefs | null> {
   const body = parseSchema(server, CreateProductionBodySchema, request.body);
 
   const { admin, current_time } = getMetadata(request);

--- a/backend/src/routes/production/handlers/delete.ts
+++ b/backend/src/routes/production/handlers/delete.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
-import type { Production } from "@viernulvier/shared/index.js";
+import type { ProductionWithBackwardsRefs } from "@viernulvier/shared/index.js";
 import { stringToInt } from "@viernulvier/shared/index.js";
 import { parseParams } from "@/routes/helpers.js";
 import { getProductionById } from "./fetch.js";
@@ -12,7 +12,7 @@ import z from "zod";
  * @param request - The Fastify request, expected to contain `id` in its params.
  * @returns The deleted production, or `null` if not found.
  */
-export async function deleteProduction(server: FastifyInstance, request: FastifyRequest): Promise<Production | null> {
+export async function deleteProduction(server: FastifyInstance, request: FastifyRequest): Promise<ProductionWithBackwardsRefs | null> {
   const { id } = parseParams(request, z.object({ id: stringToInt }));
 
   const existing = await getProductionById(server, id);

--- a/backend/src/routes/production/handlers/edit.ts
+++ b/backend/src/routes/production/handlers/edit.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
-import type { Production } from "@viernulvier/shared/index.js";
+import type { ProductionWithBackwardsRefs } from "@viernulvier/shared/index.js";
 import { HttpClientError, HttpError, getMetadata, parseParams, parseSchema } from "@/routes/helpers.js";
 import { stringToInt } from "@viernulvier/shared/index.js";
 import { getProductionById } from "./fetch.js";
@@ -34,7 +34,7 @@ const NullableEditColumns = [
  * @param request - The Fastify request, expected to contain `id` in params and a partial production body.
  * @returns The updated production, or `null` if the update failed or parsing failed.
  */
-export async function editProduction(server: FastifyInstance, request: FastifyRequest): Promise<Production | null> {
+export async function editProduction(server: FastifyInstance, request: FastifyRequest): Promise<ProductionWithBackwardsRefs | null> {
   const { id } = parseParams(request, z.object({ id: stringToInt }));
   const body = parseSchema(server, PartialProductionBodySchema, request.body);
 

--- a/backend/src/routes/production/handlers/fetch.ts
+++ b/backend/src/routes/production/handlers/fetch.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
-import type { Production, ProductionWithMeta } from "@viernulvier/shared/index.js";
-import { ProductionSchema, stringToInt } from "@viernulvier/shared/index.js";
+import type {ProductionWithBackwardsRefs, ProductionWithMeta} from "@viernulvier/shared/index.js";
+import {ProductionSchema, ProductionSchemaWithBackwardsRefs, stringToInt} from "@viernulvier/shared/index.js";
 import { parseParams, parseSchema, ParseContext } from "@/routes/helpers.js";
 import z from "zod";
 
@@ -33,10 +33,13 @@ FROM production p
  * @param id - The production ID to fetch.
  * @returns The production, or `null` if not found or parsing failed.
  */
-export async function getProductionById(server: FastifyInstance, id: string | number): Promise<Production | null> {
-  const result = await server.pg.query<Production>(`${ProductionSelect} WHERE p.id = $1`, [id]);
+export async function getProductionById(server: FastifyInstance, id: string | number): Promise<ProductionWithBackwardsRefs | null> {
+  const result = await server.pg.query<ProductionWithBackwardsRefs>(
+    `${ProductionSelect} WHERE p.id = $1`,
+    [id],
+  );
 
-  return parseSchema(server, z.array(ProductionSchema), result.rows, ParseContext.Database)[0] ?? null;
+  return parseSchema(server, z.array(ProductionSchemaWithBackwardsRefs), result.rows, ParseContext.Database)[0] ?? null;
 }
 
 /**
@@ -46,17 +49,17 @@ export async function getProductionById(server: FastifyInstance, id: string | nu
  * @param ids - The production IDs to fetch.
  * @returns The productions that were found, preserving the input ID order.
  */
-export async function getProductionsByIds(server: FastifyInstance, ids: number[]): Promise<Production[]> {
+export async function getProductionsByIds(server: FastifyInstance, ids: number[]): Promise<ProductionWithBackwardsRefs[]> {
   if (ids.length === 0) return [];
 
-  const result = await server.pg.query<Production>(
+  const result = await server.pg.query<ProductionWithBackwardsRefs>(
     `${ProductionSelect}
      WHERE p.id = ANY($1::int[])
      ORDER BY array_position($1::int[], p.id)`,
     [ids],
   );
 
-  return parseSchema(server, z.array(ProductionSchema), result.rows, ParseContext.Database);
+  return parseSchema(server, z.array(ProductionSchemaWithBackwardsRefs), result.rows, ParseContext.Database);
 }
 
 /**
@@ -66,7 +69,7 @@ export async function getProductionsByIds(server: FastifyInstance, ids: number[]
  * @param request - The Fastify request, expected to contain `id` in its params.
  * @returns The production, or `null` if not found or parsing failed.
  */
-export async function fetchProduction(server: FastifyInstance, request: FastifyRequest): Promise<Production | null> {
+export async function fetchProduction(server: FastifyInstance, request: FastifyRequest): Promise<ProductionWithBackwardsRefs | null> {
   const { id } = parseParams(request, z.object({ id: stringToInt }));
   return await getProductionById(server, id);
 }
@@ -119,9 +122,11 @@ export async function fetchProductionWithMeta(
  * @param _request - The Fastify request (currently unused, reserved for future filters).
  * @returns The list of productions, or `null` if parsing failed.
  */
-export async function fetchProductions(server: FastifyInstance, _request: FastifyRequest): Promise<Production[] | null> {
-  const result = await server.pg.query<Production>(`${ProductionSelect} ORDER BY p.id ASC`);
+export async function fetchProductions(server: FastifyInstance, _request: FastifyRequest): Promise<ProductionWithBackwardsRefs[] | null> {
+  const result = await server.pg.query<ProductionWithBackwardsRefs>(
+    `${ProductionSelect} ORDER BY p.id ASC`,
+  );
 
-  return parseSchema(server, z.array(ProductionSchema), result.rows, ParseContext.Database);
+  return parseSchema(server, z.array(ProductionSchemaWithBackwardsRefs), result.rows, ParseContext.Database);
 }
 

--- a/backend/src/routes/production/handlers/replace.ts
+++ b/backend/src/routes/production/handlers/replace.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
-import type { Production } from "@viernulvier/shared/index.js";
+import type { ProductionWithBackwardsRefs } from "@viernulvier/shared/index.js";
 import { stringToInt } from "@viernulvier/shared/index.js";
 import { getMetadata, parseParams, parseSchema } from "@/routes/helpers.js";
 import { getProductionById } from "./fetch.js";
@@ -31,7 +31,7 @@ const ReplaceColumns = [
  * @param request - The Fastify request, expected to contain `id` in params and a full production body.
  * @returns The replaced production, or `null` if not found.
  */
-export async function replaceProduction(server: FastifyInstance, request: FastifyRequest): Promise<Production | null> {
+export async function replaceProduction(server: FastifyInstance, request: FastifyRequest): Promise<ProductionWithBackwardsRefs | null> {
   const { id } = parseParams(request, z.object({ id: stringToInt }));
   const body = parseSchema(server, ProductionBodySchema, request.body);
 

--- a/backend/test/routes/production/bulk-edit.test.ts
+++ b/backend/test/routes/production/bulk-edit.test.ts
@@ -119,7 +119,13 @@ describe("Bulk edit on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         expect(params?.[0]).toEqual(ids);
-        return Promise.resolve({ rows: [updatedBulkA1, updatedBulkA2], rowCount: 2 });
+        return Promise.resolve({
+          rows: [
+            { ...updatedBulkA1, tags: [], events: [] },
+            { ...updatedBulkA2, tags: [], events: [] },
+          ],
+          rowCount: 2,
+        });
       }
 
       throw new Error(`Unexpected query in bulk-edit tests A: ${query}`);
@@ -159,7 +165,13 @@ describe("Bulk edit on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         expect(params?.[0]).toEqual(ids);
-        return Promise.resolve({ rows: [updatedBulkB1, updatedBulkB2], rowCount: 2 });
+        return Promise.resolve({
+          rows: [
+            { ...updatedBulkB1, tags: [], events: [] },
+            { ...updatedBulkB2, tags: [], events: [] },
+          ],
+          rowCount: 2,
+        });
       }
 
       throw new Error(`Unexpected query in bulk-edit tests B: ${query}`);
@@ -229,7 +241,13 @@ describe("Bulk edit on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         expect(params?.[0]).toEqual(ids);
-        return Promise.resolve({ rows: [updatedBulkC1, updatedBulkC2], rowCount: 2 });
+        return Promise.resolve({
+          rows: [
+            { ...updatedBulkC1, tags: [], events: [] },
+            { ...updatedBulkC2, tags: [], events: [] },
+          ],
+          rowCount: 2,
+        });
       }
 
       throw new Error(`Unexpected query in bulk-edit tests C: ${query}`);
@@ -281,7 +299,13 @@ describe("Bulk edit on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         expect(params?.[0]).toEqual(ids);
-        return Promise.resolve({ rows: [baseProduction1, baseProduction2], rowCount: 2 });
+        return Promise.resolve({
+          rows: [
+            { ...baseProduction1, tags: [], events: [] },
+            { ...baseProduction2, tags: [], events: [] },
+          ],
+          rowCount: 2,
+        });
       }
 
       throw new Error(`Unexpected query in bulk-edit null test: ${query}`);

--- a/backend/test/routes/production/bulk-edit.test.ts
+++ b/backend/test/routes/production/bulk-edit.test.ts
@@ -3,6 +3,7 @@ import { buildServer } from "@/server.js";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { ProductionSchema, type Production } from "@viernulvier/shared/index.js";
 import { bulkEditProductions } from "@/routes/production/handlers/bulk-edit.js";
+import { productionRowWithRefs, productionRowWithRefsAlt } from "./fixtures.js";
 
 let server: FastifyInstance;
 let sessionCookie: string;
@@ -121,8 +122,8 @@ describe("Bulk edit on production route", () => {
         expect(params?.[0]).toEqual(ids);
         return Promise.resolve({
           rows: [
-            { ...updatedBulkA1, tags: [], events: [] },
-            { ...updatedBulkA2, tags: [], events: [] },
+            productionRowWithRefs(updatedBulkA1),
+            productionRowWithRefsAlt(updatedBulkA2),
           ],
           rowCount: 2,
         });
@@ -167,8 +168,8 @@ describe("Bulk edit on production route", () => {
         expect(params?.[0]).toEqual(ids);
         return Promise.resolve({
           rows: [
-            { ...updatedBulkB1, tags: [], events: [] },
-            { ...updatedBulkB2, tags: [], events: [] },
+            productionRowWithRefs(updatedBulkB1),
+            productionRowWithRefsAlt(updatedBulkB2),
           ],
           rowCount: 2,
         });
@@ -243,8 +244,8 @@ describe("Bulk edit on production route", () => {
         expect(params?.[0]).toEqual(ids);
         return Promise.resolve({
           rows: [
-            { ...updatedBulkC1, tags: [], events: [] },
-            { ...updatedBulkC2, tags: [], events: [] },
+            productionRowWithRefs(updatedBulkC1),
+            productionRowWithRefsAlt(updatedBulkC2),
           ],
           rowCount: 2,
         });
@@ -301,8 +302,8 @@ describe("Bulk edit on production route", () => {
         expect(params?.[0]).toEqual(ids);
         return Promise.resolve({
           rows: [
-            { ...baseProduction1, tags: [], events: [] },
-            { ...baseProduction2, tags: [], events: [] },
+            productionRowWithRefs(baseProduction1),
+            productionRowWithRefsAlt(baseProduction2),
           ],
           rowCount: 2,
         });

--- a/backend/test/routes/production/create.test.ts
+++ b/backend/test/routes/production/create.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach, vi } from "vit
 import { buildServer } from "@/server.js";
 import type { FastifyInstance } from "fastify";
 import { ProductionSchema, type Production } from "@viernulvier/shared/index.js";
+import { productionRowWithRefs } from "./fixtures.js";
 
 let server: FastifyInstance;
 let sessionCookie: string;
@@ -48,7 +49,7 @@ describe("Create on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         return Promise.resolve({
-          rows: [{ ...createdProduction, tags: [], events: [] }],
+          rows: [productionRowWithRefs(createdProduction)],
           rowCount: 1,
         });
       }

--- a/backend/test/routes/production/create.test.ts
+++ b/backend/test/routes/production/create.test.ts
@@ -47,7 +47,10 @@ describe("Create on production route", () => {
       }
 
       if (upper.startsWith("SELECT")) {
-        return Promise.resolve({ rows: [createdProduction], rowCount: 1 });
+        return Promise.resolve({
+          rows: [{ ...createdProduction, tags: [], events: [] }],
+          rowCount: 1,
+        });
       }
 
       throw new Error(`Unexpected query in create tests: ${query}`);

--- a/backend/test/routes/production/delete.test.ts
+++ b/backend/test/routes/production/delete.test.ts
@@ -43,7 +43,10 @@ describe("Delete on production route", () => {
       const upper = query.trim().toUpperCase();
 
       if (upper.startsWith("SELECT")) {
-        return Promise.resolve({ rows: [mockProduction], rowCount: 1 });
+        return Promise.resolve({
+          rows: [{ ...mockProduction, tags: [], events: [] }],
+          rowCount: 1,
+        });
       }
 
       if (upper.startsWith("DELETE")) {

--- a/backend/test/routes/production/delete.test.ts
+++ b/backend/test/routes/production/delete.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach, vi } from "vit
 import { buildServer } from "@/server.js";
 import type { FastifyInstance } from "fastify";
 import { ProductionSchema, type Production } from "@viernulvier/shared/index.js";
+import { productionRowWithRefs } from "./fixtures.js";
 
 let server: FastifyInstance;
 let sessionCookie: string;
@@ -44,7 +45,7 @@ describe("Delete on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         return Promise.resolve({
-          rows: [{ ...mockProduction, tags: [], events: [] }],
+          rows: [productionRowWithRefs(mockProduction)],
           rowCount: 1,
         });
       }

--- a/backend/test/routes/production/edit.test.ts
+++ b/backend/test/routes/production/edit.test.ts
@@ -84,7 +84,10 @@ describe("Edit on production route", () => {
       }
 
       if (upper.startsWith("SELECT")) {
-        return Promise.resolve({ rows: [updatedProductionA], rowCount: 1 });
+        return Promise.resolve({
+          rows: [{ ...updatedProductionA, tags: [], events: [] }],
+          rowCount: 1,
+        });
       }
 
       throw new Error(`Unexpected query in edit tests: ${query}`);
@@ -120,7 +123,10 @@ describe("Edit on production route", () => {
       }
 
       if (upper.startsWith("SELECT")) {
-        return Promise.resolve({ rows: [updatedProductionB], rowCount: 1 });
+        return Promise.resolve({
+          rows: [{ ...updatedProductionB, tags: [], events: [] }],
+          rowCount: 1,
+        });
       }
 
       throw new Error(`Unexpected query in edit tests: ${query}`);
@@ -181,7 +187,10 @@ describe("Edit on production route", () => {
       }
 
       if (upper.startsWith("SELECT")) {
-        return Promise.resolve({ rows: [updatedProductionC], rowCount: 1 });
+        return Promise.resolve({
+          rows: [{ ...updatedProductionC, tags: [], events: [] }],
+          rowCount: 1,
+        });
       }
 
       throw new Error(`Unexpected query in edit tests: ${query}`);
@@ -223,7 +232,10 @@ describe("Edit on production route", () => {
       }
 
       if (upper.startsWith("SELECT")) {
-        return Promise.resolve({ rows: [originalProduction], rowCount: 1 });
+        return Promise.resolve({
+          rows: [{ ...originalProduction, tags: [], events: [] }],
+          rowCount: 1,
+        });
       }
 
       throw new Error(`Unexpected query in edit tests: ${query}`);
@@ -268,7 +280,10 @@ describe("Edit on production route", () => {
       }
 
       if (upper.startsWith("SELECT")) {
-        return Promise.resolve({ rows: [originalProduction], rowCount: 1 });
+        return Promise.resolve({
+          rows: [{ ...originalProduction, tags: [], events: [] }],
+          rowCount: 1,
+        });
       }
 
       throw new Error(`Unexpected query in edit tests: ${query}`);

--- a/backend/test/routes/production/edit.test.ts
+++ b/backend/test/routes/production/edit.test.ts
@@ -3,6 +3,7 @@ import { buildServer } from "@/server.js";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { ProductionSchema, type Production } from "@viernulvier/shared/index.js";
 import { editProduction } from "@/routes/production/handlers/edit.js";
+import { productionRowWithRefs } from "./fixtures.js";
 
 let server: FastifyInstance;
 let sessionCookie: string;
@@ -85,7 +86,7 @@ describe("Edit on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         return Promise.resolve({
-          rows: [{ ...updatedProductionA, tags: [], events: [] }],
+          rows: [productionRowWithRefs(updatedProductionA)],
           rowCount: 1,
         });
       }
@@ -124,7 +125,7 @@ describe("Edit on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         return Promise.resolve({
-          rows: [{ ...updatedProductionB, tags: [], events: [] }],
+          rows: [productionRowWithRefs(updatedProductionB)],
           rowCount: 1,
         });
       }
@@ -188,7 +189,7 @@ describe("Edit on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         return Promise.resolve({
-          rows: [{ ...updatedProductionC, tags: [], events: [] }],
+          rows: [productionRowWithRefs(updatedProductionC)],
           rowCount: 1,
         });
       }
@@ -233,7 +234,7 @@ describe("Edit on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         return Promise.resolve({
-          rows: [{ ...originalProduction, tags: [], events: [] }],
+          rows: [productionRowWithRefs(originalProduction)],
           rowCount: 1,
         });
       }
@@ -281,7 +282,7 @@ describe("Edit on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         return Promise.resolve({
-          rows: [{ ...originalProduction, tags: [], events: [] }],
+          rows: [productionRowWithRefs(originalProduction)],
           rowCount: 1,
         });
       }

--- a/backend/test/routes/production/fetch.test.ts
+++ b/backend/test/routes/production/fetch.test.ts
@@ -7,11 +7,12 @@ import {
   type ProductionWithBackwardsRefs,
 } from "@viernulvier/shared/index.js";
 import { getProductionsByIds } from "@/routes/production/handlers/fetch.js";
+import { productionRowWithRefs, productionRowWithRefsAlt } from "./fixtures.js";
 
 let server: FastifyInstance;
 let sessionCookie: string;
 
-const baseProduction: ProductionWithBackwardsRefs = {
+const baseProduction: ProductionWithBackwardsRefs = productionRowWithRefs({
   id: 1,
   supertitle: null,
   title: { nl: "Titel" },
@@ -27,9 +28,7 @@ const baseProduction: ProductionWithBackwardsRefs = {
   quote_source: null,
   programme: null,
   info: null,
-  events: [],
-  tags: [],
-};
+});
 
 const baseProductionWithMeta = {
   ...baseProduction,
@@ -148,11 +147,12 @@ describe("Production fetch helpers", () => {
 
   test("getProductionsByIds -> fetches with ANY(ids) in one query", async () => {
     const ids = [2, 1];
-    const secondProduction: ProductionWithBackwardsRefs = {
-      ...baseProduction,
+    const { tags: _t, events: _e, ...productionCore } = baseProduction;
+    const secondProduction: ProductionWithBackwardsRefs = productionRowWithRefsAlt({
+      ...productionCore,
       id: 2,
       title: { nl: "Tweede titel" },
-    };
+    });
 
     server.pg.query = vi.fn().mockImplementation((query: string, params?: unknown[]) => {
       const upper = query.trim().toUpperCase();

--- a/backend/test/routes/production/fetch.test.ts
+++ b/backend/test/routes/production/fetch.test.ts
@@ -1,13 +1,17 @@
 import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
 import { buildServer } from "@/server.js";
 import type { FastifyInstance } from "fastify";
-import { ProductionSchema, type Production } from "@viernulvier/shared/index.js";
+import {
+  ProductionSchema,
+  ProductionSchemaWithBackwardsRefs,
+  type ProductionWithBackwardsRefs,
+} from "@viernulvier/shared/index.js";
 import { getProductionsByIds } from "@/routes/production/handlers/fetch.js";
 
 let server: FastifyInstance;
 let sessionCookie: string;
 
-const baseProduction: Production = {
+const baseProduction: ProductionWithBackwardsRefs = {
   id: 1,
   supertitle: null,
   title: { nl: "Titel" },
@@ -23,6 +27,8 @@ const baseProduction: Production = {
   quote_source: null,
   programme: null,
   info: null,
+  events: [],
+  tags: [],
 };
 
 const baseProductionWithMeta = {
@@ -79,8 +85,8 @@ describe("Production fetch routes", () => {
     expect(response.statusCode).toBe(200);
 
     const json = response.json();
-    const parsed = ProductionSchema.array().parse(json);
-    expect(parsed).toEqual([ProductionSchema.parse(baseProduction)]);
+    const parsed = ProductionSchemaWithBackwardsRefs.array().parse(json);
+    expect(parsed).toEqual([ProductionSchemaWithBackwardsRefs.parse(baseProduction)]);
   });
 
   test("GET /api/v1/production/:id -> returns a single production", async () => {
@@ -91,8 +97,8 @@ describe("Production fetch routes", () => {
     });
 
     expect(response.statusCode).toBe(200);
-    const parsed = ProductionSchema.parse(response.json());
-    expect(parsed).toEqual(ProductionSchema.parse(baseProduction));
+    const parsed = ProductionSchemaWithBackwardsRefs.parse(response.json());
+    expect(parsed).toEqual(ProductionSchemaWithBackwardsRefs.parse(baseProduction));
   });
 
   test("GET /api/v1/production/:id -> returns 404 for unknown id", async () => {
@@ -142,7 +148,7 @@ describe("Production fetch helpers", () => {
 
   test("getProductionsByIds -> fetches with ANY(ids) in one query", async () => {
     const ids = [2, 1];
-    const secondProduction: Production = {
+    const secondProduction: ProductionWithBackwardsRefs = {
       ...baseProduction,
       id: 2,
       title: { nl: "Tweede titel" },
@@ -162,8 +168,8 @@ describe("Production fetch helpers", () => {
     const result = await getProductionsByIds(server, ids);
 
     expect(result).toEqual([
-      ProductionSchema.parse(secondProduction),
-      ProductionSchema.parse(baseProduction),
+      ProductionSchemaWithBackwardsRefs.parse(secondProduction),
+      ProductionSchemaWithBackwardsRefs.parse(baseProduction),
     ]);
   });
 });

--- a/backend/test/routes/production/fixtures.ts
+++ b/backend/test/routes/production/fixtures.ts
@@ -1,0 +1,25 @@
+/**
+ * Sample `tags` / `events` id arrays for mocked production rows — matches typical API responses.
+ */
+export const MOCK_PRODUCTION_TAG_IDS = [1] as const;
+export const MOCK_PRODUCTION_EVENT_IDS = [5197, 5204, 5217] as const;
+
+/** Second production in multi-row tests (distinct ids). */
+export const MOCK_PRODUCTION_TAG_IDS_ALT = [2, 3] as const;
+export const MOCK_PRODUCTION_EVENT_IDS_ALT = [401, 402] as const;
+
+export function productionRowWithRefs<T extends object>(row: T) {
+  return {
+    ...row,
+    tags: [...MOCK_PRODUCTION_TAG_IDS],
+    events: [...MOCK_PRODUCTION_EVENT_IDS],
+  };
+}
+
+export function productionRowWithRefsAlt<T extends object>(row: T) {
+  return {
+    ...row,
+    tags: [...MOCK_PRODUCTION_TAG_IDS_ALT],
+    events: [...MOCK_PRODUCTION_EVENT_IDS_ALT],
+  };
+}

--- a/backend/test/routes/production/replace.test.ts
+++ b/backend/test/routes/production/replace.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach, vi } from "vit
 import { buildServer } from "@/server.js";
 import type { FastifyInstance } from "fastify";
 import { ProductionSchema, type Production } from "@viernulvier/shared/index.js";
+import { productionRowWithRefs } from "./fixtures.js";
 
 let server: FastifyInstance;
 let sessionCookie: string;
@@ -48,7 +49,7 @@ describe("Replace on production route", () => {
 
       if (upper.startsWith("SELECT")) {
         return Promise.resolve({
-          rows: [{ ...replacedProduction, tags: [], events: [] }],
+          rows: [productionRowWithRefs(replacedProduction)],
           rowCount: 1,
         });
       }

--- a/backend/test/routes/production/replace.test.ts
+++ b/backend/test/routes/production/replace.test.ts
@@ -47,7 +47,10 @@ describe("Replace on production route", () => {
       }
 
       if (upper.startsWith("SELECT")) {
-        return Promise.resolve({ rows: [replacedProduction], rowCount: 1 });
+        return Promise.resolve({
+          rows: [{ ...replacedProduction, tags: [], events: [] }],
+          rowCount: 1,
+        });
       }
 
       throw new Error(`Unexpected query in replace tests: ${query}`);

--- a/frontend/src/services/productions.ts
+++ b/frontend/src/services/productions.ts
@@ -18,7 +18,7 @@
  * ```
  */
 
-import type { Production, ProductionWithMeta } from "@viernulvier/shared";
+import type {ProductionWithBackwardsRefs, ProductionWithMeta} from "@viernulvier/shared";
 import { apiFetch } from "./api";
 import type { LanguageMap } from "../utils/i18n";
 
@@ -84,13 +84,13 @@ export interface BulkUpdateProductionsInput {
 /**
  * Fetches all productions (public — no session required).
  *
- * @returns Array of productions, possibly including nested tags and events.
+ * @returns Array of productions, each with `tags` and `events` as arrays of linked IDs.
  *
  * @example
  * const productions = await getProductions();
  */
-export async function getProductions(): Promise<Production[]> {
-  return await apiFetch<Production[]>("/production");
+export async function getProductions(): Promise<ProductionWithBackwardsRefs[]> {
+  return await apiFetch<ProductionWithBackwardsRefs[]>("/production");
 }
 
 /**
@@ -103,8 +103,10 @@ export async function getProductions(): Promise<Production[]> {
  * const production = await getProduction(42);
  * console.log(production.title);
  */
-export async function getProduction(id: number): Promise<Production> {
-  return await apiFetch<Production>(`/production/${id}`);
+export async function getProduction(
+  id: number,
+): Promise<ProductionWithBackwardsRefs> {
+  return await apiFetch<ProductionWithBackwardsRefs>(`/production/${id}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -145,8 +147,11 @@ export async function getProductionWithMeta(
  */
 export async function createProduction(
   data: CreateProductionInput,
-): Promise<Production> {
-  return await apiFetch<Production>("/production", { method: "POST", body: data });
+): Promise<ProductionWithBackwardsRefs> {
+  return await apiFetch<ProductionWithBackwardsRefs>("/production", {
+    method: "POST",
+    body: data,
+  });
 }
 
 /**
@@ -160,8 +165,8 @@ export async function createProduction(
 export async function replaceProduction(
   id: number,
   data: ReplaceProductionInput,
-): Promise<Production> {
-  return await apiFetch<Production>(`/production/${id}`, {
+): Promise<ProductionWithBackwardsRefs> {
+  return await apiFetch<ProductionWithBackwardsRefs>(`/production/${id}`, {
     method: "PUT",
     body: data,
   });
@@ -182,8 +187,8 @@ export async function replaceProduction(
 export async function updateProduction(
   id: number,
   data: UpdateProductionInput,
-): Promise<Production> {
-  return await apiFetch<Production>(`/production/${id}`, {
+): Promise<ProductionWithBackwardsRefs> {
+  return await apiFetch<ProductionWithBackwardsRefs>(`/production/${id}`, {
     method: "PATCH",
     body: data,
   });
@@ -204,8 +209,8 @@ export async function updateProduction(
  */
 export async function bulkUpdateProductions(
   input: BulkUpdateProductionsInput,
-): Promise<Production[]> {
-  return await apiFetch<Production[]>("/production/bulk", {
+): Promise<ProductionWithBackwardsRefs[]> {
+  return await apiFetch<ProductionWithBackwardsRefs[]>("/production/bulk", {
     method: "PATCH",
     body: input,
   });

--- a/shared/src/types/production.ts
+++ b/shared/src/types/production.ts
@@ -82,6 +82,9 @@ export const CustomProductionFieldSchema = createSchema({
 });
 
 export type Production = z.infer<typeof ProductionSchema>;
+export type ProductionWithBackwardsRefs = z.infer<
+  typeof ProductionSchemaWithBackwardsRefs
+>;
 export type ProductionWithMeta = z.infer<
   ReturnType<typeof ProductionSchema.withMeta>
 >;


### PR DESCRIPTION
**Issue(s)**

Closes #200

____

**Description**

Production API responses now include tags and event ids (they were already selected in SQL but dropped by Zod). Parsing now uses ProductionSchemaWithBackwardsRefs.

____

**Sources**