### PR TITLE
add pagination to productions page

### DIFF
--- a/backend/src/routes/production/handlers/fetch.ts
+++ b/backend/src/routes/production/handlers/fetch.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
+import type { QueryResult } from "pg";
 import type {ProductionWithBackwardsRefs, ProductionWithMeta} from "@viernulvier/shared/index.js";
 import {ProductionSchema, ProductionSchemaWithBackwardsRefs, stringToInt} from "@viernulvier/shared/index.js";
 import { parseParams, parseSchema, ParseContext } from "@/routes/helpers.js";
@@ -153,6 +154,7 @@ export type PaginatedProductions = {
  *
  * @param server - The Fastify instance, used for database access and logging.
  * @param request - The Fastify request; optional `limit` and `offset` query params.
+ * @returns The list of productions as `{ items, total }`; throws if parsing failed.
  */
 export async function fetchProductions(
   server: FastifyInstance,
@@ -167,28 +169,25 @@ export async function fetchProductions(
   const limit = query.limit;
   const offset = query.offset ?? 0;
 
+  let result: QueryResult<ProductionWithBackwardsRefs>;
+  let total: number;
+
   if (limit === undefined) {
-    const result = await server.pg.query<ProductionWithBackwardsRefs>(
+    result = await server.pg.query<ProductionWithBackwardsRefs>(
       `${ProductionSelect} ORDER BY p.id ASC`,
     );
-    const items = parseSchema(
-      server,
-      z.array(ProductionSchemaWithBackwardsRefs),
-      result.rows,
-      ParseContext.Database,
+    total = result.rows.length;
+  } else {
+    const countResult = await server.pg.query<{ count: number }>(
+      `SELECT COUNT(*)::int AS count FROM production`,
     );
-    return { items, total: items.length };
+    total = countResult.rows[0]?.count ?? 0;
+    result = await server.pg.query<ProductionWithBackwardsRefs>(
+      `${ProductionSelect} ORDER BY p.id ASC LIMIT $1 OFFSET $2`,
+      [limit, offset],
+    );
   }
 
-  const countResult = await server.pg.query<{ count: number }>(
-    `SELECT COUNT(*)::int AS count FROM production`,
-  );
-  const total = countResult.rows[0]?.count ?? 0;
-
-  const result = await server.pg.query<ProductionWithBackwardsRefs>(
-    `${ProductionSelect} ORDER BY p.id ASC LIMIT $1 OFFSET $2`,
-    [limit, offset],
-  );
   const items = parseSchema(
     server,
     z.array(ProductionSchemaWithBackwardsRefs),

--- a/backend/src/routes/production/handlers/fetch.ts
+++ b/backend/src/routes/production/handlers/fetch.ts
@@ -128,21 +128,73 @@ export async function fetchProductionWithMeta(
   return parseSchema(server, z.array(ProductionSchema.withMeta()), result.rows, ParseContext.Database)[0] ?? null;
 }
 
+const MAX_PAGE_SIZE = 100;
+
+const ProductionListQuerySchema = z
+  .object({
+    limit: z.coerce.number().int().positive().max(MAX_PAGE_SIZE).optional(),
+    offset: z.coerce.number().int().min(0).optional(),
+  })
+  .refine(
+    (q) => q.limit !== undefined || q.offset === undefined || q.offset === 0,
+    { message: "`offset` requires `limit`" },
+  );
+
+export type PaginatedProductions = {
+  items: ProductionWithBackwardsRefs[];
+  total: number;
+};
+
 /**
  * Fetches a list of productions.
  *
+ * - Without `limit`: returns every production (same ordering as before), as `{ items, total }`.
+ * - With `limit`: returns a page `{ items, total }` where `total` is the full row count.
+ *
  * @param server - The Fastify instance, used for database access and logging.
- * @param _request - The Fastify request (currently unused, reserved for future filters).
- * @returns The list of productions, or `null` if parsing failed.
+ * @param request - The Fastify request; optional `limit` and `offset` query params.
  */
 export async function fetchProductions(
   server: FastifyInstance,
-  _request: FastifyRequest,
-): Promise<ProductionWithBackwardsRefs[] | null> {
-  const result = await server.pg.query<ProductionWithBackwardsRefs>(
-    `${ProductionSelect} ORDER BY p.id ASC`,
+  request: FastifyRequest,
+): Promise<PaginatedProductions> {
+  const query = parseSchema(
+    server,
+    ProductionListQuerySchema,
+    request.query,
+    ParseContext.Request,
   );
+  const limit = query.limit;
+  const offset = query.offset ?? 0;
 
-  return parseSchema(server, z.array(ProductionSchemaWithBackwardsRefs), result.rows, ParseContext.Database);
+  if (limit === undefined) {
+    const result = await server.pg.query<ProductionWithBackwardsRefs>(
+      `${ProductionSelect} ORDER BY p.id ASC`,
+    );
+    const items = parseSchema(
+      server,
+      z.array(ProductionSchemaWithBackwardsRefs),
+      result.rows,
+      ParseContext.Database,
+    );
+    return { items, total: items.length };
+  }
+
+  const countResult = await server.pg.query<{ count: number }>(
+    `SELECT COUNT(*)::int AS count FROM production`,
+  );
+  const total = countResult.rows[0]?.count ?? 0;
+
+  const result = await server.pg.query<ProductionWithBackwardsRefs>(
+    `${ProductionSelect} ORDER BY p.id ASC LIMIT $1 OFFSET $2`,
+    [limit, offset],
+  );
+  const items = parseSchema(
+    server,
+    z.array(ProductionSchemaWithBackwardsRefs),
+    result.rows,
+    ParseContext.Database,
+  );
+  return { items, total };
 }
 

--- a/backend/test/routes/production/fetch.test.ts
+++ b/backend/test/routes/production/fetch.test.ts
@@ -40,35 +40,49 @@ const baseProductionWithMeta = {
   updated_by: 1,
 };
 
+function mockProductionFetchPgQuery(query: string, params?: unknown[]) {
+  const upper = query.trim().toUpperCase();
+
+  if (upper.startsWith("SELECT") && upper.includes("WHERE P.ID = $1") && upper.includes("CREATED_AT")) {
+    const id = Number(params?.[0]);
+    if (id === baseProduction["id"]) {
+      return Promise.resolve({ rows: [baseProductionWithMeta], rowCount: 1 });
+    }
+    return Promise.resolve({ rows: [], rowCount: 0 });
+  }
+
+  if (
+    upper.startsWith("SELECT") &&
+    upper.includes("WHERE P.ID = $1") &&
+    !upper.includes("ANY($1::INT[])")
+  ) {
+    const id = Number(params?.[0]);
+    if (id === baseProduction["id"]) {
+      return Promise.resolve({ rows: [baseProduction], rowCount: 1 });
+    }
+    return Promise.resolve({ rows: [], rowCount: 0 });
+  }
+
+  if (upper.includes("COUNT(*)") && upper.includes("FROM PRODUCTION")) {
+    return Promise.resolve({ rows: [{ count: 1 }], rowCount: 1 });
+  }
+
+  if (upper.includes("LIMIT") && upper.includes("OFFSET")) {
+    return Promise.resolve({ rows: [baseProduction], rowCount: 1 });
+  }
+
+  if (upper.startsWith("SELECT") && upper.includes("ORDER BY P.ID ASC") && !upper.includes("LIMIT")) {
+    return Promise.resolve({ rows: [baseProduction], rowCount: 1 });
+  }
+
+  throw new Error(`Unexpected query in fetch tests: ${query}`);
+}
+
 beforeAll(async () => {
   server = await buildServer();
   sessionCookie = server.jwt.sign({ id: 1, username: "Admin1" });
 
-  server.pg.query = vi.fn().mockImplementation((query: string, params?: unknown[]) => {
-    const upper = query.trim().toUpperCase();
-
-    if (upper.startsWith("SELECT") && upper.includes("WHERE P.ID = $1") && upper.includes("CREATED_AT")) {
-      const id = Number(params?.[0]);
-      if (id === baseProduction["id"]) {
-        return Promise.resolve({ rows: [baseProductionWithMeta], rowCount: 1 });
-      }
-      return Promise.resolve({ rows: [], rowCount: 0 });
-    }
-
-    if (upper.startsWith("SELECT") && upper.includes("WHERE P.ID = $1")) {
-      const id = Number(params?.[0]);
-      if (id === baseProduction["id"]) {
-        return Promise.resolve({ rows: [baseProduction], rowCount: 1 });
-      }
-      return Promise.resolve({ rows: [], rowCount: 0 });
-    }
-
-    if (upper.startsWith("SELECT")) {
-      return Promise.resolve({ rows: [baseProduction], rowCount: 1 });
-    }
-
-    throw new Error(`Unexpected query in fetch tests: ${query}`);
-  });
+  server.pg.query = vi.fn().mockImplementation(mockProductionFetchPgQuery);
 });
 
 afterAll(async () => {
@@ -76,7 +90,7 @@ afterAll(async () => {
 });
 
 describe("Production fetch routes", () => {
-  test("GET /api/v1/production -> returns a list of productions", async () => {
+  test("GET /api/v1/production -> returns items and total", async () => {
     const response = await server.inject({
       method: "GET",
       url: "/api/v1/production",
@@ -85,9 +99,75 @@ describe("Production fetch routes", () => {
 
     expect(response.statusCode).toBe(200);
 
-    const json = response.json();
-    const parsed = ProductionSchemaWithBackwardsRefs.array().parse(json);
+    const json = response.json() as { items: unknown[]; total: number };
+    expect(json.total).toBe(1);
+    const parsed = ProductionSchemaWithBackwardsRefs.array().parse(json.items);
     expect(parsed).toEqual([ProductionSchemaWithBackwardsRefs.parse(baseProduction)]);
+  });
+
+  test("GET /api/v1/production?limit=10&offset=0 -> returns a page with full total", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/production?limit=10&offset=0",
+      cookies: { session: sessionCookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const json = response.json() as { items: unknown[]; total: number };
+    expect(json.total).toBe(1);
+    const parsed = ProductionSchemaWithBackwardsRefs.array().parse(json.items);
+    expect(parsed).toEqual([ProductionSchemaWithBackwardsRefs.parse(baseProduction)]);
+  });
+
+  test("GET /api/v1/production?offset=0 without limit -> lists all productions (offset zero allowed)", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/production?offset=0",
+      cookies: { session: sessionCookie },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const json = response.json() as { items: unknown[]; total: number };
+    expect(json.total).toBe(1);
+    expect(json.items).toHaveLength(1);
+  });
+
+  test("GET /api/v1/production?offset=n without limit -> 400 (offset requires limit)", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/production?offset=20",
+      cookies: { session: sessionCookie },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  test("GET /api/v1/production?limit=5 -> total 0 when COUNT returns no row", async () => {
+    server.pg.query = vi.fn().mockImplementation((query: string) => {
+      const upper = query.trim().toUpperCase();
+      if (upper.includes("COUNT(*)") && upper.includes("FROM PRODUCTION")) {
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      }
+      if (upper.includes("LIMIT") && upper.includes("OFFSET")) {
+        return Promise.resolve({ rows: [baseProduction], rowCount: 1 });
+      }
+      throw new Error(`Unexpected query in COUNT-empty test: ${query}`);
+    });
+
+    try {
+      const response = await server.inject({
+        method: "GET",
+        url: "/api/v1/production?limit=5&offset=0",
+        cookies: { session: sessionCookie },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const json = response.json() as { items: unknown[]; total: number };
+      expect(json.total).toBe(0);
+      expect(json.items).toHaveLength(1);
+    } finally {
+      server.pg.query = vi.fn().mockImplementation(mockProductionFetchPgQuery);
+    }
   });
 
   test("GET /api/v1/production/:id -> returns a single production", async () => {

--- a/backend/test/sql.integration.test.ts
+++ b/backend/test/sql.integration.test.ts
@@ -372,8 +372,9 @@ describe("Production routes — SQL integration", { sequential: true }, () => {
     const response = await server.inject({ method: "GET", url: "/api/v1/production" });
 
     expect(response.statusCode).toBe(HttpSuccess.OK);
-    const productions = response.json<unknown[]>();
-    expect(productions.some((p) => ProductionSchemaWithBackwardsRefs.parse(p).id === productionId)).toBe(true);
+    const body = response.json<{ items: unknown[]; total: number }>();
+    expect(body.items.some((p) => ProductionSchemaWithBackwardsRefs.parse(p).id === productionId)).toBe(true);
+    expect(body.total).toBe(body.items.length);
   });
 
   test("GET /api/v1/production/:id — returns the created production", async () => {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -48,6 +48,12 @@ export default {
     error: "Could not load productions. Please try again later.",
     empty: "No productions in the archive yet.",
     morePerformances: "& {n} more",
+    showingRange: "{from}–{to} of {total}",
+    prevPage: "Previous",
+    nextPage: "Next",
+    pageWord: "Page",
+    pageOfTotal: "of {total}",
+    goToPage: "Go to page",
   },
   admin: {
     login: {

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -49,6 +49,12 @@ export default {
       "Impossible de charger les productions. Veuillez réessayer plus tard.",
     empty: "Aucune production dans les archives pour l’instant.",
     morePerformances: "{n} de plus",
+    showingRange: "{from}–{to} sur {total}",
+    prevPage: "Précédent",
+    nextPage: "Suivant",
+    pageWord: "Page",
+    pageOfTotal: "sur {total}",
+    goToPage: "Aller à la page",
   },
   admin: {
     login: {

--- a/frontend/src/i18n/locales/nl.ts
+++ b/frontend/src/i18n/locales/nl.ts
@@ -49,6 +49,12 @@ export default {
       "De producties konden niet worden geladen. Probeer het later opnieuw.",
     empty: "Er staan nog geen producties in het archief.",
     morePerformances: "nog {n}",
+    showingRange: "{from}–{to} van {total}",
+    prevPage: "Vorige",
+    nextPage: "Volgende",
+    pageWord: "Pagina",
+    pageOfTotal: "van {total}",
+    goToPage: "Ga naar pagina",
   },
   admin: {
     login: {

--- a/frontend/src/services/productions.ts
+++ b/frontend/src/services/productions.ts
@@ -2,7 +2,7 @@
  * @file Production API — CRUD for productions.
  *
  * Public endpoints (no session required):
- *   - {@link getProductions} — list all productions
+ *   - {@link getProductions} — list productions (optional pagination)
  *   - {@link getProduction}  — fetch one production by ID
  *
  * Protected endpoints (active session required):
@@ -81,16 +81,35 @@ export interface BulkUpdateProductionsInput {
 // Public endpoints
 // ---------------------------------------------------------------------------
 
+/** Paginated public list response from {@link getProductions}. */
+export type ProductionListPage = {
+  items: ProductionWithBackwardsRefs[];
+  /** Total number of productions (all pages), not just `items.length`. */
+  total: number;
+};
+
 /**
- * Fetches all productions (public — no session required).
+ * Fetches productions (public — no session required).
  *
- * @returns Array of productions, each with `tags` and `events` as arrays of linked IDs.
+ * - With `{ limit, offset }`: returns one page plus the full `total` count.
+ * - With no options: returns every production as `items` and `total === items.length`.
  *
  * @example
- * const productions = await getProductions();
+ * const { items, total } = await getProductions({ limit: 20, offset: 0 });
  */
-export async function getProductions(): Promise<ProductionWithBackwardsRefs[]> {
-  return await apiFetch<ProductionWithBackwardsRefs[]>("/production");
+export async function getProductions(options?: {
+  limit?: number;
+  offset?: number;
+}): Promise<ProductionListPage> {
+  const params = new URLSearchParams();
+  if (options?.limit !== undefined) {
+    params.set("limit", String(options.limit));
+    params.set("offset", String(options.offset ?? 0));
+  }
+  const qs = params.toString();
+  return await apiFetch<ProductionListPage>(
+    qs ? `/production?${qs}` : "/production",
+  );
 }
 
 /**

--- a/frontend/src/services/productions.ts
+++ b/frontend/src/services/productions.ts
@@ -94,6 +94,8 @@ export type ProductionListPage = {
  * - With `{ limit, offset }`: returns one page plus the full `total` count.
  * - With no options: returns every production as `items` and `total === items.length`.
  *
+ * @returns Array of productions, each with `tags` and `events` as arrays of linked IDs.
+ *
  * @example
  * const { items, total } = await getProductions({ limit: 20, offset: 0 });
  */

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -3,7 +3,8 @@
     <AppNavbar :is-dark="isDark" @toggle-dark="isDark = !isDark" />
     <main>
       <section
-        class="border-b border-surface-3 bg-surface-1 py-12 md:py-16"
+        ref="pageTopAnchor"
+        class="scroll-mt-16 border-b border-surface-3 bg-surface-1 py-12 md:py-16"
       >
         <div class="mx-auto max-w-3xl px-6 text-center lg:px-10">
           <h1
@@ -36,7 +37,7 @@
         </p>
 
         <p
-          v-else-if="!productions.length"
+          v-else-if="totalCount === 0"
           class="py-16 text-center text-sm text-ink-secondary"
         >
           {{ t("productionsPage.empty") }}
@@ -51,6 +52,67 @@
             :tag-chips="tagChipsFor(p)"
             :halls-text="hallsTextFor(p.id)"
           />
+
+          <nav
+            v-if="totalPages > 1"
+            class="mt-10 grid grid-cols-1 justify-items-center gap-y-6 border-t border-surface-3 pt-8 sm:grid-cols-[1fr_auto] sm:items-center sm:justify-items-start sm:gap-x-12 sm:gap-y-0"
+            aria-label="Pagination"
+          >
+            <p class="text-center text-sm text-ink-secondary sm:text-left">
+              {{
+                t("productionsPage.showingRange", {
+                  from: rangeFrom,
+                  to: rangeTo,
+                  total: totalCount,
+                })
+              }}
+            </p>
+            <div
+              class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 sm:justify-self-end"
+              role="group"
+              :aria-label="t('productionsPage.goToPage')"
+            >
+              <button
+                type="button"
+                class="cursor-pointer rounded-md border border-accent-outline bg-surface-0 px-3 py-1.5 text-sm font-medium text-ink-primary transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
+                :disabled="currentPage <= 0 || listLoading"
+                @click="goToPage(currentPage - 1)"
+              >
+                {{ t("productionsPage.prevPage") }}
+              </button>
+              <div
+                class="flex items-center gap-2 text-sm tabular-nums text-ink-secondary"
+              >
+                <span class="whitespace-nowrap">{{
+                  t("productionsPage.pageWord")
+                }}</span>
+                <input
+                  :value="pageNumberInput"
+                  type="text"
+                  inputmode="numeric"
+                  autocomplete="off"
+                  maxlength="6"
+                  :disabled="listLoading"
+                  :aria-label="t('productionsPage.goToPage')"
+                  class="min-w-6 max-w-8 shrink-0 border-0 border-b border-surface-3 bg-transparent px-0 pb-px text-center text-sm tabular-nums text-ink-secondary focus:border-ink-primary focus:text-ink-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+                  @input="onPageNumberInput"
+                  @keydown.enter.prevent="commitPageNumberInput"
+                  @blur="commitPageNumberInput"
+                />
+                <span class="whitespace-nowrap">{{
+                  t("productionsPage.pageOfTotal", { total: totalPages })
+                }}</span>
+              </div>
+              <button
+                type="button"
+                class="cursor-pointer rounded-md border border-accent-outline bg-surface-0 px-3 py-1.5 text-sm font-medium text-ink-primary transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
+                :disabled="currentPage >= totalPages - 1 || listLoading"
+                @click="goToPage(currentPage + 1)"
+              >
+                {{ t("productionsPage.nextPage") }}
+              </button>
+            </div>
+          </nav>
         </div>
       </section>
     </main>
@@ -59,10 +121,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watchEffect } from "vue";
+import {
+  computed,
+  nextTick,
+  onMounted,
+  ref,
+  useTemplateRef,
+  watch,
+  watchEffect,
+} from "vue";
 import { useI18n } from "vue-i18n";
 import type {
-  Event,
+  Event as ProductionEvent,
   Hall,
   ProductionWithBackwardsRefs,
   Tag,
@@ -86,7 +156,31 @@ import {
   tagMapById,
 } from "@/utils/productionsOverview";
 
+const PAGE_SIZE = 20;
+
 const { t } = useI18n();
+
+const pageTopAnchor = useTemplateRef<HTMLElement>("pageTopAnchor");
+
+function scrollProductionsPageToTop() {
+  const el = pageTopAnchor.value;
+  if (el && typeof el.scrollIntoView === "function") {
+    el.scrollIntoView({ behavior: "smooth", block: "start" });
+    return;
+  }
+  const doc = document.documentElement;
+  const body = document.body;
+  if (typeof doc.scrollTo === "function") {
+    doc.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+  } else {
+    doc.scrollTop = 0;
+  }
+  if (typeof body.scrollTo === "function") {
+    body.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+  } else {
+    body.scrollTop = 0;
+  }
+}
 
 function getInitialDark(): boolean {
   const stored = localStorage.getItem("viernulvier-dark");
@@ -104,9 +198,65 @@ watchEffect(() => {
 });
 
 const loading = ref(true);
+const listLoading = ref(false);
 const loadError = ref(false);
 const productions = ref<ProductionWithBackwardsRefs[]>([]);
-const eventsByProduction = ref(new Map<number, Event[]>());
+const totalCount = ref(0);
+const currentPage = ref(0);
+
+const totalPages = computed(() =>
+  totalCount.value === 0 ? 0 : Math.ceil(totalCount.value / PAGE_SIZE),
+);
+
+/** 1-based page shown in the pagination field (digits only while editing). */
+const pageNumberInput = ref("1");
+
+watch(currentPage, (p) => {
+  if (totalPages.value > 0) {
+    pageNumberInput.value = String(p + 1);
+  }
+});
+
+function onPageNumberInput(e: Event) {
+  pageNumberInput.value = (e.target as HTMLInputElement).value.replace(
+    /\D/g,
+    "",
+  );
+}
+
+async function commitPageNumberInput() {
+  if (totalPages.value <= 0) return;
+
+  const raw = pageNumberInput.value.replace(/\D/g, "").trim();
+  if (raw === "") {
+    pageNumberInput.value = String(currentPage.value + 1);
+    return;
+  }
+
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n)) {
+    pageNumberInput.value = String(currentPage.value + 1);
+    return;
+  }
+
+  const pageOneBased = Math.min(Math.max(1, n), totalPages.value);
+  if (pageOneBased === currentPage.value + 1) {
+    pageNumberInput.value = String(pageOneBased);
+    return;
+  }
+
+  await goToPage(pageOneBased - 1);
+  pageNumberInput.value = String(currentPage.value + 1);
+}
+
+const rangeFrom = computed(() =>
+  totalCount.value === 0 ? 0 : currentPage.value * PAGE_SIZE + 1,
+);
+
+const rangeTo = computed(() =>
+  Math.min((currentPage.value + 1) * PAGE_SIZE, totalCount.value),
+);
+const eventsByProduction = ref(new Map<number, ProductionEvent[]>());
 const tagsById = ref(new Map<number, Tag>());
 const tagTypesById = ref(new Map<number, TagType>());
 const hallsById = ref(new Map<number, Hall>());
@@ -117,14 +267,16 @@ onMounted(async () => {
   loading.value = true;
   loadError.value = false;
   try {
-    const [prods, tags, events, halls, tagTypes] = await Promise.all([
-      getProductions(),
+    const [page, tags, events, halls, tagTypes] = await Promise.all([
+      getProductions({ limit: PAGE_SIZE, offset: 0 }),
       getTags(),
       getEvents(),
       getHalls(),
       getTagTypes(),
     ]);
-    productions.value = prods;
+    productions.value = page.items;
+    totalCount.value = page.total;
+    currentPage.value = 0;
     tagsById.value = tagMapById(tags);
     tagTypesById.value = new Map(tagTypes.map((tt) => [tt.id, tt]));
     hallsById.value = hallMapById(halls);
@@ -135,6 +287,29 @@ onMounted(async () => {
     loading.value = false;
   }
 });
+
+async function goToPage(page: number) {
+  if (page < 0 || page >= totalPages.value) return;
+  listLoading.value = true;
+  loadError.value = false;
+  try {
+    const { items, total } = await getProductions({
+      limit: PAGE_SIZE,
+      offset: page * PAGE_SIZE,
+    });
+    productions.value = items;
+    totalCount.value = total;
+    currentPage.value = page;
+    await nextTick();
+    requestAnimationFrame(() => {
+      scrollProductionsPageToTop();
+    });
+  } catch {
+    loadError.value = true;
+  } finally {
+    listLoading.value = false;
+  }
+}
 
 function dateSummaryFor(productionId: number) {
   const evs = eventsByProduction.value.get(productionId);

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -130,6 +130,8 @@ import {
   watch,
 } from "vue";
 import { useI18n } from "vue-i18n";
+import { useRoute, useRouter } from "vue-router";
+import type { LocationQueryRaw } from "vue-router";
 import type {
   Event as ProductionEvent,
   Hall,
@@ -158,9 +160,49 @@ import {
 
 const PAGE_SIZE = 20;
 
+/** 1-based page index in the URL (`?page=1` is normalized away). */
+const PAGE_QUERY_KEY = "page";
+
+const route = useRoute();
+const router = useRouter();
 const { t } = useI18n();
 
 const pageTopAnchor = useTemplateRef<HTMLElement>("pageTopAnchor");
+
+/**
+ * Reads a positive 1-based page from the route query; invalid or missing -> 1.
+ */
+function readPageOneBasedFromRoute(): number {
+  const raw = route.query[PAGE_QUERY_KEY];
+  const s = Array.isArray(raw) ? raw[0] : raw;
+  if (s === undefined || s === null || s === "") return 1;
+  const n = Number.parseInt(String(s), 10);
+  if (!Number.isFinite(n) || n < 1) return 1;
+  return n;
+}
+
+function queryForPage0(page0: number): LocationQueryRaw {
+  const q: LocationQueryRaw = { ...route.query };
+  if (page0 <= 0) {
+    delete q[PAGE_QUERY_KEY];
+  } else {
+    q[PAGE_QUERY_KEY] = String(page0 + 1);
+  }
+  return q;
+}
+
+function urlNeedsSyncForPage0(page0: number): boolean {
+  const raw = route.query[PAGE_QUERY_KEY];
+  const cur =
+    raw === undefined || raw === null || raw === ""
+      ? undefined
+      : String(Array.isArray(raw) ? raw[0] : raw);
+  const want = page0 <= 0 ? undefined : String(page0 + 1);
+  if (want === undefined) {
+    return cur !== undefined && cur !== "";
+  }
+  return cur !== want;
+}
 
 function scrollProductionsPageToTop() {
   const el = pageTopAnchor.value;
@@ -249,24 +291,77 @@ const hallsById = ref(new Map<number, Hall>());
 
 const locale = computed(() => i18n.global.locale.value as SupportedLang);
 
+async function fetchProductionsPageData(page0: number) {
+  const { items, total } = await getProductions({
+    limit: PAGE_SIZE,
+    offset: page0 * PAGE_SIZE,
+  });
+  productions.value = items;
+  totalCount.value = total;
+  currentPage.value = page0;
+}
+
+function scrollAfterPageChange() {
+  void nextTick();
+  requestAnimationFrame(() => {
+    scrollProductionsPageToTop();
+  });
+}
+
+async function replaceRouteForPage0(page0: number) {
+  await router.replace({
+    path: route.path,
+    query: queryForPage0(page0),
+    hash: route.hash,
+  });
+}
+
 onMounted(async () => {
   loading.value = true;
   loadError.value = false;
+  const requestedOneBased = readPageOneBasedFromRoute();
+  let page0 = Math.max(0, requestedOneBased - 1);
   try {
     const [page, tags, events, halls, tagTypes] = await Promise.all([
-      getProductions({ limit: PAGE_SIZE, offset: 0 }),
+      getProductions({ limit: PAGE_SIZE, offset: page0 * PAGE_SIZE }),
       getTags(),
       getEvents(),
       getHalls(),
       getTagTypes(),
     ]);
-    productions.value = page.items;
     totalCount.value = page.total;
-    currentPage.value = 0;
+    const tp =
+      totalCount.value === 0
+        ? 0
+        : Math.ceil(totalCount.value / PAGE_SIZE);
+
+    if (tp > 0) {
+      const clamped0 = Math.min(Math.max(0, page0), tp - 1);
+      if (clamped0 !== page0) {
+        page0 = clamped0;
+        const again = await getProductions({
+          limit: PAGE_SIZE,
+          offset: page0 * PAGE_SIZE,
+        });
+        productions.value = again.items;
+        totalCount.value = again.total;
+      } else {
+        productions.value = page.items;
+      }
+    } else {
+      productions.value = page.items;
+      page0 = 0;
+    }
+
+    currentPage.value = page0;
     tagsById.value = tagMapById(tags);
     tagTypesById.value = new Map(tagTypes.map((tt) => [tt.id, tt]));
     hallsById.value = hallMapById(halls);
     eventsByProduction.value = groupEventsByProductionId(events);
+
+    if (urlNeedsSyncForPage0(page0)) {
+      await replaceRouteForPage0(page0);
+    }
   } catch {
     loadError.value = true;
   } finally {
@@ -274,22 +369,44 @@ onMounted(async () => {
   }
 });
 
+watch(
+  () => readPageOneBasedFromRoute(),
+  async (oneBased) => {
+    if (loading.value) return;
+    if (totalPages.value <= 0) return;
+
+    let page0 = oneBased - 1;
+    const max0 = totalPages.value - 1;
+    const clamped0 = Math.min(Math.max(0, page0), max0);
+    if (page0 !== clamped0) {
+      await replaceRouteForPage0(clamped0);
+      return;
+    }
+    page0 = clamped0;
+
+    if (page0 === currentPage.value) return;
+
+    listLoading.value = true;
+    loadError.value = false;
+    try {
+      await fetchProductionsPageData(page0);
+      scrollAfterPageChange();
+    } catch {
+      loadError.value = true;
+    } finally {
+      listLoading.value = false;
+    }
+  },
+);
+
 async function goToPage(page: number) {
   if (page < 0 || page >= totalPages.value) return;
   listLoading.value = true;
   loadError.value = false;
   try {
-    const { items, total } = await getProductions({
-      limit: PAGE_SIZE,
-      offset: page * PAGE_SIZE,
-    });
-    productions.value = items;
-    totalCount.value = total;
-    currentPage.value = page;
-    await nextTick();
-    requestAnimationFrame(() => {
-      scrollProductionsPageToTop();
-    });
+    await fetchProductionsPageData(page);
+    await replaceRouteForPage0(page);
+    scrollAfterPageChange();
   } catch {
     loadError.value = true;
   } finally {

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-surface-0">
-    <AppNavbar :is-dark="isDark" @toggle-dark="isDark = !isDark" />
+    <AppNavbar :is-dark="isDark" @toggle-dark="toggleDark" />
     <main>
       <section
         ref="pageTopAnchor"
@@ -128,7 +128,6 @@ import {
   ref,
   useTemplateRef,
   watch,
-  watchEffect,
 } from "vue";
 import { useI18n } from "vue-i18n";
 import type {
@@ -141,6 +140,7 @@ import type {
 import AppFooter from "@/components/AppFooter.vue";
 import AppNavbar from "@/components/AppNavbar.vue";
 import ProductionListCard from "@/components/productions/ProductionListCard.vue";
+import { useDarkMode } from "@/composables/useDarkMode";
 import { i18n, type SupportedLang } from "@/i18n";
 import { getEvents } from "@/services/events";
 import { getHalls } from "@/services/halls";
@@ -182,21 +182,7 @@ function scrollProductionsPageToTop() {
   }
 }
 
-function getInitialDark(): boolean {
-  const stored = localStorage.getItem("viernulvier-dark");
-  if (stored !== null) return stored === "true";
-  return window.matchMedia("(prefers-color-scheme: dark)").matches;
-}
-
-const isDark = ref(getInitialDark());
-
-watchEffect(() => {
-  const htmlEl = document.documentElement;
-  if (isDark.value) htmlEl.classList.add("dark");
-  else htmlEl.classList.remove("dark");
-  localStorage.setItem("viernulvier-dark", String(isDark.value));
-});
-
+const { isDark, toggleDark } = useDarkMode();
 const loading = ref(true);
 const listLoading = ref(false);
 const loadError = ref(false);

--- a/frontend/test/services/productions.test.ts
+++ b/frontend/test/services/productions.test.ts
@@ -51,10 +51,23 @@ afterEach(() => vi.unstubAllGlobals());
 
 describe("getProductions", () => {
   it("GETs /api/v1/production", async () => {
-    vi.stubGlobal("fetch", mockOk([productionPayload]));
-    await getProductions();
+    vi.stubGlobal(
+      "fetch",
+      mockOk({ items: [productionPayload], total: 1 }),
+    );
+    const page = await getProductions();
+    expect(page).toEqual({ items: [productionPayload], total: 1 });
     expect(lastCall()[0]).toBe("/api/v1/production");
     expect(lastCall()[1].method).toBeUndefined();
+  });
+
+  it("GETs /api/v1/production with limit and offset", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockOk({ items: [productionPayload], total: 100 }),
+    );
+    await getProductions({ limit: 20, offset: 40 });
+    expect(lastCall()[0]).toBe("/api/v1/production?limit=20&offset=40");
   });
 });
 

--- a/frontend/test/views/ProductionsView.test.ts
+++ b/frontend/test/views/ProductionsView.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "@viernulvier/shared";
 import { routes } from "@/router/routes";
 import { i18n } from "@/i18n";
+import { __reset as resetDarkMode } from "@/composables/useDarkMode";
 import ProductionsView from "@/views/ProductionsView.vue";
 import * as productionsService from "@/services/productions";
 import type { ProductionListPage } from "@/services/productions";
@@ -100,8 +101,9 @@ describe("ProductionsView.vue", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    document.documentElement.classList.remove("dark");
     localStorage.clear();
+    resetDarkMode();
+    document.documentElement.classList.remove("dark");
   });
 
   async function mountView() {
@@ -172,6 +174,7 @@ describe("ProductionsView.vue", () => {
 
   it("uses saved dark-mode preference from localStorage", async () => {
     localStorage.setItem("viernulvier-dark", "true");
+    resetDarkMode();
     const { wrapper } = await mountView();
     expect(document.documentElement.classList.contains("dark")).toBe(true);
     wrapper.unmount();

--- a/frontend/test/views/ProductionsView.test.ts
+++ b/frontend/test/views/ProductionsView.test.ts
@@ -12,6 +12,7 @@ import { routes } from "@/router/routes";
 import { i18n } from "@/i18n";
 import ProductionsView from "@/views/ProductionsView.vue";
 import * as productionsService from "@/services/productions";
+import type { ProductionListPage } from "@/services/productions";
 import * as tagsService from "@/services/tags";
 import type { TagType } from "@viernulvier/shared";
 import * as eventsService from "@/services/events";
@@ -87,9 +88,10 @@ const mockTagTypeGenre = {
 
 describe("ProductionsView.vue", () => {
   beforeEach(() => {
-    vi.spyOn(productionsService, "getProductions").mockResolvedValue([
-      mockProduction,
-    ]);
+    vi.spyOn(productionsService, "getProductions").mockResolvedValue({
+      items: [mockProduction],
+      total: 1,
+    });
     vi.spyOn(tagsService, "getTags").mockResolvedValue([mockTag]);
     vi.spyOn(tagsService, "getTagTypes").mockResolvedValue([mockTagTypeGenre]);
     vi.spyOn(eventsService, "getEvents").mockResolvedValue([mockEvent]);
@@ -118,7 +120,10 @@ describe("ProductionsView.vue", () => {
   it("renders the page heading after data loads", async () => {
     const { wrapper } = await mountView();
     expect(wrapper.text()).toContain("Producties");
-    expect(productionsService.getProductions).toHaveBeenCalledOnce();
+    expect(productionsService.getProductions).toHaveBeenCalledWith({
+      limit: 20,
+      offset: 0,
+    });
     wrapper.unmount();
   });
 
@@ -139,8 +144,8 @@ describe("ProductionsView.vue", () => {
   });
 
   it("shows loading then empty state when the API returns no productions", async () => {
-    let finishFetch!: (value: ProductionWithBackwardsRefs[]) => void;
-    const deferred = new Promise<ProductionWithBackwardsRefs[]>((resolve) => {
+    let finishFetch!: (value: ProductionListPage) => void;
+    const deferred = new Promise<ProductionListPage>((resolve) => {
       finishFetch = resolve;
     });
     vi.spyOn(productionsService, "getProductions").mockReturnValue(deferred);
@@ -157,7 +162,7 @@ describe("ProductionsView.vue", () => {
     await nextTick();
     expect(wrapper.text()).toContain("laden");
 
-    finishFetch([]);
+    finishFetch({ items: [], total: 0 });
     await flushPromises();
 
     expect(wrapper.text()).toContain("nog geen producties");
@@ -172,13 +177,114 @@ describe("ProductionsView.vue", () => {
     wrapper.unmount();
   });
 
+  it("fetches the requested page when the page field is committed", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper } = await mountView();
+    const field = wrapper.find('input[inputmode="numeric"]');
+    expect(field.exists()).toBe(true);
+
+    await field.setValue("3");
+    await field.trigger("blur");
+    await flushPromises();
+
+    expect(getProductionsSpy).toHaveBeenLastCalledWith({
+      limit: 20,
+      offset: 40,
+    });
+
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+    wrapper.unmount();
+  });
+
+  it("does not refetch when committing the current page number", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper } = await mountView();
+    expect(getProductionsSpy).toHaveBeenCalledTimes(1);
+
+    const field = wrapper.find('input[inputmode="numeric"]');
+    await field.setValue("1");
+    await field.trigger("blur");
+    await flushPromises();
+
+    expect(getProductionsSpy).toHaveBeenCalledTimes(1);
+
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+    wrapper.unmount();
+  });
+
+  it("jumps to page 2 when Enter is pressed in the page field", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper } = await mountView();
+    const field = wrapper.find('input[inputmode="numeric"]');
+    await field.setValue("2");
+    await field.trigger("keydown.enter");
+    await flushPromises();
+
+    expect(getProductionsSpy).toHaveBeenLastCalledWith({
+      limit: 20,
+      offset: 20,
+    });
+
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+    wrapper.unmount();
+  });
+
+  it("clamps the page field to the last page when the value is too large", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper } = await mountView();
+    const field = wrapper.find('input[inputmode="numeric"]');
+    await field.setValue("999");
+    await field.trigger("blur");
+    await flushPromises();
+
+    expect(getProductionsSpy).toHaveBeenLastCalledWith({
+      limit: 20,
+      offset: 40,
+    });
+    expect((field.element as HTMLInputElement).value).toBe("3");
+
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+    wrapper.unmount();
+  });
+
   it("skips unknown tags and tags with empty localized names", async () => {
-    vi.spyOn(productionsService, "getProductions").mockResolvedValue([
-      {
-        ...mockProduction,
-        tags: [7, 99, 8] as unknown as ProductionWithBackwardsRefs["tags"],
-      } as ProductionWithBackwardsRefs,
-    ]);
+    vi.spyOn(productionsService, "getProductions").mockResolvedValue({
+      items: [
+        {
+          ...mockProduction,
+          tags: [7, 99, 8] as unknown as ProductionWithBackwardsRefs["tags"],
+        } as ProductionWithBackwardsRefs,
+      ],
+      total: 1,
+    });
     vi.spyOn(tagsService, "getTags").mockResolvedValue([
       mockTag,
       {

--- a/frontend/test/views/ProductionsView.test.ts
+++ b/frontend/test/views/ProductionsView.test.ts
@@ -278,6 +278,108 @@ describe("ProductionsView.vue", () => {
     wrapper.unmount();
   });
 
+  it("shows an error when pagination request fails", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy
+      .mockResolvedValueOnce({
+        items: [mockProduction],
+        total: 45,
+      })
+      .mockRejectedValueOnce(new Error("network"));
+
+    const { wrapper } = await mountView();
+    expect(wrapper.text()).not.toContain("niet worden geladen");
+
+    const nextBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Volgende");
+    expect(nextBtn).toBeDefined();
+    await nextBtn!.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("niet worden geladen");
+    wrapper.unmount();
+  });
+
+  it("resets the page field when the committed value is not finite", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper } = await mountView();
+    const field = wrapper.find('input[inputmode="numeric"]');
+
+    await field.setValue("9".repeat(400));
+    await field.trigger("blur");
+    await flushPromises();
+
+    expect(getProductionsSpy).toHaveBeenCalledTimes(1);
+    expect((field.element as HTMLInputElement).value).toBe("1");
+
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+    wrapper.unmount();
+  });
+
+  it("resets the page field when the committed value is empty", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper } = await mountView();
+    const field = wrapper.find('input[inputmode="numeric"]');
+
+    await field.setValue("");
+    await field.trigger("blur");
+    await flushPromises();
+
+    expect(getProductionsSpy).toHaveBeenCalledTimes(1);
+    expect((field.element as HTMLInputElement).value).toBe("1");
+
+    wrapper.unmount();
+  });
+
+  it("scrolls via fallback when the page anchor has no scrollIntoView", async () => {
+    const orig = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollIntoView",
+    );
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: undefined,
+    });
+
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    try {
+      const { wrapper } = await mountView();
+      const field = wrapper.find('input[inputmode="numeric"]');
+      await field.setValue("2");
+      await field.trigger("blur");
+      await flushPromises();
+
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+
+      expect(wrapper.text()).toContain("De voorstelling");
+      wrapper.unmount();
+    } finally {
+      if (orig) {
+        Object.defineProperty(HTMLElement.prototype, "scrollIntoView", orig);
+      }
+    }
+  });
+
   it("skips unknown tags and tags with empty localized names", async () => {
     vi.spyOn(productionsService, "getProductions").mockResolvedValue({
       items: [

--- a/frontend/test/views/ProductionsView.test.ts
+++ b/frontend/test/views/ProductionsView.test.ts
@@ -106,9 +106,9 @@ describe("ProductionsView.vue", () => {
     document.documentElement.classList.remove("dark");
   });
 
-  async function mountView() {
+  async function mountView(initialPath = "/nl/productions") {
     const router = createRouter({ history: createMemoryHistory(), routes });
-    await router.push("/nl/productions");
+    await router.push(initialPath);
     await router.isReady();
 
     const wrapper = mount(ProductionsView, {
@@ -378,6 +378,139 @@ describe("ProductionsView.vue", () => {
         Object.defineProperty(HTMLElement.prototype, "scrollIntoView", orig);
       }
     }
+  });
+
+  it("uses the page query for the initial list fetch", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper, router } = await mountView("/nl/productions?page=3");
+    expect(getProductionsSpy).toHaveBeenCalledWith({
+      limit: 20,
+      offset: 40,
+    });
+    expect(router.currentRoute.value.query.page).toBe("3");
+    wrapper.unmount();
+  });
+
+  it("drops page=1 from the URL after load", async () => {
+    const router = createRouter({ history: createMemoryHistory(), routes });
+    await router.push({ path: "/nl/productions", query: { page: "1" } });
+    await router.isReady();
+
+    const wrapper = mount(ProductionsView, {
+      global: { plugins: [router, i18n] },
+      attachTo: document.body,
+    });
+    await flushPromises();
+
+    expect(router.currentRoute.value.query.page).toBeUndefined();
+    wrapper.unmount();
+  });
+
+  it("normalizes an out-of-range page query after load", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper, router } = await mountView("/nl/productions?page=99");
+    expect(router.currentRoute.value.query.page).toBe("3");
+    expect(getProductionsSpy).toHaveBeenLastCalledWith({
+      limit: 20,
+      offset: 40,
+    });
+    wrapper.unmount();
+  });
+
+  it("refetches when the page query changes after load", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper, router } = await mountView("/nl/productions?page=2");
+    expect(getProductionsSpy).toHaveBeenLastCalledWith({
+      limit: 20,
+      offset: 20,
+    });
+
+    await router.replace({
+      path: "/nl/productions",
+      query: {},
+    });
+    await flushPromises();
+
+    expect(getProductionsSpy).toHaveBeenLastCalledWith({
+      limit: 20,
+      offset: 0,
+    });
+    wrapper.unmount();
+  });
+
+  it("clamps the page query via navigation after load", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper, router } = await mountView("/nl/productions?page=2");
+    await flushPromises();
+
+    await router.replace({
+      path: "/nl/productions",
+      query: { page: "99" },
+    });
+    await flushPromises();
+
+    expect(router.currentRoute.value.query.page).toBe("3");
+    wrapper.unmount();
+  });
+
+  it("shows an error when a route-driven page fetch fails", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy
+      .mockResolvedValueOnce({
+        items: [mockProduction],
+        total: 45,
+      })
+      .mockRejectedValueOnce(new Error("network"));
+
+    const { wrapper, router } = await mountView("/nl/productions");
+    expect(wrapper.text()).not.toContain("niet worden geladen");
+
+    await router.replace({
+      path: "/nl/productions",
+      query: { page: "2" },
+    });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("niet worden geladen");
+    wrapper.unmount();
+  });
+
+  it("updates the page query when using pagination controls", async () => {
+    const getProductionsSpy = vi.spyOn(productionsService, "getProductions");
+    getProductionsSpy.mockResolvedValue({
+      items: [mockProduction],
+      total: 45,
+    });
+
+    const { wrapper, router } = await mountView();
+    const nextBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Volgende");
+    await nextBtn!.trigger("click");
+    await flushPromises();
+
+    expect(router.currentRoute.value.query.page).toBe("2");
+    wrapper.unmount();
   });
 
   it("skips unknown tags and tags with empty localized names", async () => {


### PR DESCRIPTION
**Issue(s)**

Closes #291 

____

**Description**

Implemented pagination for the productions page.

API (GET /production):
- Responses are now always { items, total }: items is the ordered list of productions, total is the number of rows in the database (not just the current page).
- Optional query parameter limit and offset added
- Without limit: behavior matches a full list fetch: all productions in items, and total === items.length.
- With limit: one page of rows is returned and total is the full count so clients can build pagination.

Frontend:
- getProductions in productions helper accepts an optional { limit?, offset? } object and builds the query string accordingly, leaving out options keeps a single request for the full list.
- ProductionsView loads the public list in pages (of 20), shows prev/next and a page input, and displays range when there is more than one page.

Going back to the top of the page when navigating to a different page doesn't feel very smooth yet, so I'll make an issue to try and improve this in the future.

____

**Sources**