### PR TITLE
fix legacy import path for windows

### DIFF
--- a/backend/src/legacy-import/shared.ts
+++ b/backend/src/legacy-import/shared.ts
@@ -83,7 +83,7 @@ function importMetaUrlToPath(importMetaUrl: string): string {
   if (!importMetaUrl.startsWith("file://")) {
     return importMetaUrl;
   }
-  return new URL(importMetaUrl).pathname;
+  return fileURLToPath(importMetaUrl);
 }
 
 /**


### PR DESCRIPTION
**Issue(s)**

<!-- List the issue(s) for this PR here. -->

____

**Description**

Fix duplicate c:/c:/ in legacy import paths on Windows.

____

**Sources**

<!-- If applicable, add sources (e.g. links, screenshots ...) to show your work. -->
