### PR TITLE
make tag route use tag instead of tags

### DIFF
--- a/DOCS/ARCHITECTURE.md
+++ b/DOCS/ARCHITECTURE.md
@@ -150,8 +150,8 @@ Routes are organized by domain. Each domain has its own directory under `routes/
 | **Production** | `/api/v1/production` | Fetch all/one | CRUD, bulk edit |
 | **Event** | `/api/v1/event` | Fetch all/one | CRUD, bulk edit |
 | **Auth** | `/api/v1/auth` | Login, logout | Admin CRUD |
-| **Tags** | `/api/v1/tags` | Fetch public tags | Full CRUD, fetch all |
-| **Tag Types** | `/api/v1/tags/type` | Fetch all/one | CRUD |
+| **Tags** | `/api/v1/tag` | Fetch public tags | Full CRUD, fetch all |
+| **Tag Types** | `/api/v1/tag/type` | Fetch all/one | CRUD |
 | **Halls** | `/api/v1/hall` | Fetch all/one | CRUD |
 
 Every domain follows a consistent REST pattern: public GET endpoints for reading, and authenticated POST/PUT/PATCH/DELETE for writing. Most entities also expose a `/meta` variant that includes audit fields.

--- a/backend/src/routes/tag/tags.ts
+++ b/backend/src/routes/tag/tags.ts
@@ -17,30 +17,30 @@ import {
  * Registers tag routes on the Fastify instance.
  *
  * @remarks
- * - `GET /api/v1/tags/all` — fetch tags (optionally filtered by production); includes non-public tags. 🔒
- * - `GET /api/v1/tags` — fetch public tags only (same query params as `/all`).
- * - `GET /api/v1/tags/:id/all` — fetch a single tag by ID (non-public allowed). 🔒
- * - `GET /api/v1/tags/:id` — fetch a single public tag by ID.
- * - `GET /api/v1/tags/:id/meta` — fetch a single tag with metadata by ID. 🔒
- * - `POST /api/v1/tags` — create a tag. 🔒
- * - `PUT /api/v1/tags/:id` — replace a tag. 🔒
- * - `PATCH /api/v1/tags/:id` — partially update a tag. 🔒
- * - `DELETE /api/v1/tags/:id` — delete a tag by ID. 🔒
+ * - `GET /api/v1/tag/all` — fetch tags (optionally filtered by production); includes non-public tags. 🔒
+ * - `GET /api/v1/tag` — fetch public tags only (same query parameters as `GET /api/v1/tag/all`).
+ * - `GET /api/v1/tag/:id/all` — fetch a single tag by ID (non-public allowed). 🔒
+ * - `GET /api/v1/tag/:id` — fetch a single public tag by ID.
+ * - `GET /api/v1/tag/:id/meta` — fetch a single tag with metadata by ID. 🔒
+ * - `POST /api/v1/tag` — create a tag. 🔒
+ * - `PUT /api/v1/tag/:id` — replace a tag. 🔒
+ * - `PATCH /api/v1/tag/:id` — partially update a tag. 🔒
+ * - `DELETE /api/v1/tag/:id` — delete a tag by ID. 🔒
  *
  * @param server - The Fastify instance to register routes on.
  */
 export default function tagRoutes(server: FastifyInstance) {
   const protect = { preHandler: [server.authorize] };
 
-  server.get("/api/v1/tags/all", protect, replyHandler(server, fetchTags));
-  server.get("/api/v1/tags", replyHandler(server, fetchTagsVisible));
-  server.get("/api/v1/tags/:id/all", protect, replyHandler(server, fetchTag));
-  server.get("/api/v1/tags/:id", replyHandler(server, fetchTagVisible));
-  server.get("/api/v1/tags/:id/meta", protect, replyHandler(server, fetchTagWithMeta));
-  server.post("/api/v1/tags", protect, replyHandler(server, createTag));
+  server.get("/api/v1/tag/all", protect, replyHandler(server, fetchTags));
+  server.get("/api/v1/tag", replyHandler(server, fetchTagsVisible));
+  server.get("/api/v1/tag/:id/all", protect, replyHandler(server, fetchTag));
+  server.get("/api/v1/tag/:id", replyHandler(server, fetchTagVisible));
+  server.get("/api/v1/tag/:id/meta", protect, replyHandler(server, fetchTagWithMeta));
+  server.post("/api/v1/tag", protect, replyHandler(server, createTag));
 
-  server.put("/api/v1/tags/:id", protect, replyHandler(server, replaceTag));
-  server.patch("/api/v1/tags/:id", protect, replyHandler(server, editTag));
+  server.put("/api/v1/tag/:id", protect, replyHandler(server, replaceTag));
+  server.patch("/api/v1/tag/:id", protect, replyHandler(server, editTag));
   
-  server.delete("/api/v1/tags/:id", protect, replyHandler(server, deleteTag));
+  server.delete("/api/v1/tag/:id", protect, replyHandler(server, deleteTag));
 }

--- a/backend/src/routes/tag_type/tag_types.ts
+++ b/backend/src/routes/tag_type/tag_types.ts
@@ -15,26 +15,26 @@ import {
  * Registers tag type routes on the Fastify instance.
  *
  * @remarks
- * - `GET /api/v1/tags/type` — fetch all tag types.
- * - `GET /api/v1/tags/type/:id` — fetch a single tag type by ID.
- * - `GET /api/v1/tags/type/:id/meta` — fetch a single tag type with metadata by ID. 🔒
- * - `POST /api/v1/tags/type` — create a tag type. 🔒
- * - `PATCH /api/v1/tags/type/:id` — partially update a tag type. 🔒
- * - `PUT /api/v1/tags/type/:id` — replace a tag type. 🔒
- * - `DELETE /api/v1/tags/type/:id` — delete a tag type by ID. 🔒
+ * - `GET /api/v1/tag/type` — fetch all tag types.
+ * - `GET /api/v1/tag/type/:id` — fetch a single tag type by ID.
+ * - `GET /api/v1/tag/type/:id/meta` — fetch a single tag type with metadata by ID. 🔒
+ * - `POST /api/v1/tag/type` — create a tag type. 🔒
+ * - `PATCH /api/v1/tag/type/:id` — partially update a tag type. 🔒
+ * - `PUT /api/v1/tag/type/:id` — replace a tag type. 🔒
+ * - `DELETE /api/v1/tag/type/:id` — delete a tag type by ID. 🔒
  *
  * @param server - The Fastify instance to register routes on.
  */
 export default function tagTypeRoutes(server: FastifyInstance) {
   const protect = { preHandler: [server.authorize] };
 
-  server.get("/api/v1/tags/type", replyHandler(server, fetchTagTypes));
-  server.get("/api/v1/tags/type/:id", replyHandler(server, fetchTagType));
-  server.get("/api/v1/tags/type/:id/meta", protect, replyHandler(server, fetchTagTypeWithMeta));
-  server.post("/api/v1/tags/type", protect, replyHandler(server, createTagType));
+  server.get("/api/v1/tag/type", replyHandler(server, fetchTagTypes));
+  server.get("/api/v1/tag/type/:id", replyHandler(server, fetchTagType));
+  server.get("/api/v1/tag/type/:id/meta", protect, replyHandler(server, fetchTagTypeWithMeta));
+  server.post("/api/v1/tag/type", protect, replyHandler(server, createTagType));
 
-  server.patch("/api/v1/tags/type/:id", protect, replyHandler(server, editTagType));
-  server.put("/api/v1/tags/type/:id", protect, replyHandler(server, replaceTagType));
+  server.patch("/api/v1/tag/type/:id", protect, replyHandler(server, editTagType));
+  server.put("/api/v1/tag/type/:id", protect, replyHandler(server, replaceTagType));
 
-  server.delete("/api/v1/tags/type/:id", protect, replyHandler(server, deleteTagType));
+  server.delete("/api/v1/tag/type/:id", protect, replyHandler(server, deleteTagType));
 }

--- a/backend/test/routes/tag/create.test.ts
+++ b/backend/test/routes/tag/create.test.ts
@@ -37,7 +37,7 @@ beforeEach(() => {
 });
 
 describe("Create tag", () => {
-  test("POST /api/v1/tags", async () => {
+  test("POST /api/v1/tag", async () => {
     server.pg.query = vi.fn().mockResolvedValue({
       rows: [mockTag],
       rowCount: 1,
@@ -45,7 +45,7 @@ describe("Create tag", () => {
 
     const response = await server.inject({
       method: "POST",
-      url: "/api/v1/tags",
+      url: "/api/v1/tag",
       cookies: { session: sessionCookie },
       payload: {
         old_id: mockTag.old_id,
@@ -59,7 +59,7 @@ describe("Create tag", () => {
     expect(TagSchema.parse(response.json())).toEqual(mockTag);
   });
 
-  test("POST /api/v1/tags — returns 404 when insert returns no row", async () => {
+  test("POST /api/v1/tag — returns 404 when insert returns no row", async () => {
     server.pg.query = vi.fn().mockResolvedValue({
       rows: [],
       rowCount: 0,
@@ -67,7 +67,7 @@ describe("Create tag", () => {
 
     const response = await server.inject({
       method: "POST",
-      url: "/api/v1/tags",
+      url: "/api/v1/tag",
       cookies: { session: sessionCookie },
       payload: {
         old_id: mockTag.old_id,
@@ -80,11 +80,11 @@ describe("Create tag", () => {
     expect(response.statusCode).toBe(HttpClientError.NotFound);
   });
 
-  test("POST /api/v1/tags invalid body", async () => {
+  test("POST /api/v1/tag invalid body", async () => {
     const response = await server.inject({
       method: "POST",
       cookies: { session: sessionCookie },
-      url: "/api/v1/tags",
+      url: "/api/v1/tag",
       payload: {},
     });
 

--- a/backend/test/routes/tag/delete.test.ts
+++ b/backend/test/routes/tag/delete.test.ts
@@ -27,7 +27,7 @@ afterAll(async () => {
 });
 
 describe("Delete tag", () => {
-  test("DELETE /api/v1/tags/:id", async () => {
+  test("DELETE /api/v1/tag/:id", async () => {
     server.pg.query = vi.fn().mockResolvedValue({
       rows: [mockTag],
       rowCount: 1,
@@ -36,7 +36,7 @@ describe("Delete tag", () => {
     const response = await server.inject({
       method: "DELETE",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -52,7 +52,7 @@ describe("Delete tag", () => {
     const response = await server.inject({
       method: "DELETE",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
     });
 
     expect(response.statusCode).toBe(404);

--- a/backend/test/routes/tag/edit.test.ts
+++ b/backend/test/routes/tag/edit.test.ts
@@ -41,10 +41,10 @@ beforeEach(() => {
 });
 
 describe("Edit tag", () => {
-  test("PATCH /api/v1/tags/:id old_id only", async () => {
+  test("PATCH /api/v1/tag/:id old_id only", async () => {
     const response = await server.inject({
       method: "PATCH",
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
       cookies: { session: sessionCookie },
       payload: { old_id: mockTag.old_id },
     });
@@ -53,10 +53,10 @@ describe("Edit tag", () => {
     expect(TagSchema.parse(response.json())).toEqual(mockTag);
   });
 
-  test("PATCH /api/v1/tags/:id name only", async () => {
+  test("PATCH /api/v1/tag/:id name only", async () => {
     const response = await server.inject({
       method: "PATCH",
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
       cookies: { session: sessionCookie },
       payload: { name: mockTag.name },
     });
@@ -65,10 +65,10 @@ describe("Edit tag", () => {
     expect(TagSchema.parse(response.json())).toEqual(mockTag);
   });
 
-  test("PATCH /api/v1/tags/:id tag_type only", async () => {
+  test("PATCH /api/v1/tag/:id tag_type only", async () => {
     const response = await server.inject({
       method: "PATCH",
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
       cookies: { session: sessionCookie },
       payload: { tag_type: mockTag.tag_type },
     });
@@ -76,10 +76,10 @@ describe("Edit tag", () => {
     expect(response.statusCode).toBe(HttpSuccess.OK);
   });
 
-  test("PATCH /api/v1/tags/:id public only", async () => {
+  test("PATCH /api/v1/tag/:id public only", async () => {
     const response = await server.inject({
       method: "PATCH",
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
       cookies: { session: sessionCookie },
       payload: { public: mockTag.public },
     });
@@ -87,10 +87,10 @@ describe("Edit tag", () => {
     expect(response.statusCode).toBe(HttpSuccess.OK);
   });
 
-  test("PATCH /api/v1/tags/:id all fields", async () => {
+  test("PATCH /api/v1/tag/:id all fields", async () => {
     const response = await server.inject({
       method: "PATCH",
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
       cookies: { session: sessionCookie },
       payload: {  old_id: mockTag.old_id, name: mockTag.name, tag_type: mockTag.tag_type, public: mockTag.public },
     });
@@ -98,7 +98,7 @@ describe("Edit tag", () => {
     expect(response.statusCode).toBe(HttpSuccess.OK);
   });
 
-  test("PATCH /api/v1/tags/:id — returns 404 when tag not found", async () => {
+  test("PATCH /api/v1/tag/:id — returns 404 when tag not found", async () => {
     server.pg.query = vi.fn().mockResolvedValue({
       rows: [],
       rowCount: 0,
@@ -106,7 +106,7 @@ describe("Edit tag", () => {
 
     const response = await server.inject({
       method: "PATCH",
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
       cookies: { session: sessionCookie },
       payload: { name: mockTag.name },
     });

--- a/backend/test/routes/tag/fetch.test.ts
+++ b/backend/test/routes/tag/fetch.test.ts
@@ -133,32 +133,32 @@ afterAll(async () => {
 });
 
 describe("Fetch tag on id", () => {
-  test("GET /api/v1/tags/:id/all", async () => {
+  test("GET /api/v1/tag/:id/all", async () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/${tag1.id}/all`,
+      url: `/api/v1/tag/${tag1.id}/all`,
     });
 
     expect(response.statusCode).toBe(200);
     expect(TagSchema.parse(response.json())).toEqual(tag1);
   });
 
