### PR TITLE
rename FK columns

### DIFF
--- a/DOCS/DATABASE.md
+++ b/DOCS/DATABASE.md
@@ -134,18 +134,18 @@ Table event_price {
 
 Table production_tag {
   ~metadata
-  tag_id int [ref: > tag.id]
-  production_id int [ref: > production.id]
+  tag int [ref: > tag.id]
+  production int [ref: > production.id]
 }
 
 Table tag {
   ~metadata
   "id" int [PK]
   "name" varchar(32) [not null]
-  "type" int [ref: > tag_type.id, not null]
+  "tag_type" int [ref: > tag_type.id, not null]
 
   indexes {
-    type
+    tag_type
   }
 }
 
@@ -166,14 +166,14 @@ Enum field_types {
 Table image {
   ~metadata
   "id" int [PK]
-  "production_id" int [ref: > production.id]
+  "production" int [ref: > production.id]
   "res" varchar(16)
 }
 
 Table crop {
   ~metadata
   "id" int [PK]
-  "image_id" int [ref: > image.id]
+  "image" int [ref: > image.id]
   "url" varchar(128)
 }
 
@@ -187,7 +187,7 @@ Table custom_production_field_definition {
 Table production_custom_field {
   ~metadata
   "field_defenition_id" int [PK, ref: > custom_production_field_definition.id]
-  "production_id" int [PK, ref: > production.id]
+  "production" int [PK, ref: > production.id]
   "value_bool" bool [null]
   "value_number" numeric [null]
   "value_string" varchar(32) [null]
@@ -211,7 +211,7 @@ Table blog {
 Table blogpost {
   ~metadata
   "id" int [PK]
-  "blog_id" int [ref: > blog.id]
+  "blog" int [ref: > blog.id]
   "content" json
 }
   "event" int [PK, ref: > event.id]
@@ -227,18 +227,18 @@ Table blogpost {
 
 Table production_tag {
   ~metadata
-  tag_id int [ref: > tag.id]
-  production_id int [ref: > production.id]
+  tag int [ref: > tag.id]
+  production int [ref: > production.id]
 }
 
 Table tag {
   ~metadata
   "id" int [PK]
   "name" varchar(32) [not null]
-  "type" int [ref: > tag_type.id, not null]
+  "tag_type" int [ref: > tag_type.id, not null]
 
   indexes {
-    type
+    tag_type
   }
 }
 
@@ -297,7 +297,7 @@ Table blog {
 Table blogpost {
   ~metadata
   "id" int [PK]
-  "blog_id" int [ref: > blog.id]
+  "blog" int [ref: > blog.id]
   "content" json
 }
 ```

--- a/DOCS/DATABASE_nl.md
+++ b/DOCS/DATABASE_nl.md
@@ -134,18 +134,18 @@ Table event_price {
 
 Table production_tag {
   ~metadata
-  tag_id int [ref: > tag.id]
-  production_id int [ref: > production.id]
+  tag int [ref: > tag.id]
+  production int [ref: > production.id]
 }
 
 Table tag {
   ~metadata
   "id" int [PK]
   "name" varchar(32) [not null]
-  "type" int [ref: > tag_type.id, not null]
+  "tag_type" int [ref: > tag_type.id, not null]
 
   indexes {
-    type
+    tag_type
   }
 }
 
@@ -187,7 +187,7 @@ Table custom_production_field_definition {
 Table production_custom_field {
   ~metadata
   "field_defenition_id" int [PK, ref: > custom_production_field_definition.id]
-  "production_id" int [PK, ref: > production.id]
+  "production" int [PK, ref: > production.id]
   "value_bool" bool [null]
   "value_number" numeric [null]
   "value_string" varchar(32) [null]
@@ -211,7 +211,7 @@ Table blog {
 Table blogpost {
   ~metadata
   "id" int [PK]
-  "blog_id" int [ref: > blog.id]
+  "blog" int [ref: > blog.id]
   "content" json
 }
   "event" int [PK, ref: > event.id]
@@ -227,18 +227,18 @@ Table blogpost {
 
 Table production_tag {
   ~metadata
-  tag_id int [ref: > tag.id]
-  production_id int [ref: > production.id]
+  tag int [ref: > tag.id]
+  production int [ref: > production.id]
 }
 
 Table tag {
   ~metadata
   "id" int [PK]
   "name" varchar(32) [not null]
-  "type" int [ref: > tag_type.id, not null]
+  "tag_type" int [ref: > tag_type.id, not null]
 
   indexes {
-    type
+    tag_type
   }
 }
 
@@ -297,7 +297,7 @@ Table blog {
 Table blogpost {
   ~metadata
   "id" int [PK]
-  "blog_id" int [ref: > blog.id]
+  "blog" int [ref: > blog.id]
   "content" json
 }
 ```

--- a/backend/migrations/009.do.rename-fk-columns-to-table-names.sql
+++ b/backend/migrations/009.do.rename-fk-columns-to-table-names.sql
@@ -1,0 +1,29 @@
+-- UNDER NO CIRCUMSTANCES MAY THIS FILE BE EDITED WHEN LIVE
+-- ANY EDITS WILL RESOLVE IN DIFFERENT CHECKSUMS AND THE DB REJECTING THE MIGRATION
+
+-- Align FK column names with referenced tables (same pattern as event.production / event.hall).
+
+-- tag → tag_type(id)
+ALTER TABLE tag RENAME COLUMN type_id TO tag_type;
+ALTER INDEX IF EXISTS idx_tag_type_id RENAME TO idx_tag_tag_type;
+
+-- production_tag → production(id), tag(id)
+ALTER TABLE production_tag RENAME COLUMN production_id TO production;
+ALTER TABLE production_tag RENAME COLUMN tag_id TO tag;
+ALTER INDEX IF EXISTS idx_prod_tag_tag_id RENAME TO idx_prod_tag_tag;
+
+-- image → production(id)
+ALTER TABLE image RENAME COLUMN production_id TO production;
+ALTER INDEX IF EXISTS idx_image_production_id RENAME TO idx_image_production;
+
+-- crop → image(id)
+ALTER TABLE crop RENAME COLUMN image_id TO image;
+ALTER INDEX IF EXISTS idx_crop_image_id RENAME TO idx_crop_image;
+
+-- blogpost → blog(id)
+ALTER TABLE blogpost RENAME COLUMN blog_id TO blog;
+ALTER INDEX IF EXISTS idx_blogpost_blog_id RENAME TO idx_blogpost_blog;
+
+-- production_custom_field → production(id)
+ALTER TABLE production_custom_field RENAME COLUMN production_id TO production;
+ALTER INDEX IF EXISTS idx_pcf_production_id RENAME TO idx_pcf_production;

--- a/backend/migrations/009.undo.rename-fk-columns-to-table-names.sql
+++ b/backend/migrations/009.undo.rename-fk-columns-to-table-names.sql
@@ -1,0 +1,20 @@
+-- Reverts 009.do.rename-fk-columns-to-table-names.sql
+
+ALTER TABLE production_custom_field RENAME COLUMN production TO production_id;
+ALTER INDEX IF EXISTS idx_pcf_production RENAME TO idx_pcf_production_id;
+
+ALTER TABLE blogpost RENAME COLUMN blog TO blog_id;
+ALTER INDEX IF EXISTS idx_blogpost_blog RENAME TO idx_blogpost_blog_id;
+
+ALTER TABLE crop RENAME COLUMN image TO image_id;
+ALTER INDEX IF EXISTS idx_crop_image RENAME TO idx_crop_image_id;
+
+ALTER TABLE image RENAME COLUMN production TO production_id;
+ALTER INDEX IF EXISTS idx_image_production RENAME TO idx_image_production_id;
+
+ALTER TABLE production_tag RENAME COLUMN tag TO tag_id;
+ALTER TABLE production_tag RENAME COLUMN production TO production_id;
+ALTER INDEX IF EXISTS idx_prod_tag_tag RENAME TO idx_prod_tag_tag_id;
+
+ALTER TABLE tag RENAME COLUMN tag_type TO type_id;
+ALTER INDEX IF EXISTS idx_tag_tag_type RENAME TO idx_tag_type_id;

--- a/backend/src/legacy-import/import-productions-legacy.ts
+++ b/backend/src/legacy-import/import-productions-legacy.ts
@@ -76,7 +76,7 @@ async function loadGenreTagCache(client: pg.Client, genreTagTypeId: number): Pro
   const existingTags = await client.query<{ id: number; name: string }>(
     `SELECT id, name->>'nl' AS name
      FROM tag
-     WHERE type_id = $1`,
+     WHERE tag_type = $1`,
     [genreTagTypeId],
   );
 
@@ -100,7 +100,7 @@ async function getOrCreateGenreTagId(
   const existing = await client.query<{ id: number }>(
     `SELECT id
      FROM tag
-     WHERE type_id = $1
+     WHERE tag_type = $1
        AND lower(name->>'nl') = lower($2)
      LIMIT 1`,
     [genreTagTypeId, genreName],
@@ -116,7 +116,7 @@ async function getOrCreateGenreTagId(
   }
 
   const inserted = await client.query<{ id: number }>(
-    `INSERT INTO tag (name, type_id, public)
+    `INSERT INTO tag (name, tag_type, public)
      VALUES ($1::jsonb, $2, true)
      RETURNING id`,
     [JSON.stringify(toLanguageMap(genreName)), genreTagTypeId],
@@ -280,7 +280,7 @@ export async function importProductionsLegacy(client: pg.Client, args: ImportArg
         if (tagResult.created) stats.createdGenreTags++;
 
         const linkResult = await client.query(
-          `INSERT INTO production_tag (production_id, tag_id)
+          `INSERT INTO production_tag (production, tag)
            VALUES ($1, $2)
            ON CONFLICT DO NOTHING`,
           [productionId, tagResult.id],

--- a/backend/src/routes/production/handlers/fetch.ts
+++ b/backend/src/routes/production/handlers/fetch.ts
@@ -22,7 +22,7 @@ SELECT
   p.quote_source,
   p.programme,
   p.info,
-  (SELECT COALESCE(ARRAY_AGG(pt.tag_id), '{}') FROM production_tag pt WHERE pt.production_id = p.id) AS tags
+  (SELECT COALESCE(ARRAY_AGG(pt.tag), '{}') FROM production_tag pt WHERE pt.production = p.id) AS tags
 FROM production p
 `;
 

--- a/backend/src/routes/tag/handlers/create.ts
+++ b/backend/src/routes/tag/handlers/create.ts
@@ -9,7 +9,7 @@ const CreateTagBodySchema = TagSchema.pick({
   name: true,
   public: true,
 }).extend({
-  type: z.int().nonnegative(),
+  tag_type: z.int().nonnegative(),
 });
 
 const insertTag = (server: FastifyInstance) =>
@@ -31,7 +31,7 @@ export async function createTag(
 
   const rows = await insertTag(server)(
     body.name,
-    body.type,
+    body.tag_type,
     body.public,
     admin,
     current_time,

--- a/backend/src/routes/tag/handlers/create.ts
+++ b/backend/src/routes/tag/handlers/create.ts
@@ -1,16 +1,10 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import type { Tag } from "@viernulvier/shared/index.js";
 import { TagSchema } from "@viernulvier/shared/index.js";
-import { languageMap } from "@viernulvier/shared/types/helpers.js";
 import { getMetadata, parseSchema, buildQuery } from "@/routes/helpers.js";
-import { z } from "zod";
+import z from "zod";
 
-const CreateTagBodySchema = TagSchema.pick({
-  name: true,
-  public: true,
-}).extend({
-  tag_type: z.int().nonnegative(),
-});
+const CreateTagBodySchema = TagSchema.omit({ id: true, productions: true });
 
 const insertTag = (server: FastifyInstance) =>
   buildQuery(
@@ -18,7 +12,13 @@ const insertTag = (server: FastifyInstance) =>
     `INSERT INTO tag (name, tag_type, public, created_by, updated_by, created_at, updated_at)
      VALUES ($1, $2, $3, $4, $4, $5, $5)
      RETURNING id, name, tag_type, public`,
-    z.tuple([languageMap, z.int(), z.boolean(), z.int(), z.date()]),
+    z.tuple([
+      CreateTagBodySchema.shape.name,
+      CreateTagBodySchema.shape.tag_type,
+      CreateTagBodySchema.shape.public,
+      z.int(),
+      z.date(),
+    ]),
     TagSchema,
   );
 

--- a/backend/src/routes/tag/handlers/create.ts
+++ b/backend/src/routes/tag/handlers/create.ts
@@ -15,9 +15,9 @@ const CreateTagBodySchema = TagSchema.pick({
 const insertTag = (server: FastifyInstance) =>
   buildQuery(
     server,
-    `INSERT INTO tag (name, type_id, public, created_by, updated_by, created_at, updated_at)
+    `INSERT INTO tag (name, tag_type, public, created_by, updated_by, created_at, updated_at)
      VALUES ($1, $2, $3, $4, $4, $5, $5)
-     RETURNING id, name, type_id, public`,
+     RETURNING id, name, tag_type, public`,
     z.tuple([languageMap, z.int(), z.boolean(), z.int(), z.date()]),
     TagSchema,
   );

--- a/backend/src/routes/tag/handlers/delete.ts
+++ b/backend/src/routes/tag/handlers/delete.ts
@@ -9,7 +9,7 @@ const deleteTagById = (server: FastifyInstance) =>
     server,
     `DELETE FROM tag
      WHERE id = $1
-     RETURNING id, name, type_id, public`,
+     RETURNING id, name, tag_type, public`,
     z.tuple([z.int()]),
     TagSchema,
   );

--- a/backend/src/routes/tag/handlers/edit.ts
+++ b/backend/src/routes/tag/handlers/edit.ts
@@ -29,7 +29,7 @@ export async function editTag(
   }
 
   if (body.type !== undefined) {
-    fields.push(`type_id = $${i++}`);
+    fields.push(`tag_type = $${i++}`);
     values.push(body.type);
   }
 
@@ -43,7 +43,7 @@ export async function editTag(
 
   const result = await server.pg.query<Tag>(
     `UPDATE tag SET ${fields.join(", ")} WHERE id = $${i}
-     RETURNING id, name, type_id, public`,
+     RETURNING id, name, tag_type, public`,
     values,
   );
 

--- a/backend/src/routes/tag/handlers/edit.ts
+++ b/backend/src/routes/tag/handlers/edit.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 
 const EditTagBodySchema = TagSchema.pick({
   name: true,
-  type: true,
+  tag_type: true,
   public: true,
 }).partial();
 
@@ -28,9 +28,9 @@ export async function editTag(
     values.push(body.name);
   }
 
-  if (body.type !== undefined) {
+  if (body.tag_type !== undefined) {
     fields.push(`tag_type = $${i++}`);
-    values.push(body.type);
+    values.push(body.tag_type);
   }
 
   if (body.public !== undefined) {

--- a/backend/src/routes/tag/handlers/fetch.ts
+++ b/backend/src/routes/tag/handlers/fetch.ts
@@ -9,20 +9,9 @@ SELECT id, name, tag_type, public
 FROM tag
 `;
 
-/** Row shape returned by tag SELECTs before `productions` is merged from `production_tag`. */
-const TagDbRowSchema = z.object({
-  id: TagSchema.shape.id,
-  name: TagSchema.shape.name,
-  tag_type: z.int().nonnegative(),
-  public: TagSchema.shape.public,
-});
-
-const TagDbRowWithMetaSchema = TagDbRowSchema.extend({
-  created_at: z.coerce.date(),
-  updated_at: z.coerce.date(),
-  created_by: z.int().nonnegative(),
-  updated_by: z.int().nonnegative(),
-});
+/** Tag row from SQL before `productions` is merged from `production_tag`. */
+const TagDbRowSchema = TagSchema.omit({ productions: true });
+const TagDbRowWithMetaSchema = TagSchema.withMeta().omit({ productions: true });
 
 const TagsListQuerySchema = z.object({
   production: stringToInt.optional(),
@@ -68,10 +57,7 @@ function tagsFromDbRows(
   byTag: Map<number, number[]>,
 ): Tag[] {
   return rows.map((row) => ({
-    id: row.id,
-    name: row.name,
-    type: row.tag_type,
-    public: row.public,
+    ...row,
     productions: byTag.get(row.id) ?? [],
   }));
 }
@@ -79,17 +65,10 @@ function tagsFromDbRows(
 function tagsWithMetaFromDbRows(
   rows: z.infer<typeof TagDbRowWithMetaSchema>[],
   byTag: Map<number, number[]>,
-) {
+): TagWithMeta[] {
   return rows.map((row) => ({
-    id: row.id,
-    name: row.name,
-    type: row.tag_type,
-    public: row.public,
+    ...row,
     productions: byTag.get(row.id) ?? [],
-    created_at: row.created_at,
-    updated_at: row.updated_at,
-    created_by: row.created_by,
-    updated_by: row.updated_by,
   }));
 }
 

--- a/backend/src/routes/tag/handlers/fetch.ts
+++ b/backend/src/routes/tag/handlers/fetch.ts
@@ -15,7 +15,7 @@ const TagDbRowWithMetaSchema = TagSchema.withMeta().omit({ productions: true });
 
 const TagsListQuerySchema = z.object({
   production: stringToInt.optional(),
-  /** When `includeProductions=true`, each tag includes full `productions` id list (default: empty arrays). */
+  /** When `includeProductions=true`, each tag includes a `productions` id list; otherwise the field is omitted. */
   includeProductions: z.literal("true").optional(),
 });
 
@@ -55,11 +55,17 @@ async function fetchProductionIdsByTagIds(
 function tagsFromDbRows(
   rows: z.infer<typeof TagDbRowSchema>[],
   byTag: Map<number, number[]>,
+  includeProductions: boolean,
 ): Tag[] {
-  return rows.map((row) => ({
-    ...row,
-    productions: byTag.get(row.id) ?? [],
-  }));
+  return rows.map((row) => {
+    if (!includeProductions) {
+      return { ...row };
+    }
+    return {
+      ...row,
+      productions: byTag.get(row.id) ?? [],
+    };
+  });
 }
 
 function tagsWithMetaFromDbRows(
@@ -134,7 +140,7 @@ async function fetchTag(
   const row = rows[0];
   if (!row) return null;
   const byTag = await fetchProductionIdsByTagIds(server, [row.id]);
-  const merged = tagsFromDbRows([row], byTag);
+  const merged = tagsFromDbRows([row], byTag, true);
   return parseSchema(server, TagSchema, merged[0], ParseContext.Database);
 }
 
@@ -147,7 +153,7 @@ async function fetchTagVisible(
   const row = rows[0];
   if (!row) return null;
   const byTag = await fetchProductionIdsByTagIds(server, [row.id]);
-  const merged = tagsFromDbRows([row], byTag);
+  const merged = tagsFromDbRows([row], byTag, true);
   return parseSchema(server, TagSchema, merged[0], ParseContext.Database);
 }
 
@@ -184,7 +190,7 @@ async function fetchTags(
         rows.map((r) => r.id),
       )
       : new Map<number, number[]>();
-  const merged = tagsFromDbRows(rows, byTag);
+  const merged = tagsFromDbRows(rows, byTag, includeProductions !== undefined);
   return parseSchema(server, z.array(TagSchema), merged, ParseContext.Database);
 }
 
@@ -208,7 +214,7 @@ async function fetchTagsVisible(
         rows.map((r) => r.id),
       )
       : new Map<number, number[]>();
-  const merged = tagsFromDbRows(rows, byTag);
+  const merged = tagsFromDbRows(rows, byTag, includeProductions !== undefined);
   return parseSchema(server, z.array(TagSchema), merged, ParseContext.Database);
 }
 

--- a/backend/src/routes/tag/handlers/fetch.ts
+++ b/backend/src/routes/tag/handlers/fetch.ts
@@ -5,7 +5,7 @@ import { parseParams, buildQuery, parseSchema } from "@/routes/helpers.js";
 import { z } from "zod";
 
 const TagSelect = `
-SELECT id, name, type_id, public
+SELECT id, name, tag_type, public
 FROM tag
 `;
 
@@ -32,7 +32,7 @@ const fetchTagVisibleByIdQuery = (server: FastifyInstance) =>
 const fetchTagWithMetaByIdQuery = (server: FastifyInstance) =>
   buildQuery(
     server,
-    `SELECT id, name, type_id, public, created_at, updated_at, created_by, updated_by
+    `SELECT id, name, tag_type, public, created_at, updated_at, created_by, updated_by
      FROM tag WHERE id = $1`,
     z.tuple([z.int()]),
     TagSchema.withMeta(),
@@ -44,10 +44,10 @@ const fetchTagsAllQuery = (server: FastifyInstance) =>
 const fetchTagsByProductionQuery = (server: FastifyInstance) =>
   buildQuery(
     server,
-    `SELECT t.id, t.name, t.type_id, public
+    `SELECT t.id, t.name, t.tag_type, public
      FROM tag t
-     JOIN production_tag pt ON pt.tag_id = t.id
-     WHERE pt.production_id = $1`,
+     JOIN production_tag pt ON pt.tag = t.id
+     WHERE pt.production = $1`,
     z.tuple([z.int()]),
     TagSchema,
   );
@@ -58,10 +58,10 @@ const fetchTagsVisibleAllQuery = (server: FastifyInstance) =>
 const fetchTagsVisibleByProductionQuery = (server: FastifyInstance) =>
   buildQuery(
     server,
-    `SELECT t.id, t.name, t.type_id, public
+    `SELECT t.id, t.name, t.tag_type, public
      FROM tag t
-     JOIN production_tag pt ON pt.tag_id = t.id
-     WHERE pt.production_id = $1 AND t.public = true`,
+     JOIN production_tag pt ON pt.tag = t.id
+     WHERE pt.production = $1 AND t.public = true`,
     z.tuple([z.int()]),
     TagSchema,
   );

--- a/backend/src/routes/tag/handlers/fetch.ts
+++ b/backend/src/routes/tag/handlers/fetch.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import type { Tag, TagWithMeta } from "@viernulvier/shared/index.js";
 import { TagSchema, stringToInt } from "@viernulvier/shared/index.js";
-import { parseParams, buildQuery, parseSchema } from "@/routes/helpers.js";
+import { parseParams, buildQuery, parseSchema, ParseContext } from "@/routes/helpers.js";
 import { z } from "zod";
 
 const TagSelect = `
@@ -9,16 +9,96 @@ SELECT id, name, tag_type, public
 FROM tag
 `;
 
+/** Row shape returned by tag SELECTs before `productions` is merged from `production_tag`. */
+const TagDbRowSchema = z.object({
+  id: TagSchema.shape.id,
+  name: TagSchema.shape.name,
+  tag_type: z.int().nonnegative(),
+  public: TagSchema.shape.public,
+});
+
+const TagDbRowWithMetaSchema = TagDbRowSchema.extend({
+  created_at: z.coerce.date(),
+  updated_at: z.coerce.date(),
+  created_by: z.int().nonnegative(),
+  updated_by: z.int().nonnegative(),
+});
+
 const TagsListQuerySchema = z.object({
   production: stringToInt.optional(),
+  /** When `includeProductions=true`, each tag includes full `productions` id list (default: empty arrays). */
+  includeProductions: z.literal("true").optional(),
 });
+
+const ProductionTagLinkSchema = z.object({
+  tag: z.int(),
+  production: z.int(),
+});
+
+async function fetchProductionIdsByTagIds(
+  server: FastifyInstance,
+  tagIds: number[],
+): Promise<Map<number, number[]>> {
+  if (tagIds.length === 0) {
+    return new Map();
+  }
+  const res = await server.pg.query<{ tag: number; production: number }>(
+    `SELECT tag, production FROM production_tag
+     WHERE tag = ANY($1::int[])
+     ORDER BY tag, production`,
+    [tagIds],
+  );
+  const links = parseSchema(
+    server,
+    z.array(ProductionTagLinkSchema),
+    res.rows,
+    ParseContext.Database,
+  );
+  const map = new Map<number, number[]>();
+  for (const { tag, production } of links) {
+    const list = map.get(tag) ?? [];
+    list.push(production);
+    map.set(tag, list);
+  }
+  return map;
+}
+
+function tagsFromDbRows(
+  rows: z.infer<typeof TagDbRowSchema>[],
+  byTag: Map<number, number[]>,
+): Tag[] {
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    type: row.tag_type,
+    public: row.public,
+    productions: byTag.get(row.id) ?? [],
+  }));
+}
+
+function tagsWithMetaFromDbRows(
+  rows: z.infer<typeof TagDbRowWithMetaSchema>[],
+  byTag: Map<number, number[]>,
+) {
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    type: row.tag_type,
+    public: row.public,
+    productions: byTag.get(row.id) ?? [],
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    created_by: row.created_by,
+    updated_by: row.updated_by,
+  }));
+}
 
 const fetchTagByIdQuery = (server: FastifyInstance) =>
   buildQuery(
     server,
     `${TagSelect} WHERE id = $1`,
     z.tuple([z.int()]),
-    TagSchema,
+    TagDbRowSchema,
   );
 
 const fetchTagVisibleByIdQuery = (server: FastifyInstance) =>
@@ -26,7 +106,7 @@ const fetchTagVisibleByIdQuery = (server: FastifyInstance) =>
     server,
     `${TagSelect} WHERE id = $1 AND public = true`,
     z.tuple([z.int()]),
-    TagSchema,
+    TagDbRowSchema,
   );
 
 const fetchTagWithMetaByIdQuery = (server: FastifyInstance) =>
@@ -35,35 +115,35 @@ const fetchTagWithMetaByIdQuery = (server: FastifyInstance) =>
     `SELECT id, name, tag_type, public, created_at, updated_at, created_by, updated_by
      FROM tag WHERE id = $1`,
     z.tuple([z.int()]),
-    TagSchema.withMeta(),
+    TagDbRowWithMetaSchema,
   );
 
 const fetchTagsAllQuery = (server: FastifyInstance) =>
-  buildQuery(server, `${TagSelect}`, TagSchema);
+  buildQuery(server, `${TagSelect}`, TagDbRowSchema);
 
 const fetchTagsByProductionQuery = (server: FastifyInstance) =>
   buildQuery(
     server,
-    `SELECT t.id, t.name, t.tag_type, public
+    `SELECT DISTINCT t.id, t.name, t.tag_type, public
      FROM tag t
      JOIN production_tag pt ON pt.tag = t.id
      WHERE pt.production = $1`,
     z.tuple([z.int()]),
-    TagSchema,
+    TagDbRowSchema,
   );
 
 const fetchTagsVisibleAllQuery = (server: FastifyInstance) =>
-  buildQuery(server, `${TagSelect} WHERE public = true`, TagSchema);
+  buildQuery(server, `${TagSelect} WHERE public = true`, TagDbRowSchema);
 
 const fetchTagsVisibleByProductionQuery = (server: FastifyInstance) =>
   buildQuery(
     server,
-    `SELECT t.id, t.name, t.tag_type, public
+    `SELECT DISTINCT t.id, t.name, t.tag_type, public
      FROM tag t
      JOIN production_tag pt ON pt.tag = t.id
      WHERE pt.production = $1 AND t.public = true`,
     z.tuple([z.int()]),
-    TagSchema,
+    TagDbRowSchema,
   );
 
 async function fetchTag(
@@ -72,7 +152,11 @@ async function fetchTag(
 ): Promise<Tag | null> {
   const { id } = parseParams(request, z.object({ id: stringToInt }));
   const rows = await fetchTagByIdQuery(server)(id);
-  return rows[0] ?? null;
+  const row = rows[0];
+  if (!row) return null;
+  const byTag = await fetchProductionIdsByTagIds(server, [row.id]);
+  const merged = tagsFromDbRows([row], byTag);
+  return parseSchema(server, TagSchema, merged[0], ParseContext.Database);
 }
 
 async function fetchTagVisible(
@@ -81,7 +165,11 @@ async function fetchTagVisible(
 ): Promise<Tag | null> {
   const { id } = parseParams(request, z.object({ id: stringToInt }));
   const rows = await fetchTagVisibleByIdQuery(server)(id);
-  return rows[0] ?? null;
+  const row = rows[0];
+  if (!row) return null;
+  const byTag = await fetchProductionIdsByTagIds(server, [row.id]);
+  const merged = tagsFromDbRows([row], byTag);
+  return parseSchema(server, TagSchema, merged[0], ParseContext.Database);
 }
 
 async function fetchTagWithMeta(
@@ -90,29 +178,59 @@ async function fetchTagWithMeta(
 ): Promise<TagWithMeta | null> {
   const { id } = parseParams(request, z.object({ id: stringToInt }));
   const rows = await fetchTagWithMetaByIdQuery(server)(id);
-  return rows[0] ?? null;
+  const row = rows[0];
+  if (!row) return null;
+  const byTag = await fetchProductionIdsByTagIds(server, [row.id]);
+  const merged = tagsWithMetaFromDbRows([row], byTag);
+  return parseSchema(server, TagSchema.withMeta(), merged[0], ParseContext.Database);
 }
 
 async function fetchTags(
   server: FastifyInstance,
   request: FastifyRequest,
 ): Promise<Tag[] | null> {
-  const { production } = parseSchema(server, TagsListQuerySchema, request.query);
-  if (production !== undefined) {
-    return await fetchTagsByProductionQuery(server)(production);
-  }
-  return await fetchTagsAllQuery(server)();
+  const { production, includeProductions } = parseSchema(
+    server,
+    TagsListQuerySchema,
+    request.query,
+  );
+  const rows =
+    production !== undefined
+      ? await fetchTagsByProductionQuery(server)(production)
+      : await fetchTagsAllQuery(server)();
+  const byTag =
+    includeProductions !== undefined
+      ? await fetchProductionIdsByTagIds(
+        server,
+        rows.map((r) => r.id),
+      )
+      : new Map<number, number[]>();
+  const merged = tagsFromDbRows(rows, byTag);
+  return parseSchema(server, z.array(TagSchema), merged, ParseContext.Database);
 }
 
 async function fetchTagsVisible(
   server: FastifyInstance,
   request: FastifyRequest,
 ): Promise<Tag[] | null> {
-  const { production } = parseSchema(server, TagsListQuerySchema, request.query);
-  if (production !== undefined) {
-    return await fetchTagsVisibleByProductionQuery(server)(production);
-  }
-  return await fetchTagsVisibleAllQuery(server)();
+  const { production, includeProductions } = parseSchema(
+    server,
+    TagsListQuerySchema,
+    request.query,
+  );
+  const rows =
+    production !== undefined
+      ? await fetchTagsVisibleByProductionQuery(server)(production)
+      : await fetchTagsVisibleAllQuery(server)();
+  const byTag =
+    includeProductions !== undefined
+      ? await fetchProductionIdsByTagIds(
+        server,
+        rows.map((r) => r.id),
+      )
+      : new Map<number, number[]>();
+  const merged = tagsFromDbRows(rows, byTag);
+  return parseSchema(server, z.array(TagSchema), merged, ParseContext.Database);
 }
 
 export { fetchTag, fetchTags, fetchTagWithMeta, fetchTagVisible, fetchTagsVisible };

--- a/backend/src/routes/tag/handlers/replace.ts
+++ b/backend/src/routes/tag/handlers/replace.ts
@@ -21,9 +21,9 @@ export async function replaceTag(
 
   const result = await server.pg.query<Tag>(
     `UPDATE tag
-     SET name = $1, type_id = $2, public = $3, updated_by = $4, updated_at = $5
+     SET name = $1, tag_type = $2, public = $3, updated_by = $4, updated_at = $5
      WHERE id = $6
-     RETURNING id, name, type_id, public`,
+     RETURNING id, name, tag_type, public`,
     [body.name, body.type, body.public, admin, current_time, id],
   );
 

--- a/backend/src/routes/tag/handlers/replace.ts
+++ b/backend/src/routes/tag/handlers/replace.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 
 const ReplaceTagBodySchema = TagSchema.pick({
   name: true,
-  type: true,
+  tag_type: true,
   public: true,
 });
 
@@ -24,7 +24,7 @@ export async function replaceTag(
      SET name = $1, tag_type = $2, public = $3, updated_by = $4, updated_at = $5
      WHERE id = $6
      RETURNING id, name, tag_type, public`,
-    [body.name, body.type, body.public, admin, current_time, id],
+    [body.name, body.tag_type, body.public, admin, current_time, id],
   );
 
   return parseSchema(server, z.array(TagSchema), result.rows, ParseContext.Database)[0] ?? null;

--- a/backend/test/legacy-import/import-productions-legacy.test.ts
+++ b/backend/test/legacy-import/import-productions-legacy.test.ts
@@ -89,7 +89,7 @@ describe("importProductionsLegacy", () => {
         if (name === "Genre") return Promise.resolve({ rows: [{ id: 20 }] });
         return Promise.resolve({ rows: [] });
       }
-      if (sql.includes("FROM tag") && sql.includes("type_id = $1") && !sql.includes("lower(name")) {
+      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("lower(name")) {
         return Promise.resolve({ rows: [] });
       }
       if (sql.includes("FROM tag") && sql.includes("lower(name->>'nl')")) {
@@ -142,7 +142,7 @@ describe("importProductionsLegacy", () => {
         if (name === "Genre") return Promise.resolve({ rows: [{ id: 20 }] });
         return Promise.resolve({ rows: [] });
       }
-      if (sql.includes("FROM tag") && sql.includes("type_id = $1") && !sql.includes("lower(name")) {
+      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("lower(name")) {
         return Promise.resolve({ rows: [] });
       }
       if (sql.trimStart().startsWith("BEGIN")) return Promise.resolve({ rows: [] });
@@ -242,7 +242,7 @@ describe("importProductionsLegacy", () => {
         if (name === "Genre") return Promise.resolve({ rows: [{ id: 20 }] });
         return Promise.resolve({ rows: [] });
       }
-      if (sql.includes("FROM tag") && sql.includes("type_id = $1") && !sql.includes("lower(name")) {
+      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("lower(name")) {
         return Promise.resolve({ rows: [] });
       }
       if (sql.trimStart().startsWith("BEGIN")) return Promise.resolve({ rows: [] });
@@ -294,7 +294,7 @@ describe("importProductionsLegacy", () => {
         const id = parsed.nl === "Tag" ? 10 : 20;
         return Promise.resolve({ rows: [{ id }] });
       }
-      if (sql.includes("FROM tag") && sql.includes("type_id = $1") && !sql.includes("lower(name")) {
+      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("lower(name")) {
         return Promise.resolve({ rows: [] });
       }
       if (sql.trimStart().startsWith("BEGIN")) return Promise.resolve({ rows: [] });

--- a/backend/test/routes/tag/create.test.ts
+++ b/backend/test/routes/tag/create.test.ts
@@ -10,7 +10,7 @@ let sessionCookie: string;
 const mockTag: Tag = {
   id: 5,
   name: { en: "Music", nl: "Muziek" },
-  type: 1,
+  tag_type: 1,
   productions: [],
   public: true,
 };
@@ -48,7 +48,7 @@ describe("Create tag", () => {
       cookies: { session: sessionCookie },
       payload: {
         name: mockTag.name,
-        type: mockTag.type,
+        tag_type: mockTag.tag_type,
         public: mockTag.public,
       },
     });
@@ -69,7 +69,7 @@ describe("Create tag", () => {
       cookies: { session: sessionCookie },
       payload: {
         name: mockTag.name,
-        type: mockTag.type,
+        tag_type: mockTag.tag_type,
         public: mockTag.public,
       },
     });

--- a/backend/test/routes/tag/delete.test.ts
+++ b/backend/test/routes/tag/delete.test.ts
@@ -10,7 +10,7 @@ let sessionCookie: string;
 const mockTag: Tag = {
   id: 5,
   name: { en: "Music", nl: "Muziek" },
-  type: 1,
+  tag_type: 1,
   productions: [],
   public: true,
 };

--- a/backend/test/routes/tag/edit.test.ts
+++ b/backend/test/routes/tag/edit.test.ts
@@ -10,7 +10,7 @@ let sessionCookie: string;
 const mockTag: Tag = {
   id: 5,
   name: { en: "Music", nl: "Muziek" },
-  type: 1,
+  tag_type: 1,
   productions: [],
   public: true,
 };
@@ -52,12 +52,12 @@ describe("Edit tag", () => {
     expect(TagSchema.parse(response.json())).toEqual(mockTag);
   });
 
-  test("PATCH /api/v1/tags/:id type only", async () => {
+  test("PATCH /api/v1/tags/:id tag_type only", async () => {
     const response = await server.inject({
       method: "PATCH",
       url: `/api/v1/tags/${mockTag.id}`,
       cookies: { session: sessionCookie },
-      payload: { type: mockTag.type },
+      payload: { tag_type: mockTag.tag_type },
     });
 
     expect(response.statusCode).toBe(HttpSuccess.OK);
@@ -79,7 +79,7 @@ describe("Edit tag", () => {
       method: "PATCH",
       url: `/api/v1/tags/${mockTag.id}`,
       cookies: { session: sessionCookie },
-      payload: { name: mockTag.name, type: mockTag.type, public: mockTag.public },
+      payload: { name: mockTag.name, tag_type: mockTag.tag_type, public: mockTag.public },
     });
 
     expect(response.statusCode).toBe(HttpSuccess.OK);

--- a/backend/test/routes/tag/fetch.test.ts
+++ b/backend/test/routes/tag/fetch.test.ts
@@ -30,6 +30,15 @@ const privateTag: Tag = {
   public: false,
 };
 
+/** Public tag with no production links — exercises `byTag.get(id) ?? []` when `includeProductions=true`. */
+const tagNoLinks: Tag = {
+  id: 42,
+  name: { en: "Concert", nl: "Concert" },
+  tag_type: 1,
+  productions: [],
+  public: true,
+};
+
 const tag1WithMeta = {
   ...tag1,
   created_at: new Date(),
@@ -38,7 +47,7 @@ const tag1WithMeta = {
   updated_by: 1,
 };
 
-const mockTags: Tag[] = [tag1, tag2, privateTag];
+const mockTags: Tag[] = [tag1, tag2, privateTag, tagNoLinks];
 
 /** List responses omit `productions` unless `includeProductions=true`. */
 const mockTagsListDefault: Tag[] = mockTags.map((t) => {
@@ -263,7 +272,7 @@ describe("Fetch tags for production", () => {
 
     expect(result).toEqual(
       mockTags
-        .filter((t) => t.productions.includes(1))
+        .filter((t) => (t.productions ?? []).includes(1))
         .map((t) => {
           const { productions: _, ...rest } = t;
           return rest;
@@ -280,7 +289,7 @@ describe("Fetch tags for production", () => {
 
     expect(response.statusCode).toBe(200);
     expect(TagSchema.array().parse(response.json())).toEqual(
-      mockTags.filter((t) => t.productions.includes(1)),
+      mockTags.filter((t) => (t.productions ?? []).includes(1)),
     );
   });
 
@@ -300,7 +309,7 @@ describe("Fetch visible tags for production", () => {
 
     expect(result).toEqual(
       mockTags
-        .filter((t) => t.public && t.productions.includes(1))
+        .filter((t) => t.public && (t.productions ?? []).includes(1))
         .map((t) => {
           const { productions: _, ...rest } = t;
           return rest;
@@ -316,7 +325,7 @@ describe("Fetch visible tags for production", () => {
 
     expect(response.statusCode).toBe(200);
     expect(TagSchema.array().parse(response.json())).toEqual(
-      mockTags.filter((t) => t.public && t.productions.includes(1)),
+      mockTags.filter((t) => t.public && (t.productions ?? []).includes(1)),
     );
   });
 

--- a/backend/test/routes/tag/fetch.test.ts
+++ b/backend/test/routes/tag/fetch.test.ts
@@ -40,35 +40,69 @@ const tag1WithMeta = {
 
 const mockTags: Tag[] = [tag1, tag2, privateTag];
 
+/** List responses omit production ids unless `includeProductions=true`. */
+const mockTagsListDefault: Tag[] = mockTags.map((t) => ({
+  ...t,
+  productions: [],
+}));
+
+function tagToDbRow(t: Tag) {
+  return {
+    id: t.id,
+    name: t.name,
+    tag_type: t.type,
+    public: t.public,
+  };
+}
+
 beforeAll(async () => {
   server = await buildServer();
 
   sessionCookie = server.jwt.sign({ id: 1, username: "Admin" });
 
   server.pg.query = vi.fn().mockImplementation((query: string, params?: unknown[]) => {
+    if (query.includes("tag = ANY")) {
+      const raw = params?.[0];
+      const ids = Array.isArray(raw) ? (raw as number[]) : [];
+      const linkRows: { tag: number; production: number }[] = [];
+      for (const t of mockTags) {
+        if (ids.includes(t.id)) {
+          for (const pid of t.productions) {
+            linkRows.push({ tag: t.id, production: pid });
+          }
+        }
+      }
+      return Promise.resolve({ rows: linkRows, rowCount: linkRows.length });
+    }
+
     const id = params?.[0];
     const isMetaQuery = query.includes("created_at");
     const isVisibleQuery = query.includes("public = true");
 
-    let rows;
+    let rows: ReturnType<typeof tagToDbRow>[] | Array<ReturnType<typeof tagToDbRow> & {
+      created_at: Date;
+      updated_at: Date;
+      created_by: number;
+      updated_by: number;
+    }>;
 
     if (query.includes("production_tag")) {
-      rows = mockTags.filter((t) =>
-        t.productions.includes(Number(id)),
-      );
-    } else if (id) {
-      rows = mockTags.filter((t) => t.id === Number(id));
+      rows = mockTags
+        .filter((t) => t.productions.includes(Number(id)))
+        .map(tagToDbRow);
+    } else if (id != null && !Array.isArray(id)) {
+      rows = mockTags.filter((t) => t.id === Number(id)).map(tagToDbRow);
     } else {
-      rows = mockTags;
+      rows = mockTags.map(tagToDbRow);
     }
 
     if (isVisibleQuery) {
-      rows = rows.filter((t) => t.public);
+      rows = rows.filter((r) => r.public);
     }
 
     if (isMetaQuery) {
-      rows = rows.map((t) => ({
-        ...t,
+      rows = rows.map((r) => ({
+        ...r,
         created_at: tag1WithMeta.created_at,
         updated_at: tag1WithMeta.updated_at,
         created_by: 1,
@@ -141,11 +175,42 @@ describe("Fetch visible tag on id", () => {
 });
 
 describe("Fetch tags", () => {
-  test("GET /api/v1/tags/all", async () => {
+  test("GET /api/v1/tags/all?includeProductions=true returns [] when no tags exist (no production_tag query)", async () => {
+    const prev = server.pg.query;
+    server.pg.query = vi.fn().mockImplementation((query: string) => {
+      if (query.includes("tag = ANY")) {
+        throw new Error("unexpected production_tag lookup with zero tag ids");
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+
+    const response = await server.inject({
+      method: "GET",
+      cookies: { session: sessionCookie },
+      url: `/api/v1/tags/all?includeProductions=true`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual([]);
+    server.pg.query = prev;
+  });
+
+  test("GET /api/v1/tags/all (productions omitted by default)", async () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
       url: `/api/v1/tags/all`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(TagSchema.array().parse(response.json())).toEqual(mockTagsListDefault);
+  });
+
+  test("GET /api/v1/tags/all?includeProductions=true", async () => {
+    const response = await server.inject({
+      method: "GET",
+      cookies: { session: sessionCookie },
+      url: `/api/v1/tags/all?includeProductions=true`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -155,7 +220,7 @@ describe("Fetch tags", () => {
 
 describe("Fetch visible tags", () => {
 
-  test("GET /api/v1/tags returns only public tags", async () => {
+  test("GET /api/v1/tags returns only public tags (productions omitted by default)", async () => {
 
     const response = await server.inject({
       method: "GET",
@@ -166,14 +231,26 @@ describe("Fetch visible tags", () => {
 
     const result = TagSchema.array().parse(response.json());
 
-    expect(result).toEqual(mockTags.filter((t) => t.public));
+    expect(result).toEqual(mockTagsListDefault.filter((t) => t.public));
+  });
+
+  test("GET /api/v1/tags?includeProductions=true", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/api/v1/tags?includeProductions=true`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(TagSchema.array().parse(response.json())).toEqual(
+      mockTags.filter((t) => t.public),
+    );
   });
 
 });
 
 describe("Fetch tags for production", () => {
 
-  test("GET /api/v1/tags/all?production={id}", async () => {
+  test("GET /api/v1/tags/all?production={id} (productions omitted by default)", async () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
@@ -184,14 +261,32 @@ describe("Fetch tags for production", () => {
 
     const result = TagSchema.array().parse(response.json());
 
-    expect(result).toEqual(mockTags.filter((t) => t.productions.includes(1)));
+    expect(result).toEqual(
+      mockTags.filter((t) => t.productions.includes(1)).map((t) => ({
+        ...t,
+        productions: [],
+      })),
+    );
+  });
+
+  test("GET /api/v1/tags/all?production={id}&includeProductions=true", async () => {
+    const response = await server.inject({
+      method: "GET",
+      cookies: { session: sessionCookie },
+      url: `/api/v1/tags/all?production=1&includeProductions=true`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(TagSchema.array().parse(response.json())).toEqual(
+      mockTags.filter((t) => t.productions.includes(1)),
+    );
   });
 
 });
 
 describe("Fetch visible tags for production", () => {
 
-  test("GET /api/v1/tags?production={id}", async () => {
+  test("GET /api/v1/tags?production={id} (productions omitted by default)", async () => {
     const response = await server.inject({
       method: "GET",
       url: `/api/v1/tags?production=1`,
@@ -202,6 +297,20 @@ describe("Fetch visible tags for production", () => {
     const result = TagSchema.array().parse(response.json());
 
     expect(result).toEqual(
+      mockTags
+        .filter((t) => t.public && t.productions.includes(1))
+        .map((t) => ({ ...t, productions: [] })),
+    );
+  });
+
+  test("GET /api/v1/tags?production={id}&includeProductions=true", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/api/v1/tags?production=1&includeProductions=true`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(TagSchema.array().parse(response.json())).toEqual(
       mockTags.filter((t) => t.public && t.productions.includes(1)),
     );
   });
@@ -220,6 +329,43 @@ describe("Fetch tag with metadata", () => {
 
     expect(response.statusCode).toBe(200);
     expect(TagSchema.withMeta().parse(response.json())).toEqual(tag1WithMeta);
+  });
+
+  test("GET /api/v1/tags/:id/meta includes empty productions when tag has no production_tag rows", async () => {
+    const prev = server.pg.query;
+    server.pg.query = vi.fn().mockImplementation((query: string, _params?: unknown[]) => {
+      if (query.includes("tag = ANY")) {
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      }
+      if (query.includes("created_at")) {
+        return Promise.resolve({
+          rows: [
+            {
+              ...tagToDbRow(tag1),
+              created_at: tag1WithMeta.created_at,
+              updated_at: tag1WithMeta.updated_at,
+              created_by: 1,
+              updated_by: 1,
+            },
+          ],
+          rowCount: 1,
+        });
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+
+    const response = await server.inject({
+      method: "GET",
+      cookies: { session: sessionCookie },
+      url: `/api/v1/tags/${tag1.id}/meta`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(TagSchema.withMeta().parse(response.json())).toEqual({
+      ...tag1WithMeta,
+      productions: [],
+    });
+    server.pg.query = prev;
   });
 
   test("GET returns 404 when tag not found", async () => {

--- a/backend/test/routes/tag/fetch.test.ts
+++ b/backend/test/routes/tag/fetch.test.ts
@@ -9,7 +9,7 @@ let sessionCookie: string;
 const tag1: Tag = {
   id: 5,
   name: { en: "Music", nl: "Muziek" },
-  type: 1,
+  tag_type: 1,
   productions: [1],
   public: true,
 };
@@ -17,7 +17,7 @@ const tag1: Tag = {
 const tag2: Tag = {
   id: 6,
   name: { en: "Family", nl: "Familie" },
-  type: 1,
+  tag_type: 1,
   productions: [1, 2],
   public: true,
 };
@@ -25,7 +25,7 @@ const tag2: Tag = {
 const privateTag: Tag = {
   id: 10,
   name: { en: "Private", nl: "Privé" },
-  type: 1,
+  tag_type: 1,
   productions: [1], // important for production tests
   public: false,
 };
@@ -50,7 +50,7 @@ function tagToDbRow(t: Tag) {
   return {
     id: t.id,
     name: t.name,
-    tag_type: t.type,
+    tag_type: t.tag_type,
     public: t.public,
   };
 }

--- a/backend/test/routes/tag/fetch.test.ts
+++ b/backend/test/routes/tag/fetch.test.ts
@@ -40,11 +40,11 @@ const tag1WithMeta = {
 
 const mockTags: Tag[] = [tag1, tag2, privateTag];
 
-/** List responses omit production ids unless `includeProductions=true`. */
-const mockTagsListDefault: Tag[] = mockTags.map((t) => ({
-  ...t,
-  productions: [],
-}));
+/** List responses omit `productions` unless `includeProductions=true`. */
+const mockTagsListDefault: Tag[] = mockTags.map((t) => {
+  const { productions: _, ...rest } = t;
+  return rest;
+});
 
 function tagToDbRow(t: Tag) {
   return {
@@ -67,7 +67,7 @@ beforeAll(async () => {
       const linkRows: { tag: number; production: number }[] = [];
       for (const t of mockTags) {
         if (ids.includes(t.id)) {
-          for (const pid of t.productions) {
+          for (const pid of t.productions ?? []) {
             linkRows.push({ tag: t.id, production: pid });
           }
         }
@@ -88,7 +88,7 @@ beforeAll(async () => {
 
     if (query.includes("production_tag")) {
       rows = mockTags
-        .filter((t) => t.productions.includes(Number(id)))
+        .filter((t) => (t.productions ?? []).includes(Number(id)))
         .map(tagToDbRow);
     } else if (id != null && !Array.isArray(id)) {
       rows = mockTags.filter((t) => t.id === Number(id)).map(tagToDbRow);
@@ -262,10 +262,12 @@ describe("Fetch tags for production", () => {
     const result = TagSchema.array().parse(response.json());
 
     expect(result).toEqual(
-      mockTags.filter((t) => t.productions.includes(1)).map((t) => ({
-        ...t,
-        productions: [],
-      })),
+      mockTags
+        .filter((t) => t.productions.includes(1))
+        .map((t) => {
+          const { productions: _, ...rest } = t;
+          return rest;
+        }),
     );
   });
 
@@ -299,7 +301,10 @@ describe("Fetch visible tags for production", () => {
     expect(result).toEqual(
       mockTags
         .filter((t) => t.public && t.productions.includes(1))
-        .map((t) => ({ ...t, productions: [] })),
+        .map((t) => {
+          const { productions: _, ...rest } = t;
+          return rest;
+        }),
     );
   });
 

--- a/backend/test/routes/tag/replace.test.ts
+++ b/backend/test/routes/tag/replace.test.ts
@@ -10,7 +10,7 @@ let sessionCookie: string;
 const mockTag: Tag = {
   id: 5,
   name: { en: "Music", nl: "Muziek" },
-  type: 1,
+  tag_type: 1,
   productions: [],
   public: true,
 };
@@ -48,7 +48,7 @@ describe("Replace tag", () => {
       cookies: { session: sessionCookie },
       payload: {
         name: mockTag.name,
-        type: mockTag.type,
+        tag_type: mockTag.tag_type,
         public: mockTag.public,
       },
     });
@@ -69,7 +69,7 @@ describe("Replace tag", () => {
       cookies: { session: sessionCookie },
       payload: {
         name: mockTag.name,
-        type: mockTag.type,
+        tag_type: mockTag.tag_type,
         public: mockTag.public,
       },
     });
@@ -84,7 +84,7 @@ describe("Replace tag", () => {
       cookies: { session: sessionCookie },
       payload: {
         name: mockTag.name,
-        type: mockTag.type,
+        tag_type: mockTag.tag_type,
       },
     });
 

--- a/data/imports/README.md
+++ b/data/imports/README.md
@@ -59,10 +59,10 @@ Events use `legacy_production_import_map` to resolve production foreign keys, so
 **Genres → `tag` + `production_tag`**
 
 - The **`Genre`** column may list **several genres separated by commas**. Each part is trimmed and deduplicated.
-- For each genre name, the script looks for an existing **`tag`** with that **`name->>'nl'`** (case-insensitive) and **`type_id`** = the Genre tag type.
+- For each genre name, the script looks for an existing **`tag`** with that **`name->>'nl'`** (case-insensitive) and **`tag_type`** = the Genre tag type.
   - If **found**, that tag id is reused.
-  - If **not found**, a new **`tag`** is created (`type_id` = Genre, `public` = true) and cached for the rest of the run.
-- Each production is linked with **`INSERT INTO production_tag (production_id, tag_id) … ON CONFLICT DO NOTHING`** so duplicate links are harmless.
+  - If **not found**, a new **`tag`** is created (`tag_type` = Genre, `public` = true) and cached for the rest of the run.
+- Each production is linked with **`INSERT INTO production_tag (production, tag) … ON CONFLICT DO NOTHING`** so duplicate links are harmless.
 
 **Legacy id map**
 

--- a/frontend/src/services/tags.ts
+++ b/frontend/src/services/tags.ts
@@ -43,7 +43,7 @@ export interface CreateTagInput {
   /** Localised display name of the tag. */
   name: LanguageMap;
   /** ID of the tag type this tag belongs to. */
-  type: number;
+  tag_type: number;
   /** Whether this tag is visible to the public. */
   public: boolean;
 }
@@ -157,7 +157,7 @@ export async function getTagWithMeta(id: number): Promise<TagWithMeta> {
  * @example
  * const tag = await createTag({
  *   name: { nl: "Drama", en: "Drama", fr: "Drame" },
- *   type: 1,
+ *   tag_type: 1,
  *   public: true,
  * });
  */

--- a/frontend/test/services/tags.test.ts
+++ b/frontend/test/services/tags.test.ts
@@ -39,7 +39,7 @@ function lastCall(): [string, RequestInit] {
   return calls[calls.length - 1]!;
 }
 
-const tagPayload = { id: 1, name: { nl: "Drama" }, type: 1, public: true };
+const tagPayload = { id: 1, name: { nl: "Drama" }, tag_type: 1, public: true };
 const tagTypePayload = { id: 1, name: { nl: "Genre" } };
 
 // ---------------------------------------------------------------------------
@@ -88,7 +88,7 @@ describe("getTagWithMeta", () => {
 
 describe("createTag", () => {
   it("POSTs to /api/v1/tags", async () => {
-    const input = { name: { nl: "Drama" }, type: 1, public: true };
+    const input = { name: { nl: "Drama" }, tag_type: 1, public: true };
     await createTag(input);
     expect(lastCall()[0]).toBe("/api/v1/tags");
     expect(lastCall()[1].method).toBe("POST");
@@ -98,7 +98,7 @@ describe("createTag", () => {
 
 describe("replaceTag", () => {
   it("PUTs to /api/v1/tags/:id", async () => {
-    await replaceTag(1, { name: { nl: "Komedie" }, type: 1, public: true });
+    await replaceTag(1, { name: { nl: "Komedie" }, tag_type: 1, public: true });
     expect(lastCall()[0]).toBe("/api/v1/tags/1");
     expect(lastCall()[1].method).toBe("PUT");
   });

--- a/shared/src/types/crop.ts
+++ b/shared/src/types/crop.ts
@@ -6,7 +6,7 @@ import { primaryKey, foreignKey } from "./helpers.js";
 export const CropSchema = createSchema({
   id: primaryKey(),
 
-  image_id: foreignKey(() => ImageSchema),
+  image: foreignKey(() => ImageSchema),
 
   url: z.url().min(1).max(2048),
 });

--- a/shared/src/types/image.ts
+++ b/shared/src/types/image.ts
@@ -6,7 +6,7 @@ import { primaryKey, foreignKey } from "./helpers.js";
 export const ImageSchema = createSchema({
   id: primaryKey(),
 
-  production_id: foreignKey(() => ProductionSchema),
+  production: foreignKey(() => ProductionSchema),
 
   res: z
     .string()

--- a/shared/src/types/production.ts
+++ b/shared/src/types/production.ts
@@ -58,7 +58,7 @@ export const CustomProductionFieldSchema = createSchema({
     > {
     return foreignKey(() => CustomProductionFieldDefinitionSchema);
   },
-  get production_id(): ForeignKey<typeof ProductionSchema> {
+  get production(): ForeignKey<typeof ProductionSchema> {
     return foreignKey(() => ProductionSchema);
   },
   type: FieldTypeSchema,

--- a/shared/src/types/tag.ts
+++ b/shared/src/types/tag.ts
@@ -21,7 +21,7 @@ export type TagTypeWithMeta = z.infer<
 export const TagSchema = createSchema({
   id: primaryKey(),
   name: languageMap,
-  get type(): ForeignKey<typeof TagTypeSchema> {
+  get tag_type(): ForeignKey<typeof TagTypeSchema> {
     return foreignKey(() => TagTypeSchema);
   },
   public: z.boolean(),

--- a/shared/src/types/tag.ts
+++ b/shared/src/types/tag.ts
@@ -18,6 +18,10 @@ export type TagTypeWithMeta = z.infer<
   ReturnType<typeof TagTypeSchema.withMeta>
 >;
 
+type TagProductionsSchema = z.ZodOptional<
+  z.ZodArray<ForeignKey<typeof ProductionSchema>>
+>;
+
 export const TagSchema = createSchema({
   id: primaryKey(),
   name: languageMap,
@@ -26,9 +30,7 @@ export const TagSchema = createSchema({
   },
   public: z.boolean(),
 
-  get productions(): z.ZodOptional<
-    z.ZodArray<ForeignKey<typeof ProductionSchema>>
-  > {
+  get productions(): TagProductionsSchema {
     return z.array(foreignKey(() => ProductionSchema)).optional();
   },
 });

--- a/shared/src/types/tag.ts
+++ b/shared/src/types/tag.ts
@@ -26,8 +26,10 @@ export const TagSchema = createSchema({
   },
   public: z.boolean(),
 
-  get productions(): z.ZodArray<ForeignKey<typeof ProductionSchema>> {
-    return z.array(foreignKey(() => ProductionSchema));
+  get productions(): z.ZodOptional<
+    z.ZodArray<ForeignKey<typeof ProductionSchema>>
+  > {
+    return z.array(foreignKey(() => ProductionSchema)).optional();
   },
 });
 


### PR DESCRIPTION
**Issue(s)**

Closes #245 

____

**Description**

Adds migration 009 to rename foreign-key columns so they match the referenced table names to be more consistent (same idea as event.production / event.hall) , and updates backend SQL, shared Zod shapes, legacy import paths, and docs accordingly.

If #244 is merged before this pr, change the base branch into staging.

____

**Sources**