### PR TITLE
Feat/scraper endpoint schema changes

### DIFF
--- a/backend/scripts/scraper/event.ts
+++ b/backend/scripts/scraper/event.ts
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import type { Event } from "@viernulvier/shared/index.js";
 import { EventSchemaWithoutPrice } from "@viernulvier/shared/index.js";
 

--- a/backend/scripts/scraper/event.ts
+++ b/backend/scripts/scraper/event.ts
@@ -1,6 +1,4 @@
-/* eslint-disable */
-
-import type { Event } from "@viernulvier/shared/index.js";
+// import type { Event } from "@viernulvier/shared/index.js";
 import { EventSchemaWithoutPrice } from "@viernulvier/shared/index.js";
 
 interface EventListMeta {
@@ -60,22 +58,22 @@ async function fetchPageRequest(
   return await response
 }
 
-async function fetchEventRequest(id: number, authToken: string) {
-  const url = `https://www.viernulvier.gent/api/v1/events/${id}`;
+// async function fetchEventRequest(id: number, authToken: string) {
+//   const url = `https://www.viernulvier.gent/api/v1/events/${id}`;
 
-  const response = await fetch(url, {
-    headers: {
-      accept: "application/ld+json",
-      "X-AUTH-TOKEN": authToken,
-    },
-  });
+//   const response = await fetch(url, {
+//     headers: {
+//       accept: "application/ld+json",
+//       "X-AUTH-TOKEN": authToken,
+//     },
+//   });
 
-  if (!response.ok) {
-    throw new Error(`API returned status ${response.status}`);
-  }
+//   if (!response.ok) {
+//     throw new Error(`API returned status ${response.status}`);
+//   }
 
-  return await response;
-}
+//   return await response;
+// }
 
 async function fetchEventsPage(
   page: number = 1,
@@ -117,7 +115,7 @@ async function processEvent(event: EventJSON) {
     return;
   }
 
-  const parsedEvent = eventParse.data as Event;
+  // const parsedEvent = eventParse.data as Event;
 }
 
 
@@ -130,7 +128,7 @@ export async function scrapeAllEvents(
   for (let page = 1; page <= totalPages; page++) {
     const data = await fetchEventsPage(page, beforeDate, authToken);
     for (const event of data.member) {
-      const id = event["@id"].split("/").pop() as unknown as number;
+      // const id = event["@id"].split("/").pop() as unknown as number;
       console.log(`Processing event ${event["@id"]} (${page}/${totalPages})`);
       await processEvent(event);
     }

--- a/backend/src/routes/event/handlers/bulk-edit.ts
+++ b/backend/src/routes/event/handlers/bulk-edit.ts
@@ -36,6 +36,7 @@ export async function editEvents(
   const existingEvents = selectedEvents as Event[];
 
   const updatedEvents = existingEvents.map((selectedEvent: Event) => ({
+    old_id: body.old_id ?? selectedEvent.old_id,
     starts_at: body.starts_at ?? selectedEvent.starts_at,
     ends_at: body.ends_at ?? selectedEvent.ends_at,
     production: body.production ?? selectedEvent.production,
@@ -49,6 +50,7 @@ export async function editEvents(
 
   const results = await Promise.all(
     updatedEvents.map((updatedEvent, index) => updateEvent(server)(
+      updatedEvent.old_id,
       updatedEvent.starts_at,
       updatedEvent.ends_at,
       updatedEvent.production,

--- a/backend/src/routes/event/handlers/create.ts
+++ b/backend/src/routes/event/handlers/create.ts
@@ -27,9 +27,10 @@ export async function createEvent(
   const result = await buildQuery(
     server,
     `INSERT INTO events (starts_at, ends_at, production, hall, doors_at, vendor_id, info, created_at, updated_at, created_by, updated_by)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8, $9, $9)
-      RETURNING id, starts_at, ends_at, production, hall, doors_at, vendor_id, info, ${selectPriceSubquery}`,
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $9, $10, $10)
+      RETURNING id, old_id, starts_at, ends_at, production, hall, doors_at, vendor_id, info, ${selectPriceSubquery}`,
     z.tuple([
+      EventCreateSchema.shape.old_id,
       EventCreateSchema.shape.starts_at,
       EventCreateSchema.shape.ends_at,
       EventCreateSchema.shape.production,
@@ -39,10 +40,10 @@ export async function createEvent(
       EventCreateSchema.shape.info,
       z.date(),
       z.number().nonnegative(),
-
     ]),
     EventSchema,
   )(
+    body.old_id,
     body.starts_at,
     body.ends_at,
     body.production,

--- a/backend/src/routes/event/handlers/edit.ts
+++ b/backend/src/routes/event/handlers/edit.ts
@@ -29,6 +29,7 @@ export async function editEvent(
   if (!selectedEvent) return null;
 
   const updatedEvent: EventCreate = {
+    old_id: body.old_id ?? selectedEvent.old_id,
     starts_at: body.starts_at ?? selectedEvent.starts_at,
     ends_at: body.ends_at ?? selectedEvent.ends_at,
     production: body.production ?? selectedEvent.production,
@@ -42,6 +43,7 @@ export async function editEvent(
   const { current_time, admin } = getMetadata(request);
 
   const result = await updateEvent(server)(
+    updatedEvent.old_id,
     updatedEvent.starts_at,
     updatedEvent.ends_at,
     updatedEvent.production,

--- a/backend/src/routes/event/handlers/fetch.ts
+++ b/backend/src/routes/event/handlers/fetch.ts
@@ -20,7 +20,7 @@ export async function fetchEvent(
 ): Promise<Event | null> {
   const { id } = parseParams(request, z.object({ id: stringToInt }));
   const result = await buildQuery(server,
-    `SELECT id, starts_at, ends_at, production, hall, doors_at, vendor_id, info, ${selectPriceSubquery}
+    `SELECT id, old_id, starts_at, ends_at, production, hall, doors_at, vendor_id, info, ${selectPriceSubquery}
     FROM events WHERE id = $1`,
     z.tuple([z.int()]),
     EventSchema,
@@ -44,7 +44,7 @@ export async function fetchEventWithMeta(
   const { id } = parseParams(request, z.object({ id: stringToInt }));
   const result = await buildQuery(
     server,
-    `SELECT id, starts_at, ends_at, production, hall, doors_at, vendor_id, info, ${selectPriceSubquery},
+    `SELECT id, old_id, starts_at, ends_at, production, hall, doors_at, vendor_id, info, ${selectPriceSubquery},
         created_at, updated_at, created_by, updated_by
     FROM events WHERE id = $1`,
     z.tuple([z.int()]),
@@ -66,7 +66,7 @@ export async function fetchEvents(
 ): Promise<Event[]> {
   const result = await buildQuery(
     server,
-    `SELECT id, starts_at, ends_at, production, hall, doors_at, vendor_id, info, ${selectPriceSubquery}
+    `SELECT id, old_id, starts_at, ends_at, production, hall, doors_at, vendor_id, info, ${selectPriceSubquery}
     FROM events`,
     EventSchema,
   )();

--- a/backend/src/routes/event/handlers/helper.ts
+++ b/backend/src/routes/event/handlers/helper.ts
@@ -94,11 +94,12 @@ export function updateEvent(server: FastifyInstance) {
   return buildQuery(
     server,
     `UPDATE events
-    SET starts_at = $1, ends_at = $2, production = $3, hall = $4, doors_at = $5, vendor_id = $6, info = $7,
-        updated_at = $8, updated_by = $9
-    WHERE id = $10
-    RETURNING id, starts_at, ends_at, production, hall, doors_at, vendor_id, info, ${selectPriceSubquery}`,
+    SET old_id = $1, starts_at = $2, ends_at = $3, production = $4, hall = $5, doors_at = $6, vendor_id = $7, info = $8,
+        updated_at = $9, updated_by = $10
+    WHERE id = $11
+    RETURNING id, old_id, starts_at, ends_at, production, hall, doors_at, vendor_id, info, ${selectPriceSubquery}`,
     z.tuple([
+      EventCreateSchema.shape.old_id,
       EventCreateSchema.shape.starts_at,
       EventCreateSchema.shape.ends_at,
       EventCreateSchema.shape.production,

--- a/backend/src/routes/event/handlers/replace.ts
+++ b/backend/src/routes/event/handlers/replace.ts
@@ -26,6 +26,7 @@ export async function replaceEvent(
   const { admin, current_time } = getMetadata(request);
 
   const result = await updateEvent(server)(
+    body.old_id,
     body.starts_at,
     body.ends_at,
     body.production,

--- a/backend/src/routes/hall/handlers/create.ts
+++ b/backend/src/routes/hall/handlers/create.ts
@@ -14,6 +14,7 @@ const insertHall = (server: FastifyInstance) =>
      VALUES ($1, $2, $3, $4, $4, $5, $5)
      RETURNING id, name, address, vendor_id`,
     z.tuple([
+      z.int().nonnegative().nullable(), // old_id
       languageMap,            // name
       z.string(),             // address
       z.int().nonnegative(),  // vendor_id
@@ -35,6 +36,7 @@ export async function createHall(server: FastifyInstance, request: FastifyReques
   const { admin, current_time } = getMetadata(request);
 
   const rows = await insertHall(server)(
+    body["old_id"],
     body["name"],
     body["address"],
     body["vendor_id"],

--- a/backend/src/routes/hall/handlers/delete.ts
+++ b/backend/src/routes/hall/handlers/delete.ts
@@ -8,7 +8,7 @@ const deleteHallById = (server: FastifyInstance) =>
   buildQuery(
     server,
     `DELETE FROM hall WHERE id = $1
-     RETURNING id, name, address, vendor_id`,
+     RETURNING id, old_id, name, address, vendor_id`,
     z.tuple([z.int()]),
     HallSchema,
   );

--- a/backend/src/routes/hall/handlers/edit.ts
+++ b/backend/src/routes/hall/handlers/edit.ts
@@ -28,6 +28,7 @@ export async function editHall(server: FastifyInstance, request: FastifyRequest)
     values.push(value);
   };
 
+  addField("old_id", body["old_id"]);
   addField("name", body["name"]);
   addField("address", body["address"]);
   addField("vendor_id", body["vendor_id"]);
@@ -41,7 +42,7 @@ export async function editHall(server: FastifyInstance, request: FastifyRequest)
 
   const result = await server.pg.query<Hall>(
     `UPDATE hall SET ${fields.join(", ")} WHERE id = $${i}
-     RETURNING id, name, address, vendor_id`,
+     RETURNING id, old_id, name, address, vendor_id`,
     values,
   );
 

--- a/backend/src/routes/hall/handlers/fetch.ts
+++ b/backend/src/routes/hall/handlers/fetch.ts
@@ -7,6 +7,7 @@ import z from "zod";
 const HallSelect = `
 SELECT
   id,
+  old_id,
   address,
   vendor_id,
   name
@@ -31,7 +32,7 @@ const fetchHallByIdQuery = (server: FastifyInstance) =>
 const fetchHallWithMetaByIdQuery = (server: FastifyInstance) =>
   buildQuery(
     server,
-    `SELECT id, address, vendor_id, name, created_at, updated_at, created_by, updated_by
+    `SELECT id, old_id, address, vendor_id, name, created_at, updated_at, created_by, updated_by
      FROM hall WHERE id = $1`,
     z.tuple([z.int()]),
     HallSchema.withMeta(),

--- a/backend/src/routes/hall/handlers/replace.ts
+++ b/backend/src/routes/hall/handlers/replace.ts
@@ -9,10 +9,11 @@ const ReplaceHallBodySchema = HallSchema.omit({ id: true });
 const replaceHallQuery = (server: FastifyInstance) =>
   buildQuery(
     server,
-    `UPDATE hall SET name = $1, address = $2, vendor_id = $3, updated_by = $4, updated_at = $5
-     WHERE id = $6
-     RETURNING id, name, address, vendor_id`,
+    `UPDATE hall SET old_id = $1, name = $2, address = $3, vendor_id = $4, updated_by = $5, updated_at = $6
+     WHERE id = $7
+     RETURNING id, old_id, name, address, vendor_id`,
     z.tuple([
+      z.int().nonnegative().nullable(), // old_id
       languageMap,           // name
       z.string(),            // address
       z.int().nonnegative(), // vendor_id
@@ -37,6 +38,7 @@ export async function replaceHall(server: FastifyInstance, request: FastifyReque
   const { admin, current_time } = getMetadata(request);
 
   const rows = await replaceHallQuery(server)(
+    body["old_id"],
     body["name"],
     body["address"],
     body["vendor_id"],

--- a/backend/src/routes/production/handlers/body-schema.ts
+++ b/backend/src/routes/production/handlers/body-schema.ts
@@ -4,6 +4,8 @@ import z from "zod";
 export const ProductionBodySchema = ProductionSchema.pick({
   vendor_id: true,
   box_office_id: true,
+  old_id: true,
+  finalized: true,
   supertitle: true,
   title: true,
   artist: true,
@@ -29,6 +31,8 @@ export const CreateProductionBodySchema = ProductionSchema.pick({
   teaser: true,
 }).extend(
   ProductionSchema.pick({
+    old_id: true,
+    finalized: true,
     supertitle: true,
     description: true,
     description_extra: true,

--- a/backend/src/routes/production/handlers/create.ts
+++ b/backend/src/routes/production/handlers/create.ts
@@ -15,6 +15,8 @@ const RequiredCreateColumns = [
 ] as const;
 
 const NullableCreateColumns = [
+  "old_id",
+  "finalized",
   "supertitle",
   "description",
   "description_extra",

--- a/backend/src/routes/tag/handlers/create.ts
+++ b/backend/src/routes/tag/handlers/create.ts
@@ -4,6 +4,7 @@ import { TagSchema } from "@viernulvier/shared/index.js";
 import { getMetadata, parseFirstRow, parseSchema } from "@/routes/helpers.js";
 
 const CreateTagBodySchema = TagSchema.pick({
+  old_id: true,
   name: true,
   type: true,
   public: true,
@@ -20,10 +21,10 @@ export async function createTag(
   const { admin, current_time } = getMetadata(request);
 
   const result = await server.pg.query<Tag>(
-    `INSERT INTO tag (name, type_id, public, created_by, updated_by, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $4, $5, $5)
-     RETURNING id, name, type_id`,
-    [body.name, body.type, body.public, admin, current_time],
+    `INSERT INTO tag (old_id, name, type_id, public, created_by, updated_by, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $5, $6, $6)
+     RETURNING id, old_id, name, type_id`,
+    [body.old_id, body.name, body.type, body.public, admin, current_time],
   );
 
   return parseFirstRow(server, TagSchema, result.rows);

--- a/backend/src/routes/tag/handlers/delete.ts
+++ b/backend/src/routes/tag/handlers/delete.ts
@@ -11,7 +11,7 @@ export async function deleteTag(
   const result = await server.pg.query<Tag>(
     `DELETE FROM tag
      WHERE id = $1
-     RETURNING id, name, type_id, public`,
+     RETURNING id, old_id, name, type_id, public`,
     [getParam(request, "id")],
   );
 

--- a/backend/src/routes/tag/handlers/edit.ts
+++ b/backend/src/routes/tag/handlers/edit.ts
@@ -4,6 +4,7 @@ import { TagSchema } from "@viernulvier/shared/index.js";
 import { getMetadata, getParam, parseFirstRow, parseSchema } from "@/routes/helpers.js";
 
 const EditTagBodySchema = TagSchema.pick({
+  old_id: true,
   name: true,
   type: true,
   public: true,
@@ -23,6 +24,11 @@ export async function editTag(
   const values: unknown[] = [];
   let i = 1;
 
+  if (body.old_id !== undefined) {
+    fields.push(`old_id = $${i++}`);
+    values.push(body.old_id);
+  }
+
   if (body.name !== undefined) {
     fields.push(`name = $${i++}`);
     values.push(body.name);
@@ -37,13 +43,14 @@ export async function editTag(
     fields.push(`public = $${i++}`);
     values.push(body.public);
   }
+  
 
   fields.push(`updated_by = $${i++}`, `updated_at = $${i++}`);
   values.push(admin, current_time, id);
 
   const result = await server.pg.query<Tag>(
     `UPDATE tag SET ${fields.join(", ")} WHERE id = $${i}
-     RETURNING id, name, type_id, public`,
+     RETURNING id, old_id, name, type_id, public`,
     values,
   );
 

--- a/backend/src/routes/tag/handlers/fetch.ts
+++ b/backend/src/routes/tag/handlers/fetch.ts
@@ -9,7 +9,7 @@ async function fetchTag(
 ): Promise<Tag | null> {
 
   const result = await server.pg.query<Tag>(
-    `SELECT id, name, type_id, public
+    `SELECT id, old_id, name, type_id, public
      FROM tag
      WHERE id = $1`,
     [getParam(request, "id")],
@@ -24,7 +24,7 @@ async function fetchTagVisible(
 ): Promise<Tag | null> {
 
   const result = await server.pg.query<Tag>(
-    `SELECT id, name, type_id, public
+    `SELECT id, old_id, name, type_id, public
      FROM tag
      WHERE id = $1 AND public = true`,
     [getParam(request, "id")],
@@ -41,7 +41,7 @@ async function fetchTagWithMeta(
 ): Promise<TagWithMeta | null> {
 
   const result = await server.pg.query<TagWithMeta>(
-    `SELECT id, name, type_id, public,
+    `SELECT id, old_id, name, type_id, public,
             created_at, updated_at,
             created_by, updated_by
      FROM tag
@@ -62,7 +62,7 @@ async function fetchTags(
 
   if (production) {
     const result = await server.pg.query<Tag>(
-      `SELECT t.id, t.name, t.type_id, public
+      `SELECT t.id, t.old_id, t.name, t.type_id, t.public
        FROM tag t
        JOIN production_tag pt ON pt.tag_id = t.id
        WHERE pt.production_id = $1`,
@@ -73,7 +73,7 @@ async function fetchTags(
   }
 
   const result = await server.pg.query<Tag>(
-    `SELECT id, name, type_id, public FROM tag`,
+    `SELECT id, old_id, name, type_id, public FROM tag`,
   );
 
   return result.rows;
@@ -89,7 +89,7 @@ async function fetchTagsVisible(
 
   if (production) {
     const result = await server.pg.query<Tag>(
-      `SELECT t.id, t.name, t.type_id, public
+      `SELECT t.id, t.old_id, t.name, t.type_id, public
        FROM tag t
        JOIN production_tag pt ON pt.tag_id = t.id
        WHERE pt.production_id = $1 AND t.public = true`,
@@ -100,7 +100,7 @@ async function fetchTagsVisible(
   }
 
   const result = await server.pg.query<Tag>(
-    `SELECT id, name, type_id, public FROM tag WHERE public = true`,
+    `SELECT id, old_id, name, type_id, public FROM tag WHERE public = true`,
   );
 
   return result.rows;

--- a/backend/src/routes/tag/handlers/replace.ts
+++ b/backend/src/routes/tag/handlers/replace.ts
@@ -4,6 +4,7 @@ import { TagSchema } from "@viernulvier/shared/index.js";
 import { getMetadata, getParam, parseFirstRow, parseSchema } from "@/routes/helpers.js";
 
 const ReplaceTagBodySchema = TagSchema.pick({
+  old_id: true,
   name: true,
   type: true,
   public: true,
@@ -21,10 +22,10 @@ export async function replaceTag(
 
   const result = await server.pg.query<Tag>(
     `UPDATE tag
-     SET name = $1, type_id = $2, public = $3, updated_by = $4, updated_at = $5
-     WHERE id = $6
-     RETURNING id, name, type_id, public`,
-    [body.name, body.type, body.public, admin, current_time, id],
+     SET old_id = $1, name = $2, type_id = $3, public = $4, updated_by = $5, updated_at = $6
+     WHERE id = $7
+     RETURNING id, old_id, name, type_id, public`,
+    [body.old_id, body.name, body.type, body.public, admin, current_time, id],
   );
 
   return parseFirstRow(server, TagSchema, result.rows);

--- a/backend/test/routes/event/bulk-edit.test.ts
+++ b/backend/test/routes/event/bulk-edit.test.ts
@@ -9,6 +9,7 @@ let sessionCookie: string;
 
 const baseEvent = {
   id: 1,
+  old_id: 111,
   starts_at: new Date("2026-01-01T18:00:00.000Z"),
   ends_at: new Date("2026-01-01T20:00:00.000Z"),
   production: 10,
@@ -30,7 +31,7 @@ beforeAll(async () => {
 
   server.pg.query = vi.fn().mockImplementation((query: string, params?: unknown[]) => {
     if (query.includes("UPDATE events")) {
-      const id = Number(params?.[9]);
+      const id = Number(params?.[10]);
       const index = storedEvents.findIndex((event) => Number(event.id) === id);
       if (index === -1) return Promise.resolve({ rows: [] });
 
@@ -38,13 +39,14 @@ beforeAll(async () => {
       const current = storedEvents[index]!;
       const updated = {
         ...current,
-        starts_at: (params?.[0] as Date | undefined) ?? current["starts_at"],
-        ends_at: (params?.[1] as Date | undefined) ?? current["ends_at"],
-        production: (params?.[2] as number | undefined) ?? current["production"],
-        hall: (params?.[3] as number | undefined) ?? current["hall"],
-        doors_at: (params?.[4] as Date | undefined) ?? current["doors_at"],
-        vendor_id: (params?.[5] as number | undefined) ?? current["vendor_id"],
-        info: params?.[6] ?? current["info"],
+        old_id: (params?.[0] as number | undefined) ?? current["old_id"],
+        starts_at: (params?.[1] as Date | undefined) ?? current["starts_at"],
+        ends_at: (params?.[2] as Date | undefined) ?? current["ends_at"],
+        production: (params?.[3] as number | undefined) ?? current["production"],
+        hall: (params?.[4] as number | undefined) ?? current["hall"],
+        doors_at: (params?.[5] as Date | undefined) ?? current["doors_at"],
+        vendor_id: (params?.[6] as number | undefined) ?? current["vendor_id"],
+        info: params?.[7] ?? current["info"],
       };
 
       // eslint-disable-next-line security/detect-object-injection

--- a/backend/test/routes/event/create.test.ts
+++ b/backend/test/routes/event/create.test.ts
@@ -12,6 +12,7 @@ let shouldRejectQuery = false;
 let sessionCookie: string;
 
 const basePayload = {
+  old_id: 111,
   starts_at: "2026-01-01T18:00:00.000Z",
   ends_at: "2026-01-01T20:00:00.000Z",
   production: 10,
@@ -38,18 +39,19 @@ beforeAll(async () => {
     }
 
     if (query.includes("INSERT INTO events")) {
-      const vendorId = params?.[5] as number;
+      const vendorId = params?.[6] as number;
       if (vendorId === 404) return Promise.resolve({ rows: [] });
 
       const createdEvent = {
         id: idCounter++,
-        starts_at: params?.[0] as Date,
-        ends_at: params?.[1] as Date,
-        production: params?.[2] as number,
-        hall: params?.[3] as number,
-        doors_at: params?.[4] as Date,
-        vendor_id: params?.[5] as number,
-        info: params?.[6],
+        old_id: params?.[0] as number,
+        starts_at: params?.[1] as Date,
+        ends_at: params?.[2] as Date,
+        production: params?.[3] as number,
+        hall: params?.[4] as number,
+        doors_at: params?.[5] as Date,
+        vendor_id: params?.[6] as number,
+        info: params?.[7],
       };
 
       storedEvents.push(createdEvent);
@@ -158,9 +160,9 @@ describe("Event Create Routes", () => {
       });
       expect(queryMock).toHaveBeenCalledOnce();
       const params = queryMock.mock.calls[0]?.[1] as unknown[];
-      expect(params[0]).toBeInstanceOf(Date);
       expect(params[1]).toBeInstanceOf(Date);
-      expect(params[4]).toBeInstanceOf(Date);
+      expect(params[2]).toBeInstanceOf(Date);
+      expect(params[5]).toBeInstanceOf(Date);
     });
   });
 });

--- a/backend/test/routes/event/delete.test.ts
+++ b/backend/test/routes/event/delete.test.ts
@@ -9,6 +9,7 @@ let sessionCookie: string;
 
 const baseEvent = {
   id: 1,
+  old_id: 111,
   starts_at: new Date("2026-01-01T18:00:00.000Z"),
   ends_at: new Date("2026-01-01T20:00:00.000Z"),
   production: 10,
@@ -21,8 +22,8 @@ const baseEvent = {
 
 const initialEvents = [
   baseEvent,
-  { ...baseEvent, id: 2, production: 11, hall: 4, info: { nl: "Info mock 2" }, price: [2] },
-  { ...baseEvent, id: 3, production: 12, hall: 5, info: { nl: "Info mock 3" }, price: [3] },
+  { ...baseEvent, id: 2, old_id: 112, production: 11, hall: 4, info: { nl: "Info mock 2" }, price: [2] },
+  { ...baseEvent, id: 3, old_id: 113, production: 12, hall: 5, info: { nl: "Info mock 3" }, price: [3] },
 ];
 
 beforeAll(async () => {

--- a/backend/test/routes/event/edit.test.ts
+++ b/backend/test/routes/event/edit.test.ts
@@ -9,6 +9,7 @@ let sessionCookie: string;
 
 const baseEvent = {
   id: 1,
+  old_id: 111,
   starts_at: new Date("2026-01-01T18:00:00.000Z"),
   ends_at: new Date("2026-01-01T20:00:00.000Z"),
   production: 10,
@@ -24,8 +25,8 @@ const baseEvent = {
 
 const initialEvents = [
   baseEvent,
-  { ...baseEvent, id: 2, production: 11, hall: 4, info: { nl: "Info mock 2" } },
-  { ...baseEvent, id: 3, production: 12, hall: 5, info: { nl: "Info mock 3" } },
+  { ...baseEvent, id: 2, old_id: 112, production: 11, hall: 4, info: { nl: "Info mock 2" } },
+  { ...baseEvent, id: 3, old_id: 113, production: 12, hall: 5, info: { nl: "Info mock 3" } },
 ];
 
 beforeAll(async () => {
@@ -34,7 +35,7 @@ beforeAll(async () => {
 
   server.pg.query = vi.fn().mockImplementation((query: string, params?: unknown[]) => {
     if (query.includes("UPDATE events")) {
-      const id = Number(params?.[9]);
+      const id = Number(params?.[10]);
       const index = storedEvents.findIndex((event) => Number(event.id) === id);
       if (index === -1) return Promise.resolve({ rows: [] });
 
@@ -42,15 +43,16 @@ beforeAll(async () => {
       const current = storedEvents[index]!;
       const updated = {
         ...current,
-        starts_at: (params?.[0] as Date | undefined) ?? current["starts_at"],
-        ends_at: (params?.[1] as Date | undefined) ?? current["ends_at"],
-        production: (params?.[2] as number | undefined) ?? current["production"],
-        hall: (params?.[3] as number | undefined) ?? current["hall"],
-        doors_at: (params?.[4] as Date | undefined) ?? current["doors_at"],
-        vendor_id: (params?.[5] as number | undefined) ?? current["vendor_id"],
-        info: params?.[6] ?? current["info"],
-        updated_at: params?.[7] ? new Date(params?.[7] as string) : new Date(),
-        updated_by: params?.[8],
+        old_id: (params?.[0] as number | undefined) ?? current["old_id"],
+        starts_at: (params?.[1] as Date | undefined) ?? current["starts_at"],
+        ends_at: (params?.[2] as Date | undefined) ?? current["ends_at"],
+        production: (params?.[3] as number | undefined) ?? current["production"],
+        hall: (params?.[4] as number | undefined) ?? current["hall"],
+        doors_at: (params?.[5] as Date | undefined) ?? current["doors_at"],
+        vendor_id: (params?.[6] as number | undefined) ?? current["vendor_id"],
+        info: params?.[7] ?? current["info"],
+        updated_at: params?.[8] ? new Date(params?.[8] as string) : new Date(),
+        updated_by: params?.[9],
       };
 
       // eslint-disable-next-line security/detect-object-injection
@@ -174,6 +176,7 @@ describe("Event Edit Routes", () => {
       expect(editResponse.statusCode).toBe(200);
       const body = editResponse.json();
       expect(body.id).toBe(2);
+      expect(body.old_id).toBe(initialEvents[1]!.old_id);
       expect(body.production).toBe(99);
       expect(body.starts_at).toBe(initialEvents[1]!.starts_at.toISOString());
       expect(body.ends_at).toBe(initialEvents[1]!.ends_at.toISOString());
@@ -193,6 +196,7 @@ describe("Event Edit Routes", () => {
       expect(listResponse.json()).toHaveLength(3);
       const listedEvent = listResponse.json()[1];
       expect(listedEvent.id).toBe(2);
+      expect(listedEvent.old_id).toBe(112);
       expect(listedEvent.production).toBe(99);
       expect(listedEvent.starts_at).toBe(initialEvents[1]!.starts_at.toISOString());
       expect(listedEvent.ends_at).toBe(initialEvents[1]!.ends_at.toISOString());
@@ -221,6 +225,7 @@ describe("Event Edit Routes", () => {
       expect(editResponse.statusCode).toBe(200);
       const editBody = editResponse.json();
       expect(editBody.id).toBe(2);
+      expect(editBody.old_id).toBe(112);
       expect(editBody.starts_at).toBe(newStartsAt.toISOString());
       expect(editBody.ends_at).toBe(newEndsAt.toISOString());
       expect(editBody.hall).toBe(9);
@@ -240,6 +245,7 @@ describe("Event Edit Routes", () => {
       expect(listResponse.json()).toHaveLength(3);
       const listedEvent2 = listResponse.json()[1];
       expect(listedEvent2.id).toBe(2);
+      expect(listedEvent2.old_id).toBe(112);
       expect(listedEvent2.starts_at).toBe(newStartsAt.toISOString());
       expect(listedEvent2.ends_at).toBe(newEndsAt.toISOString());
       expect(listedEvent2.hall).toBe(9);

--- a/backend/test/routes/event/fetch.test.ts
+++ b/backend/test/routes/event/fetch.test.ts
@@ -10,6 +10,7 @@ let sessionCookie: string;
 
 const baseMockEvent: EventWithoutPrice = {
   id: 1,
+  old_id: 111,
   starts_at: new Date("2026-01-01T18:00:00.000Z"),
   ends_at: new Date("2026-01-01T20:00:00.000Z"),
   production: 10,
@@ -28,8 +29,8 @@ const metaData = {
 
 const mockEvents: EventWithoutPrice[] = [
   baseMockEvent,
-  { ...baseMockEvent, id: 2, production: 11, hall: 4, info: { nl: "Info mock 2" } },
-  { ...baseMockEvent, id: 3, production: 12, hall: 5, info: { nl: "Info mock 3" } },
+  { ...baseMockEvent, id: 2, old_id: 112, production: 11, hall: 4, info: { nl: "Info mock 2" } },
+  { ...baseMockEvent, id: 3, old_id: 113, production: 12, hall: 5, info: { nl: "Info mock 3" } },
 ];
 
 const mockInvalidEvent: EventWithoutPrice = {

--- a/backend/test/routes/event/replace.test.ts
+++ b/backend/test/routes/event/replace.test.ts
@@ -9,6 +9,7 @@ let sessionCookie: string;
 
 const baseEvent = {
   id: 1,
+  old_id: 111,
   starts_at: new Date("2026-01-01T18:00:00.000Z"),
   ends_at: new Date("2026-01-01T20:00:00.000Z"),
   production: 10,
@@ -24,8 +25,8 @@ const baseEvent = {
 
 const initialEvents = [
   baseEvent,
-  { ...baseEvent, id: 2, production: 11, hall: 4, info: { nl: "Info mock 2" } },
-  { ...baseEvent, id: 3, production: 12, hall: 5, info: { nl: "Info mock 3" } },
+  { ...baseEvent, id: 2, old_id: 112, production: 11, hall: 4, info: { nl: "Info mock 2" } },
+  { ...baseEvent, id: 3, old_id: 113, production: 12, hall: 5, info: { nl: "Info mock 3" } },
 ];
 
 beforeAll(async () => {
@@ -34,7 +35,7 @@ beforeAll(async () => {
 
   server.pg.query = vi.fn().mockImplementation((query: string, params?: unknown[]) => {
     if (query.includes("UPDATE events")) {
-      const id = Number(params?.[9]);
+      const id = Number(params?.[10]);
       const index = storedEvents.findIndex((event) => Number(event.id) === id);
       if (index === -1) return Promise.resolve({ rows: [] });
 
@@ -42,15 +43,16 @@ beforeAll(async () => {
       const current = storedEvents[index]!;
       const updated = {
         ...current,
-        starts_at: (params?.[0] as Date | undefined) ?? current["starts_at"],
-        ends_at: (params?.[1] as Date | undefined) ?? current["ends_at"],
-        production: (params?.[2] as number | undefined) ?? current["production"],
-        hall: (params?.[3] as number | undefined) ?? current["hall"],
-        doors_at: (params?.[4] as Date | undefined) ?? current["doors_at"],
-        vendor_id: (params?.[5] as number | undefined) ?? current["vendor_id"],
-        info: params?.[6] ?? current["info"],
-        updated_at: params?.[7] ? new Date(params?.[7] as string) : new Date(),
-        updated_by: params?.[8],
+        old_id: (params?.[0] as number | undefined) ?? current["old_id"],
+        starts_at: (params?.[1] as Date | undefined) ?? current["starts_at"],
+        ends_at: (params?.[2] as Date | undefined) ?? current["ends_at"],
+        production: (params?.[3] as number | undefined) ?? current["production"],
+        hall: (params?.[4] as number | undefined) ?? current["hall"],
+        doors_at: (params?.[5] as Date | undefined) ?? current["doors_at"],
+        vendor_id: (params?.[6] as number | undefined) ?? current["vendor_id"],
+        info: params?.[7] ?? current["info"],
+        updated_at: params?.[8] ? new Date(params?.[8] as string) : new Date(),
+        updated_by: params?.[9],
       };
 
       // eslint-disable-next-line security/detect-object-injection
@@ -89,6 +91,7 @@ beforeEach(() => {
 describe("Event Replace Routes", () => {
   describe("error handling", () => {
     const replacement = {
+      old_id: 112,
       starts_at: new Date("2026-03-01T18:00:00.000Z"),
       ends_at: new Date("2026-03-01T21:00:00.000Z"),
       production: 19,
@@ -165,6 +168,7 @@ describe("Event Replace Routes", () => {
 
   describe("replacing events", () => {
     const replacement = {
+      old_id: 112,
       starts_at: new Date("2026-03-01T18:00:00.000Z"),
       ends_at: new Date("2026-03-01T21:00:00.000Z"),
       production: 19,
@@ -187,6 +191,7 @@ describe("Event Replace Routes", () => {
       expect(replaceResponse.json()).toEqual({
         ...replacement,
         id: 1,
+        old_id: replacement.old_id,
         price: [],
         starts_at: replacement.starts_at.toISOString(),
         ends_at: replacement.ends_at.toISOString(),
@@ -213,6 +218,7 @@ describe("Event Replace Routes", () => {
       
       // Check first event (the replaced one) has updated data and metadata
       expect(events[0]!.id).toBe(1);
+      expect(events[0]!.old_id).toBe(replacement.old_id);
       expect(events[0]!.starts_at).toBe(replacement.starts_at.toISOString());
       expect(events[0]!.ends_at).toBe(replacement.ends_at.toISOString());
       expect(events[0]!.doors_at).toBe(replacement.doors_at.toISOString());

--- a/backend/test/routes/hall/create.test.ts
+++ b/backend/test/routes/hall/create.test.ts
@@ -7,7 +7,7 @@ import { HttpSuccess, HttpClientError } from "@/routes/helpers.js";
 let server: FastifyInstance;
 let sessionCookie: string;
 
-const mockHall: Hall = { id: 1, name: { nl: "Grote Zaal" }, address: "Sint-Pietersnieuwstraat 23", vendor_id: 42 };
+const mockHall: Hall = { id: 1, old_id: 111, name: { nl: "Grote Zaal" }, address: "Sint-Pietersnieuwstraat 23", vendor_id: 42 };
 
 beforeAll(async () => {
   server = await buildServer();
@@ -31,6 +31,7 @@ describe("Create on hall route", () => {
       url: "/api/v1/hall",
       cookies: { session: sessionCookie },
       payload: {
+        old_id: 111,
         name: { nl: "Grote Zaal" },
         address: "Sint-Pietersnieuwstraat 23",
         vendor_id: 42,
@@ -49,6 +50,7 @@ describe("Create on hall route", () => {
       url: "/api/v1/hall",
       cookies: { session: sessionCookie },
       payload: {
+        old_id: 111,
         name: { nl: "Grote Zaal" },
         address: "Sint-Pietersnieuwstraat 23",
         vendor_id: 42,
@@ -74,6 +76,7 @@ describe("Create on hall route", () => {
       method: "POST",
       url: "/api/v1/hall",
       payload: {
+        old_id: 111,
         name: { nl: "Grote Zaal" },
         address: "Sint-Pietersnieuwstraat 23",
         vendor_id: 42,

--- a/backend/test/routes/hall/delete.test.ts
+++ b/backend/test/routes/hall/delete.test.ts
@@ -7,7 +7,7 @@ import { HttpSuccess, HttpClientError } from "@/routes/helpers.js";
 let server: FastifyInstance;
 let sessionCookie: string;
 
-const mockHall: Hall = { id: 1, name: { nl: "Grote Zaal" }, address: "Sint-Pietersnieuwstraat 23", vendor_id: 42 };
+const mockHall: Hall = { id: 1, old_id: 111, name: { nl: "Grote Zaal" }, address: "Sint-Pietersnieuwstraat 23", vendor_id: 42 };
 
 beforeAll(async () => {
   server = await buildServer();

--- a/backend/test/routes/hall/edit.test.ts
+++ b/backend/test/routes/hall/edit.test.ts
@@ -9,6 +9,7 @@ let sessionCookie: string;
 
 const originalHall: Hall = {
   id: 1,
+  old_id: 111,
   name: { nl: "Grote Zaal" },
   address: "Sint-Pietersnieuwstraat 23",
   vendor_id: 42,
@@ -23,6 +24,11 @@ const updatedHallA: Hall = {
 const updatedHallB: Hall = {
   ...originalHall,
   vendor_id: 99,
+};
+
+const updatedHallC: Hall = {
+  ...originalHall,
+  old_id: 999,
 };
 
 beforeAll(async () => {
@@ -145,5 +151,29 @@ describe("Edit on hall route", () => {
     });
 
     expect(response.statusCode).toBe(HttpClientError.BadRequest);
+  });
+
+  test("PATCH /api/v1/hall/:id — updates old_id", async () => {
+    server.pg.query = vi.fn().mockImplementation((query: string) => {
+      const upper = query.trim().toUpperCase();
+
+      if (upper.startsWith("UPDATE")) {
+        return Promise.resolve({ rows: [updatedHallC], rowCount: 1 });
+      }
+
+      throw new Error(`Unexpected query in edit tests: ${query}`);
+    });
+
+    const response = await server.inject({
+      method: "PATCH",
+      url: `/api/v1/hall/${originalHall["id"]}`,
+      cookies: { session: sessionCookie },
+      payload: {
+        old_id: 999,
+      },
+    });
+
+    expect(response.statusCode).toBe(HttpSuccess.OK);
+    expect(HallSchema.parse(response.json())).toEqual(updatedHallC);
   });
 });

--- a/backend/test/routes/hall/fetch.test.ts
+++ b/backend/test/routes/hall/fetch.test.ts
@@ -8,8 +8,8 @@ let server: FastifyInstance;
 let sessionCookie: string;
 
 const mockHalls: Array<Hall> = [
-  { id: 1, name: { nl: "Grote Zaal" }, address: "Sint-Pietersnieuwstraat 23", vendor_id: 42 },
-  { id: 2, name: { nl: "Kleine Zaal" }, address: "Sint-Pietersnieuwstraat 23", vendor_id: 43 },
+  { id: 1, old_id: 111, name: { nl: "Grote Zaal" },  address: "Sint-Pietersnieuwstraat 23", vendor_id: 42 },
+  { id: 2, old_id: 222, name: { nl: "Kleine Zaal" }, address: "Sint-Pietersnieuwstraat 23", vendor_id: 43 },
 ];
 
 const mockTime = new Date();

--- a/backend/test/routes/hall/replace.test.ts
+++ b/backend/test/routes/hall/replace.test.ts
@@ -9,6 +9,7 @@ let sessionCookie: string;
 
 const replacedHall: Hall = {
   id: 1,
+  old_id: 111,
   name: { nl: "Nieuwe Grote Zaal" },
   address: "Nieuw Adres 1",
   vendor_id: 99,
@@ -44,6 +45,7 @@ describe("Replace on hall route", () => {
       url: `/api/v1/hall/${replacedHall["id"]}`,
       cookies: { session: sessionCookie },
       payload: {
+        old_id: replacedHall["old_id"],
         name: replacedHall["name"],
         address: replacedHall["address"],
         vendor_id: replacedHall["vendor_id"],
@@ -62,6 +64,7 @@ describe("Replace on hall route", () => {
       url: `/api/v1/hall/${replacedHall["id"]}`,
       cookies: { session: sessionCookie },
       payload: {
+        old_id: replacedHall["old_id"],
         name: replacedHall["name"],
         address: replacedHall["address"],
         vendor_id: replacedHall["vendor_id"],
@@ -89,6 +92,7 @@ describe("Replace on hall route", () => {
       method: "PUT",
       url: `/api/v1/hall/${replacedHall["id"]}`,
       payload: {
+        old_id: replacedHall["old_id"],
         name: replacedHall["name"],
         address: replacedHall["address"],
         vendor_id: replacedHall["vendor_id"],

--- a/backend/test/routes/production/bulk-edit.test.ts
+++ b/backend/test/routes/production/bulk-edit.test.ts
@@ -11,6 +11,8 @@ const baseProduction1: Production = {
   id: 1,
   vendor_id: 10,
   box_office_id: 20,
+  old_id: 1111,
+  finalized: true,
   supertitle: null,
   title: { nl: "Titel 1" },
   artist: { nl: "Artiest 1" },

--- a/backend/test/routes/production/create.test.ts
+++ b/backend/test/routes/production/create.test.ts
@@ -10,6 +10,8 @@ const createdProduction: Production = {
   id: 1,
   vendor_id: 10,
   box_office_id: 20,
+  old_id: 1111,
+  finalized: true,
   supertitle: null,
   title: { nl: "Titel" },
   artist: { nl: "Artiest" },

--- a/backend/test/routes/production/delete.test.ts
+++ b/backend/test/routes/production/delete.test.ts
@@ -10,6 +10,8 @@ const mockProduction: Production = {
   id: 1,
   vendor_id: 10,
   box_office_id: 20,
+  old_id: 1111,
+  finalized: true,
   supertitle: null,
   title: { nl: "Titel" },
   artist: { nl: "Artiest" },

--- a/backend/test/routes/production/edit.test.ts
+++ b/backend/test/routes/production/edit.test.ts
@@ -11,6 +11,8 @@ const originalProduction: Production = {
   id: 1,
   vendor_id: 10,
   box_office_id: 20,
+  old_id: 1111,
+  finalized: true,
   supertitle: null,
   title: { nl: "Oude titel" },
   artist: { nl: "Oude artiest" },

--- a/backend/test/routes/production/fetch.test.ts
+++ b/backend/test/routes/production/fetch.test.ts
@@ -11,6 +11,8 @@ const baseProduction: Production = {
   id: 1,
   vendor_id: 10,
   box_office_id: 20,
+  old_id: 1111,
+  finalized: true,
   supertitle: null,
   title: { nl: "Titel" },
   artist: { nl: "Artiest" },

--- a/backend/test/routes/production/replace.test.ts
+++ b/backend/test/routes/production/replace.test.ts
@@ -10,6 +10,8 @@ const replacedProduction: Production = {
   id: 1,
   vendor_id: 111,
   box_office_id: 222,
+  old_id: 1111,
+  finalized: true,
   supertitle: { nl: "Nieuwe supertitel" },
   title: { nl: "Nieuwe titel" },
   artist: { nl: "Nieuwe artiest" },
@@ -62,6 +64,8 @@ describe("Replace on production route", () => {
       payload: {
         vendor_id: replacedProduction["vendor_id"],
         box_office_id: replacedProduction["box_office_id"],
+        old_id: replacedProduction["old_id"],
+        finalized: replacedProduction["finalized"],
         supertitle: replacedProduction["supertitle"],
         title: replacedProduction["title"],
         artist: replacedProduction["artist"],
@@ -106,6 +110,8 @@ describe("Replace on production route", () => {
       payload: {
         vendor_id: replacedProduction["vendor_id"],
         box_office_id: replacedProduction["box_office_id"],
+        old_id: replacedProduction["old_id"],
+        finalized: replacedProduction["finalized"],
         supertitle: replacedProduction["supertitle"],
         title: replacedProduction["title"],
         artist: replacedProduction["artist"],

--- a/backend/test/routes/tag/create.test.ts
+++ b/backend/test/routes/tag/create.test.ts
@@ -8,6 +8,7 @@ let sessionCookie: string;
 
 const mockTag: Tag = {
   id: 5,
+  old_id: 111,
   name: { en: "Music", nl: "Muziek" },
   type: 1,
   productions: [],
@@ -42,6 +43,7 @@ describe("Create tag", () => {
       url: "/api/v1/tags",
       cookies: { session: sessionCookie },
       payload: {
+        old_id: mockTag.old_id,
         name: mockTag.name,
         type: mockTag.type,
         public: mockTag.public,

--- a/backend/test/routes/tag/delete.test.ts
+++ b/backend/test/routes/tag/delete.test.ts
@@ -9,6 +9,7 @@ let sessionCookie: string;
 
 const mockTag: Tag = {
   id: 5,
+  old_id: 111,
   name: { en: "Music", nl: "Muziek" },
   type: 1,
   productions: [],

--- a/backend/test/routes/tag/edit.test.ts
+++ b/backend/test/routes/tag/edit.test.ts
@@ -8,6 +8,7 @@ let sessionCookie: string;
 
 const mockTag: Tag = {
   id: 5,
+  old_id: 111,
   name: { en: "Music", nl: "Muziek" },
   type: 1,
   productions: [],
@@ -36,6 +37,18 @@ afterAll(async () => {
 });
 
 describe("Edit tag", () => {
+  test("PATCH /api/v1/tags/:id old_id only", async () => {
+    const response = await server.inject({
+      method: "PATCH",
+      url: `/api/v1/tags/${mockTag.id}`,
+      cookies: { session: sessionCookie },
+      payload: { old_id: mockTag.old_id },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(TagSchema.parse(response.json())).toEqual(mockTag);
+  });
+
   test("PATCH /api/v1/tags/:id name only", async () => {
     const response = await server.inject({
       method: "PATCH",
@@ -75,7 +88,7 @@ describe("Edit tag", () => {
       method: "PATCH",
       url: `/api/v1/tags/${mockTag.id}`,
       cookies: { session: sessionCookie },
-      payload: { name: mockTag.name, type: mockTag.type, public: mockTag.public },
+      payload: {  old_id: mockTag.old_id, name: mockTag.name, type: mockTag.type, public: mockTag.public },
     });
 
     expect(response.statusCode).toBe(200);

--- a/backend/test/routes/tag/fetch.test.ts
+++ b/backend/test/routes/tag/fetch.test.ts
@@ -8,6 +8,7 @@ let sessionCookie: string;
 
 const tag1: Tag = {
   id: 5,
+  old_id: 111,
   name: { en: "Music", nl: "Muziek" },
   type: 1,
   productions: [1],
@@ -16,6 +17,7 @@ const tag1: Tag = {
 
 const tag2: Tag = {
   id: 6,
+  old_id: 112,
   name: { en: "Family", nl: "Familie" },
   type: 1,
   productions: [1, 2],
@@ -24,6 +26,7 @@ const tag2: Tag = {
 
 const privateTag: Tag = {
   id: 10,
+  old_id: 113,
   name: { en: "Private", nl: "Privé" },
   type: 1,
   productions: [1], // important for production tests

--- a/backend/test/routes/tag/replace.test.ts
+++ b/backend/test/routes/tag/replace.test.ts
@@ -8,6 +8,7 @@ let sessionCookie: string;
 
 const mockTag: Tag = {
   id: 5,
+  old_id: 111,
   name: { en: "Music", nl: "Muziek" },
   type: 1,
   productions: [],
@@ -42,6 +43,7 @@ describe("Replace tag", () => {
       url: `/api/v1/tags/${mockTag.id}`,
       cookies: { session: sessionCookie },
       payload: {
+        old_id: mockTag.old_id,
         name: mockTag.name,
         type: mockTag.type,
         public: mockTag.public,

--- a/shared/src/types/event.ts
+++ b/shared/src/types/event.ts
@@ -7,6 +7,7 @@ import { foreignKey, languageMap, primaryKey, ForeignKey } from "./helpers.js";
 
 export const EventSchemaWithoutPrice = createSchema({
   id: primaryKey(),
+  old_id: z.int().nonnegative().nullable(),
   starts_at: z.date(),
   ends_at: z.date(),
   doors_at: z.date(),

--- a/shared/src/types/hall.ts
+++ b/shared/src/types/hall.ts
@@ -5,6 +5,7 @@ import { languageMap, primaryKey } from "./helpers.js";
 
 export const HallSchema = createSchema({
   id: primaryKey(),
+  old_id: z.int().nonnegative().nullable(),
   address: z.string(),
   vendor_id: z.int().nonnegative(),
   name: languageMap,

--- a/shared/src/types/production.ts
+++ b/shared/src/types/production.ts
@@ -8,6 +8,8 @@ export const ProductionSchema = createSchema({
   id: primaryKey(),
   vendor_id: z.int().nonnegative(),
   box_office_id: z.int().nonnegative(),
+  old_id: z.int().nonnegative().nullable(),
+  finalized: z.boolean(),
   supertitle: languageMap.nullable(),
   title: languageMap,
   artist: languageMap,

--- a/shared/src/types/tag.ts
+++ b/shared/src/types/tag.ts
@@ -20,6 +20,7 @@ export type TagTypeWithMeta = z.infer<
 
 export const TagSchema = createSchema({
   id: primaryKey(),
+  old_id: z.int().nonnegative().nullable(),
   name: languageMap,
   get type(): ForeignKey<typeof TagTypeSchema> {
     return foreignKey(() => TagTypeSchema);


### PR DESCRIPTION
**Issue(s)**

#214 #213 #215 #216 

____

**Description**

adds fields to the following endpoints and schemas needed for our (future) scraping tool.

production, hall, tag, event, event_price

field "old_id": represents id of object in endpoint of client
field "finalized": field for a production to indicate it's been fully inserted (meaning all events have passed) from clients api. 

____

**Sources**

n/a