-  test("GET /api/v1/tags/:id/all returns 404 when tag not found", async () => {
+  test("GET /api/v1/tag/:id/all returns 404 when tag not found", async () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/999/all`,
+      url: `/api/v1/tag/999/all`,
     });
 
     expect(response.statusCode).toBe(404);
   });
 
-  test("GET /api/v1/tags/:id returns 404", async () => {
+  test("GET /api/v1/tag/:id returns 404", async () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/999`,
+      url: `/api/v1/tag/999`,
     });
 
     expect(response.statusCode).toBe(404);
@@ -167,20 +167,20 @@ describe("Fetch tag on id", () => {
 
 describe("Fetch visible tag on id", () => {
 
-  test("GET /api/v1/tags/:id returns visible tag", async () => {
+  test("GET /api/v1/tag/:id returns visible tag", async () => {
     const response = await server.inject({
       method: "GET",
-      url: `/api/v1/tags/${tag1.id}`,
+      url: `/api/v1/tag/${tag1.id}`,
     });
 
     expect(response.statusCode).toBe(200);
     expect(TagSchema.parse(response.json())).toEqual(tag1);
   });
 
-  test("GET /api/v1/tags/:id returns 404 when tag is not public", async () => {
+  test("GET /api/v1/tag/:id returns 404 when tag is not public", async () => {
     const response = await server.inject({
       method: "GET",
-      url: `/api/v1/tags/${privateTag.id}`,
+      url: `/api/v1/tag/${privateTag.id}`,
     });
 
     expect(response.statusCode).toBe(404);
@@ -189,7 +189,7 @@ describe("Fetch visible tag on id", () => {
 });
 
 describe("Fetch tags", () => {
-  test("GET /api/v1/tags/all?includeProductions=true returns [] when no tags exist (no production_tag query)", async () => {
+  test("GET /api/v1/tag/all?includeProductions=true returns [] when no tags exist (no production_tag query)", async () => {
     const prev = server.pg.query;
     server.pg.query = vi.fn().mockImplementation((query: string) => {
       if (query.includes("tag = ANY")) {
@@ -201,7 +201,7 @@ describe("Fetch tags", () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/all?includeProductions=true`,
+      url: `/api/v1/tag/all?includeProductions=true`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -209,22 +209,22 @@ describe("Fetch tags", () => {
     server.pg.query = prev;
   });
 
-  test("GET /api/v1/tags/all (productions omitted by default)", async () => {
+  test("GET /api/v1/tag/all (productions omitted by default)", async () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/all`,
+      url: `/api/v1/tag/all`,
     });
 
     expect(response.statusCode).toBe(200);
     expect(TagSchema.array().parse(response.json())).toEqual(mockTagsListDefault);
   });
 
-  test("GET /api/v1/tags/all?includeProductions=true", async () => {
+  test("GET /api/v1/tag/all?includeProductions=true", async () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/all?includeProductions=true`,
+      url: `/api/v1/tag/all?includeProductions=true`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -234,11 +234,11 @@ describe("Fetch tags", () => {
 
 describe("Fetch visible tags", () => {
 
-  test("GET /api/v1/tags returns only public tags (productions omitted by default)", async () => {
+  test("GET /api/v1/tag returns only public tags (productions omitted by default)", async () => {
 
     const response = await server.inject({
       method: "GET",
-      url: `/api/v1/tags`,
+      url: `/api/v1/tag`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -248,10 +248,10 @@ describe("Fetch visible tags", () => {
     expect(result).toEqual(mockTagsListDefault.filter((t) => t.public));
   });
 
-  test("GET /api/v1/tags?includeProductions=true", async () => {
+  test("GET /api/v1/tag?includeProductions=true", async () => {
     const response = await server.inject({
       method: "GET",
-      url: `/api/v1/tags?includeProductions=true`,
+      url: `/api/v1/tag?includeProductions=true`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -264,11 +264,11 @@ describe("Fetch visible tags", () => {
 
 describe("Fetch tags for production", () => {
 
-  test("GET /api/v1/tags/all?production={id} (productions omitted by default)", async () => {
+  test("GET /api/v1/tag/all?production={id} (productions omitted by default)", async () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/all?production=1`,
+      url: `/api/v1/tag/all?production=1`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -285,11 +285,11 @@ describe("Fetch tags for production", () => {
     );
   });
 
-  test("GET /api/v1/tags/all?production={id}&includeProductions=true", async () => {
+  test("GET /api/v1/tag/all?production={id}&includeProductions=true", async () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/all?production=1&includeProductions=true`,
+      url: `/api/v1/tag/all?production=1&includeProductions=true`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -302,10 +302,10 @@ describe("Fetch tags for production", () => {
 
 describe("Fetch visible tags for production", () => {
 
-  test("GET /api/v1/tags?production={id} (productions omitted by default)", async () => {
+  test("GET /api/v1/tag?production={id} (productions omitted by default)", async () => {
     const response = await server.inject({
       method: "GET",
-      url: `/api/v1/tags?production=1`,
+      url: `/api/v1/tag?production=1`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -322,10 +322,10 @@ describe("Fetch visible tags for production", () => {
     );
   });
 
-  test("GET /api/v1/tags?production={id}&includeProductions=true", async () => {
+  test("GET /api/v1/tag?production={id}&includeProductions=true", async () => {
     const response = await server.inject({
       method: "GET",
-      url: `/api/v1/tags?production=1&includeProductions=true`,
+      url: `/api/v1/tag?production=1&includeProductions=true`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -338,19 +338,19 @@ describe("Fetch visible tags for production", () => {
 
 describe("Fetch tag with metadata", () => {
 
-  test("GET /api/v1/tags/:id/meta", async () => {
+  test("GET /api/v1/tag/:id/meta", async () => {
 
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/${tag1WithMeta.id}/meta`,
+      url: `/api/v1/tag/${tag1WithMeta.id}/meta`,
     });
 
     expect(response.statusCode).toBe(200);
     expect(TagSchema.withMeta().parse(response.json())).toEqual(tag1WithMeta);
   });
 
-  test("GET /api/v1/tags/:id/meta includes empty productions when tag has no production_tag rows", async () => {
+  test("GET /api/v1/tag/:id/meta includes empty productions when tag has no production_tag rows", async () => {
     const prev = server.pg.query;
     server.pg.query = vi.fn().mockImplementation((query: string, _params?: unknown[]) => {
       if (query.includes("tag = ANY")) {
@@ -376,7 +376,7 @@ describe("Fetch tag with metadata", () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/${tag1.id}/meta`,
+      url: `/api/v1/tag/${tag1.id}/meta`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -392,7 +392,7 @@ describe("Fetch tag with metadata", () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/999/meta`,
+      url: `/api/v1/tag/999/meta`,
     });
 
     expect(response.statusCode).toBe(404);

--- a/backend/test/routes/tag/replace.test.ts
+++ b/backend/test/routes/tag/replace.test.ts
@@ -37,7 +37,7 @@ beforeEach(() => {
 });
 
 describe("Replace tag", () => {
-  test("PUT /api/v1/tags/:id", async () => {
+  test("PUT /api/v1/tag/:id", async () => {
     server.pg.query = vi.fn().mockResolvedValue({
       rows: [mockTag],
       rowCount: 1,
@@ -45,7 +45,7 @@ describe("Replace tag", () => {
 
     const response = await server.inject({
       method: "PUT",
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
       cookies: { session: sessionCookie },
       payload: {
         old_id: mockTag.old_id,
@@ -59,7 +59,7 @@ describe("Replace tag", () => {
     expect(TagSchema.parse(response.json())).toEqual(mockTag);
   });
 
-  test("PUT /api/v1/tags/:id — returns 404 when tag not found", async () => {
+  test("PUT /api/v1/tag/:id — returns 404 when tag not found", async () => {
     server.pg.query = vi.fn().mockResolvedValue({
       rows: [],
       rowCount: 0,
@@ -67,7 +67,7 @@ describe("Replace tag", () => {
 
     const response = await server.inject({
       method: "PUT",
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
       cookies: { session: sessionCookie },
       payload: {
         old_id: mockTag.old_id,
@@ -80,10 +80,10 @@ describe("Replace tag", () => {
     expect(response.statusCode).toBe(HttpClientError.NotFound);
   });
 
-  test("PUT /api/v1/tags/:id — rejects invalid body", async () => {
+  test("PUT /api/v1/tag/:id — rejects invalid body", async () => {
     const response = await server.inject({
       method: "PUT",
-      url: `/api/v1/tags/${mockTag.id}`,
+      url: `/api/v1/tag/${mockTag.id}`,
       cookies: { session: sessionCookie },
       payload: {
         name: mockTag.name,

--- a/backend/test/routes/tag_type/create.test.ts
+++ b/backend/test/routes/tag_type/create.test.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
 });
 
 describe("Create tag_type", () => {
-  test("POST /api/v1/tags/type", async () => {
+  test("POST /api/v1/tag/type", async () => {
     server.pg.query = vi.fn().mockImplementation((query: string) => {
       if (query.includes("INSERT")) {
         return Promise.resolve({
@@ -52,7 +52,7 @@ describe("Create tag_type", () => {
 
     const response = await server.inject({
       method: "POST",
-      url: "/api/v1/tags/type",
+      url: "/api/v1/tag/type",
       cookies: { session: sessionCookie },
       payload: {
         name: tagType.name,
@@ -63,7 +63,7 @@ describe("Create tag_type", () => {
     expect(TagTypeSchema.parse(response.json())).toEqual(tagType);
   });
 
-  test("POST /api/v1/tags/type — returns 404 when insert returns no row", async () => {
+  test("POST /api/v1/tag/type — returns 404 when insert returns no row", async () => {
     server.pg.query = vi.fn().mockResolvedValue({
       rows: [],
       rowCount: 0,
@@ -71,7 +71,7 @@ describe("Create tag_type", () => {
 
     const response = await server.inject({
       method: "POST",
-      url: "/api/v1/tags/type",
+      url: "/api/v1/tag/type",
       cookies: { session: sessionCookie },
       payload: {
         name: tagType.name,
@@ -84,7 +84,7 @@ describe("Create tag_type", () => {
   test("POST invalid body", async () => {
     const response = await server.inject({
       method: "POST",
-      url: "/api/v1/tags/type",
+      url: "/api/v1/tag/type",
       cookies: { session: sessionCookie },
       payload: {},
     });

--- a/backend/test/routes/tag_type/delete.test.ts
+++ b/backend/test/routes/tag_type/delete.test.ts
@@ -41,12 +41,12 @@ afterAll(async () => {
 
 describe("Delete tag_type", () => {
 
-  test("DELETE /api/v1/tags/type/:id", async () => {
+  test("DELETE /api/v1/tag/type/:id", async () => {
 
     const response = await server.inject({
       method: "DELETE",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/type/${tagType.id}`,
+      url: `/api/v1/tag/type/${tagType.id}`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -58,7 +58,7 @@ describe("Delete tag_type", () => {
     const response = await server.inject({
       method: "DELETE",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/type/999`,
+      url: `/api/v1/tag/type/999`,
     });
 
     expect(response.statusCode).toBe(404);

--- a/backend/test/routes/tag_type/edit.test.ts
+++ b/backend/test/routes/tag_type/edit.test.ts
@@ -57,11 +57,11 @@ afterAll(async () => {
 
 describe("Edit tag_type", () => {
 
-  test("PATCH /api/v1/tags/type/:id", async () => {
+  test("PATCH /api/v1/tag/type/:id", async () => {
 
     const response = await server.inject({
       method: "PATCH",
-      url: `/api/v1/tags/type/${tagType.id}`,
+      url: `/api/v1/tag/type/${tagType.id}`,
       cookies: { session: sessionCookie },
       payload: {
         name: tagType.name,
@@ -76,7 +76,7 @@ describe("Edit tag_type", () => {
 
     const response = await server.inject({
       method: "PATCH",
-      url: `/api/v1/tags/type/999`,
+      url: `/api/v1/tag/type/999`,
       cookies: { session: sessionCookie },
       payload: {
         name: tagType.name,
@@ -88,11 +88,11 @@ describe("Edit tag_type", () => {
 
 });
 
-test("PATCH /api/v1/tags/type/:id without name still updates metadata", async () => {
+test("PATCH /api/v1/tag/type/:id without name still updates metadata", async () => {
 
   const response = await server.inject({
     method: "PATCH",
-    url: `/api/v1/tags/type/${tagType.id}`,
+    url: `/api/v1/tag/type/${tagType.id}`,
     cookies: { session: sessionCookie },
     payload: {}, // no name field
   });

--- a/backend/test/routes/tag_type/fetch.test.ts
+++ b/backend/test/routes/tag_type/fetch.test.ts
@@ -59,11 +59,11 @@ afterAll(async () => {
 
 describe("Fetch tag_type", () => {
 
-  test("GET /api/v1/tags/type/:id", async () => {
+  test("GET /api/v1/tag/type/:id", async () => {
 
     const response = await server.inject({
       method: "GET",
-      url: `/api/v1/tags/type/${tagType.id}`,
+      url: `/api/v1/tag/type/${tagType.id}`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -74,7 +74,7 @@ describe("Fetch tag_type", () => {
 
     const response = await server.inject({
       method: "GET",
-      url: `/api/v1/tags/type/999`,
+      url: `/api/v1/tag/type/999`,
     });
 
     expect(response.statusCode).toBe(404);
@@ -82,11 +82,11 @@ describe("Fetch tag_type", () => {
 
 });
 
-test("GET /api/v1/tags/type", async () => {
+test("GET /api/v1/tag/type", async () => {
 
   const response = await server.inject({
     method: "GET",
-    url: `/api/v1/tags/type`,
+    url: `/api/v1/tag/type`,
   });
 
   expect(response.statusCode).toBe(200);
@@ -95,12 +95,12 @@ test("GET /api/v1/tags/type", async () => {
 
 describe("Fetch tag_type with metadata", () => {
 
-  test("GET /api/v1/tags/type/:id/meta", async () => {
+  test("GET /api/v1/tag/type/:id/meta", async () => {
 
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/type/${tagTypeWithMeta.id}/meta`,
+      url: `/api/v1/tag/type/${tagTypeWithMeta.id}/meta`,
     });
 
     expect(response.statusCode).toBe(200);
@@ -112,7 +112,7 @@ describe("Fetch tag_type with metadata", () => {
     const response = await server.inject({
       method: "GET",
       cookies: { session: sessionCookie },
-      url: `/api/v1/tags/type/999/meta`,
+      url: `/api/v1/tag/type/999/meta`,
     });
 
     expect(response.statusCode).toBe(404);

--- a/backend/test/routes/tag_type/replace.test.ts
+++ b/backend/test/routes/tag_type/replace.test.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
 });
 
 describe("Replace tag_type", () => {
-  test("PUT /api/v1/tags/type/:id", async () => {
+  test("PUT /api/v1/tag/type/:id", async () => {
     server.pg.query = vi.fn().mockImplementation((query: string, params?: unknown[]) => {
       if (query.includes("UPDATE")) {
         const id = Number(params?.[params.length - 1]);
@@ -60,7 +60,7 @@ describe("Replace tag_type", () => {
 
     const response = await server.inject({
       method: "PUT",
-      url: `/api/v1/tags/type/${tagType.id}`,
+      url: `/api/v1/tag/type/${tagType.id}`,
       cookies: { session: sessionCookie },
       payload: {
         name: tagType.name,
@@ -71,7 +71,7 @@ describe("Replace tag_type", () => {
     expect(TagTypeSchema.parse(response.json())).toEqual(tagType);
   });
 
-  test("PUT /api/v1/tags/type/:id — returns 404 when tag_type not found", async () => {
+  test("PUT /api/v1/tag/type/:id — returns 404 when tag_type not found", async () => {
     server.pg.query = vi.fn().mockResolvedValue({
       rows: [],
       rowCount: 0,
@@ -79,7 +79,7 @@ describe("Replace tag_type", () => {
 
     const response = await server.inject({
       method: "PUT",
-      url: `/api/v1/tags/type/${tagType.id}`,
+      url: `/api/v1/tag/type/${tagType.id}`,
       cookies: { session: sessionCookie },
       payload: {
         name: tagType.name,
@@ -89,10 +89,10 @@ describe("Replace tag_type", () => {
     expect(response.statusCode).toBe(HttpClientError.NotFound);
   });
 
-  test("PUT /api/v1/tags/type/:id — rejects invalid body", async () => {
+  test("PUT /api/v1/tag/type/:id — rejects invalid body", async () => {
     const response = await server.inject({
       method: "PUT",
-      url: `/api/v1/tags/type/${tagType.id}`,
+      url: `/api/v1/tag/type/${tagType.id}`,
       cookies: { session: sessionCookie },
       payload: {},
     });

--- a/frontend/src/services/tags.ts
+++ b/frontend/src/services/tags.ts
@@ -95,7 +95,7 @@ export type UpdateTagTypeInput = Partial<CreateTagTypeInput>;
  * const tags = await getTags();
  */
 export async function getTags(): Promise<Tag[]> {
-  return await apiFetch<Tag[]>("/tags");
+  return await apiFetch<Tag[]>("/tag");
 }
 
 /**
@@ -105,7 +105,7 @@ export async function getTags(): Promise<Tag[]> {
  * @throws {ApiError} 404 — tag not found or not public.
  */
 export async function getTag(id: number): Promise<Tag> {
-  return await apiFetch<Tag>(`/tags/${id}`);
+  return await apiFetch<Tag>(`/tag/${id}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -121,7 +121,7 @@ export async function getTag(id: number): Promise<Tag> {
  * const allTags = await getAllTags();
  */
 export async function getAllTags(): Promise<Tag[]> {
-  return await apiFetch<Tag[]>("/tags/all");
+  return await apiFetch<Tag[]>("/tag/all");
 }
 
 /**
@@ -132,7 +132,7 @@ export async function getAllTags(): Promise<Tag[]> {
  * @throws {ApiError} 404 — tag not found.
  */
 export async function getTagAdmin(id: number): Promise<Tag> {
-  return await apiFetch<Tag>(`/tags/${id}/all`);
+  return await apiFetch<Tag>(`/tag/${id}/all`);
 }
 
 /**
@@ -143,7 +143,7 @@ export async function getTagAdmin(id: number): Promise<Tag> {
  * @throws {ApiError} 404 — tag not found.
  */
 export async function getTagWithMeta(id: number): Promise<TagWithMeta> {
-  return await apiFetch<TagWithMeta>(`/tags/${id}/meta`);
+  return await apiFetch<TagWithMeta>(`/tag/${id}/meta`);
 }
 
 /**
@@ -162,7 +162,7 @@ export async function getTagWithMeta(id: number): Promise<TagWithMeta> {
  * });
  */
 export async function createTag(data: CreateTagInput): Promise<Tag> {
-  return await apiFetch<Tag>("/tags", { method: "POST", body: data });
+  return await apiFetch<Tag>("/tag", { method: "POST", body: data });
 }
 
 /**
@@ -177,7 +177,7 @@ export async function replaceTag(
   id: number,
   data: ReplaceTagInput,
 ): Promise<Tag> {
-  return await apiFetch<Tag>(`/tags/${id}`, { method: "PUT", body: data });
+  return await apiFetch<Tag>(`/tag/${id}`, { method: "PUT", body: data });
 }
 
 /**
@@ -196,7 +196,7 @@ export async function updateTag(
   id: number,
   data: UpdateTagInput,
 ): Promise<Tag> {
-  return await apiFetch<Tag>(`/tags/${id}`, { method: "PATCH", body: data });
+  return await apiFetch<Tag>(`/tag/${id}`, { method: "PATCH", body: data });
 }
 
 /**
@@ -207,7 +207,7 @@ export async function updateTag(
  * @throws {ApiError} 404 — tag not found.
  */
 export async function deleteTag(id: number): Promise<void> {
-  await apiFetch<void>(`/tags/${id}`, { method: "DELETE" });
+  await apiFetch<void>(`/tag/${id}`, { method: "DELETE" });
 }
 
 // ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@ export async function deleteTag(id: number): Promise<void> {
  * const types = await getTagTypes();
  */
 export async function getTagTypes(): Promise<TagType[]> {
-  return await apiFetch<TagType[]>("/tags/type");
+  return await apiFetch<TagType[]>("/tag/type");
 }
 
 /**
@@ -231,7 +231,7 @@ export async function getTagTypes(): Promise<TagType[]> {
  * @throws {ApiError} 404 — tag type not found.
  */
 export async function getTagType(id: number): Promise<TagType> {
-  return await apiFetch<TagType>(`/tags/type/${id}`);
+  return await apiFetch<TagType>(`/tag/type/${id}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -246,7 +246,7 @@ export async function getTagType(id: number): Promise<TagType> {
  * @throws {ApiError} 404 — tag type not found.
  */
 export async function getTagTypeWithMeta(id: number): Promise<TagTypeWithMeta> {
-  return await apiFetch<TagTypeWithMeta>(`/tags/type/${id}/meta`);
+  return await apiFetch<TagTypeWithMeta>(`/tag/type/${id}/meta`);
 }
 
 /**
@@ -263,7 +263,7 @@ export async function getTagTypeWithMeta(id: number): Promise<TagTypeWithMeta> {
 export async function createTagType(
   data: CreateTagTypeInput,
 ): Promise<TagType> {
-  return await apiFetch<TagType>("/tags/type", { method: "POST", body: data });
+  return await apiFetch<TagType>("/tag/type", { method: "POST", body: data });
 }
 
 /**
@@ -278,7 +278,7 @@ export async function replaceTagType(
   id: number,
   data: ReplaceTagTypeInput,
 ): Promise<TagType> {
-  return await apiFetch<TagType>(`/tags/type/${id}`, { method: "PUT", body: data });
+  return await apiFetch<TagType>(`/tag/type/${id}`, { method: "PUT", body: data });
 }
 
 /**
@@ -293,7 +293,7 @@ export async function updateTagType(
   id: number,
   data: UpdateTagTypeInput,
 ): Promise<TagType> {
-  return await apiFetch<TagType>(`/tags/type/${id}`, { method: "PATCH", body: data });
+  return await apiFetch<TagType>(`/tag/type/${id}`, { method: "PATCH", body: data });
 }
 
 /**
@@ -304,5 +304,5 @@ export async function updateTagType(
  * @throws {ApiError} 404 — tag type not found.
  */
 export async function deleteTagType(id: number): Promise<void> {
-  await apiFetch<void>(`/tags/type/${id}`, { method: "DELETE" });
+  await apiFetch<void>(`/tag/type/${id}`, { method: "DELETE" });
 }

--- a/frontend/test/services/tags.test.ts
+++ b/frontend/test/services/tags.test.ts
@@ -50,73 +50,73 @@ beforeEach(() => vi.stubGlobal("fetch", mockOk(tagPayload)));
 afterEach(() => vi.unstubAllGlobals());
 
 describe("getTags", () => {
-  it("GETs /api/v1/tags", async () => {
+  it("GETs /api/v1/tag", async () => {
     vi.stubGlobal("fetch", mockOk([tagPayload]));
     await getTags();
-    expect(lastCall()[0]).toBe("/api/v1/tags");
+    expect(lastCall()[0]).toBe("/api/v1/tag");
   });
 });
 
 describe("getTag", () => {
-  it("GETs /api/v1/tags/:id", async () => {
+  it("GETs /api/v1/tag/:id", async () => {
     await getTag(1);
-    expect(lastCall()[0]).toBe("/api/v1/tags/1");
+    expect(lastCall()[0]).toBe("/api/v1/tag/1");
   });
 });
 
 describe("getAllTags", () => {
-  it("GETs /api/v1/tags/all", async () => {
+  it("GETs /api/v1/tag/all", async () => {
     vi.stubGlobal("fetch", mockOk([tagPayload]));
     await getAllTags();
-    expect(lastCall()[0]).toBe("/api/v1/tags/all");
+    expect(lastCall()[0]).toBe("/api/v1/tag/all");
   });
 });
 
 describe("getTagAdmin", () => {
-  it("GETs /api/v1/tags/:id/all", async () => {
+  it("GETs /api/v1/tag/:id/all", async () => {
     await getTagAdmin(1);
-    expect(lastCall()[0]).toBe("/api/v1/tags/1/all");
+    expect(lastCall()[0]).toBe("/api/v1/tag/1/all");
   });
 });
 
 describe("getTagWithMeta", () => {
-  it("GETs /api/v1/tags/:id/meta", async () => {
+  it("GETs /api/v1/tag/:id/meta", async () => {
     await getTagWithMeta(1);
-    expect(lastCall()[0]).toBe("/api/v1/tags/1/meta");
+    expect(lastCall()[0]).toBe("/api/v1/tag/1/meta");
   });
 });
 
 describe("createTag", () => {
-  it("POSTs to /api/v1/tags", async () => {
+  it("POSTs to /api/v1/tag", async () => {
     const input = { name: { nl: "Drama" }, tag_type: 1, public: true };
     await createTag(input);
-    expect(lastCall()[0]).toBe("/api/v1/tags");
+    expect(lastCall()[0]).toBe("/api/v1/tag");
     expect(lastCall()[1].method).toBe("POST");
     expect(lastCall()[1].body).toBe(JSON.stringify(input));
   });
 });
 
 describe("replaceTag", () => {
-  it("PUTs to /api/v1/tags/:id", async () => {
+  it("PUTs to /api/v1/tag/:id", async () => {
     await replaceTag(1, { name: { nl: "Komedie" }, tag_type: 1, public: true });
-    expect(lastCall()[0]).toBe("/api/v1/tags/1");
+    expect(lastCall()[0]).toBe("/api/v1/tag/1");
     expect(lastCall()[1].method).toBe("PUT");
   });
 });
 
 describe("updateTag", () => {
-  it("PATCHes /api/v1/tags/:id", async () => {
+  it("PATCHes /api/v1/tag/:id", async () => {
     await updateTag(1, { public: false });
-    expect(lastCall()[0]).toBe("/api/v1/tags/1");
+    expect(lastCall()[0]).toBe("/api/v1/tag/1");
     expect(lastCall()[1].method).toBe("PATCH");
   });
 });
 
 describe("deleteTag", () => {
-  it("DELETEs /api/v1/tags/:id", async () => {
+  it("DELETEs /api/v1/tag/:id", async () => {
     vi.stubGlobal("fetch", mockOk({}, 204));
     await deleteTag(1);
-    expect(lastCall()[0]).toBe("/api/v1/tags/1");
+    expect(lastCall()[0]).toBe("/api/v1/tag/1");
     expect(lastCall()[1].method).toBe("DELETE");
   });
 });
@@ -126,63 +126,63 @@ describe("deleteTag", () => {
 // ---------------------------------------------------------------------------
 
 describe("getTagTypes", () => {
-  it("GETs /api/v1/tags/type", async () => {
+  it("GETs /api/v1/tag/type", async () => {
     vi.stubGlobal("fetch", mockOk([tagTypePayload]));
     await getTagTypes();
-    expect(lastCall()[0]).toBe("/api/v1/tags/type");
+    expect(lastCall()[0]).toBe("/api/v1/tag/type");
   });
 });
 
 describe("getTagType", () => {
-  it("GETs /api/v1/tags/type/:id", async () => {
+  it("GETs /api/v1/tag/type/:id", async () => {
     vi.stubGlobal("fetch", mockOk(tagTypePayload));
     await getTagType(1);
-    expect(lastCall()[0]).toBe("/api/v1/tags/type/1");
+    expect(lastCall()[0]).toBe("/api/v1/tag/type/1");
   });
 });
 
 describe("getTagTypeWithMeta", () => {
-  it("GETs /api/v1/tags/type/:id/meta", async () => {
+  it("GETs /api/v1/tag/type/:id/meta", async () => {
     vi.stubGlobal("fetch", mockOk(tagTypePayload));
     await getTagTypeWithMeta(1);
-    expect(lastCall()[0]).toBe("/api/v1/tags/type/1/meta");
+    expect(lastCall()[0]).toBe("/api/v1/tag/type/1/meta");
   });
 });
 
 describe("createTagType", () => {
-  it("POSTs to /api/v1/tags/type", async () => {
+  it("POSTs to /api/v1/tag/type", async () => {
     vi.stubGlobal("fetch", mockOk(tagTypePayload, 201));
     const input = { name: { nl: "Genre" } };
     await createTagType(input);
-    expect(lastCall()[0]).toBe("/api/v1/tags/type");
+    expect(lastCall()[0]).toBe("/api/v1/tag/type");
     expect(lastCall()[1].method).toBe("POST");
     expect(lastCall()[1].body).toBe(JSON.stringify(input));
   });
 });
 
 describe("replaceTagType", () => {
-  it("PUTs to /api/v1/tags/type/:id", async () => {
+  it("PUTs to /api/v1/tag/type/:id", async () => {
     vi.stubGlobal("fetch", mockOk(tagTypePayload));
     await replaceTagType(1, { name: { nl: "Nieuw Genre" } });
-    expect(lastCall()[0]).toBe("/api/v1/tags/type/1");
+    expect(lastCall()[0]).toBe("/api/v1/tag/type/1");
     expect(lastCall()[1].method).toBe("PUT");
   });
 });
 
 describe("updateTagType", () => {
-  it("PATCHes /api/v1/tags/type/:id", async () => {
+  it("PATCHes /api/v1/tag/type/:id", async () => {
     vi.stubGlobal("fetch", mockOk(tagTypePayload));
     await updateTagType(1, { name: { en: "Genre" } });
-    expect(lastCall()[0]).toBe("/api/v1/tags/type/1");
+    expect(lastCall()[0]).toBe("/api/v1/tag/type/1");
     expect(lastCall()[1].method).toBe("PATCH");
   });
 });
 
 describe("deleteTagType", () => {
-  it("DELETEs /api/v1/tags/type/:id", async () => {
+  it("DELETEs /api/v1/tag/type/:id", async () => {
     vi.stubGlobal("fetch", mockOk({}, 204));
     await deleteTagType(1);
-    expect(lastCall()[0]).toBe("/api/v1/tags/type/1");
+    expect(lastCall()[0]).toBe("/api/v1/tag/type/1");
     expect(lastCall()[1].method).toBe("DELETE");
   });
 });


### PR DESCRIPTION
**Issue(s)**

Closes #218 

____

**Description**

Change tag endpoint route to the singular /api/v1/tag instead of /api/v1/tags, to be consistent with all other endpoints. 

____

**Sources**