### PR TITLE
handle overlap of api/legacy data

### DIFF
--- a/backend/scripts/import-events-legacy.ts
+++ b/backend/scripts/import-events-legacy.ts
@@ -13,15 +13,26 @@ const DEFAULT_FILE = resolveDefaultLegacyImportFile(import.meta.url, [
   "events.csv",
 ]);
 
+const DEFAULT_PRODUCTIONS_FILE = resolveDefaultLegacyImportFile(import.meta.url, [
+  "data",
+  "imports",
+  "productions.csv",
+]);
+
 async function main() {
   const args = parseLegacyImportCli({
     defaultFile: DEFAULT_FILE,
     scriptForUsage: "import:events",
     description: "Import legacy events CSV into Postgres.",
+    eventsProductionsDefault: DEFAULT_PRODUCTIONS_FILE,
   });
 
   assertDatabaseUrl();
   assertCsvFileExists(args.filePath);
+  if (args.productionsFilePath === undefined) {
+    throw new Error("Internal error: missing productionsFilePath (events CLI must set eventsProductionsDefault).");
+  }
+  assertCsvFileExists(args.productionsFilePath);
 
   const client = new pg.Client({ connectionString: process.env["DATABASE_URL"] });
   await client.connect();

--- a/backend/src/legacy-import/import-events-legacy.ts
+++ b/backend/src/legacy-import/import-events-legacy.ts
@@ -3,6 +3,10 @@ import fs from "node:fs";
 import pg from "pg";
 import { parse } from "csv-parse";
 import {
+  indexLanguageMapValues,
+  SQL_FIND_HALL_ID_BY_ANY_LANG_NAME,
+} from "./jsonb-name-match.js";
+import {
   cleanValue,
   LEGACY_IMPORT_PROGRESS_EVERY,
   legacyCsvParseOptions,
@@ -118,12 +122,11 @@ async function loadProductionMap(client: pg.Client): Promise<Map<string, number>
 
 async function loadHallCache(client: pg.Client): Promise<Map<string, number>> {
   const map = new Map<string, number>();
-  const rows = await client.query<{ id: number; name: string }>(
-    `SELECT id, name->>'nl' AS name
-     FROM hall`,
+  const rows = await client.query<{ id: number; name: unknown }>(
+    `SELECT id, name FROM hall`,
   );
   for (const row of rows.rows) {
-    map.set(hallKey(row.name), row.id);
+    indexLanguageMapValues(map, row.id, row.name, hallKey);
   }
   return map;
 }
@@ -139,10 +142,7 @@ async function getOrCreateHallId(
   if (cached) return { id: cached, created: false };
 
   const existing = await client.query<{ id: number; address: string | null }>(
-    `SELECT id, address
-     FROM hall
-     WHERE lower(name->>'nl') = lower($1)
-     LIMIT 1`,
+    SQL_FIND_HALL_ID_BY_ANY_LANG_NAME,
     [hall.name],
   );
   const existingHall = existing.rows[0];

--- a/backend/src/legacy-import/import-events-legacy.ts
+++ b/backend/src/legacy-import/import-events-legacy.ts
@@ -1,10 +1,13 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import pg from "pg";
 import { parse } from "csv-parse";
 import {
   indexLanguageMapValues,
   SQL_FIND_HALL_ID_BY_ANY_LANG_NAME,
+  SQL_LIST_PRODUCTION_IDS_BY_TITLE_AND_ARTIST,
 } from "./jsonb-name-match.js";
 import {
   cleanValue,
@@ -23,8 +26,17 @@ import {
 } from "./validate-legacy-inserts.js";
 import { EventCreateSchema } from "@/routes/event/handlers/helper.js";
 
+/** Alias for callers/tests; same as {@link ImportArgs} (includes optional `productionsFilePath`). */
+export type LegacyEventImportArgs = ImportArgs;
+
 export const LEGACY_EVENT_IMPORT_SOURCE = "events-voorstellingen-csv";
 export const LEGACY_EVENT_PRODUCTION_MAP_SOURCE = "productions-output-csv";
+
+/** True when this legacy production row was inserted by the importer (vs mapped to existing API row). */
+export type ProductionMapEntry = {
+  productionId: number;
+  createdNew: boolean;
+};
 
 type ParsedHall = {
   name: string;
@@ -42,8 +54,44 @@ type ImportStats = {
   skippedDuplicateInFile: number;
   skippedAlreadyImported: number;
   skippedValidationFailed: number;
+  skippedFullDuplicateProductionEvent: number;
+  deletedOrphanProductionsAfterDuplicate: number;
   failedRows: number;
 };
+
+type BufferedEventRow = {
+  row: Record<string, string>;
+  legacyKey: string;
+};
+
+const SQL_EVENT_EXISTS_ON_PRODUCTIONS_FOR_BRUSSELS_DAYS = `
+SELECT EXISTS (
+  SELECT 1
+  FROM unnest($1::date[]) AS gd(gday)
+  WHERE EXISTS (
+    SELECT 1 FROM event e
+    WHERE e.production = ANY($2::int[])
+    AND (e.starts_at AT TIME ZONE 'Europe/Brussels')::date = gd.gday
+  )
+)
+`;
+
+function defaultLegacyProductionsCsvPath(): string {
+  return path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "..",
+    "data",
+    "imports",
+    "productions.csv",
+  );
+}
+
+/** Calendar date string YYYY-MM-DD in Europe/Brussels for a UTC instant (matches DB comparison). */
+export function calendarDateBrussels(utc: Date): string {
+  return utc.toLocaleDateString("en-CA", { timeZone: "Europe/Brussels" });
+}
 
 /** Parse legacy event datetime cell to UTC Date or null. */
 export function parseCsvDate(value: string): Date | null {
@@ -106,18 +154,52 @@ async function assertProductionMapTableExists(client: pg.Client): Promise<void> 
   }
 }
 
-async function loadProductionMap(client: pg.Client): Promise<Map<string, number>> {
-  const map = new Map<string, number>();
-  const rows = await client.query<{ legacy_id: string; production_id: number }>(
-    `SELECT legacy_id, production_id
+async function loadProductionMap(client: pg.Client): Promise<Map<string, ProductionMapEntry>> {
+  const map = new Map<string, ProductionMapEntry>();
+  const rows = await client.query<{
+    legacy_id: string;
+    production_id: number;
+    created_new_production: boolean | null;
+  }>(
+    `SELECT legacy_id, production_id,
+            COALESCE(created_new_production, false) AS created_new_production
      FROM legacy_production_import_map
      WHERE source = $1`,
     [LEGACY_EVENT_PRODUCTION_MAP_SOURCE],
   );
   for (const row of rows.rows) {
-    map.set(row.legacy_id, row.production_id);
+    map.set(row.legacy_id, {
+      productionId: row.production_id,
+      createdNew: row.created_new_production === true,
+    });
   }
   return map;
+}
+
+async function loadLegacyProductionMetaFromCsv(filePath: string): Promise<Map<string, { titel: string; ondertitel: string }>> {
+  const map = new Map<string, { titel: string; ondertitel: string }>();
+  const stream = fs.createReadStream(filePath);
+  const parser = parse({ ...legacyCsvParseOptions });
+  stream.pipe(parser);
+  for await (const rowRaw of parser as AsyncIterable<CsvRecord>) {
+    const row = normalizeRow(rowRaw);
+    const legacyId = row["id"] ?? "";
+    if (legacyId.length === 0) continue;
+    map.set(legacyId, { titel: row["titel"] ?? "", ondertitel: row["ondertitel"] ?? "" });
+  }
+  return map;
+}
+
+async function listProductionIdsByTitleAndArtist(
+  client: pg.Client,
+  titel: string,
+  ondertitel: string,
+): Promise<number[]> {
+  const t = titel.trim();
+  if (t.length === 0) return [];
+  const a = ondertitel.trim();
+  const result = await client.query<{ id: number }>(SQL_LIST_PRODUCTION_IDS_BY_TITLE_AND_ARTIST, [t, a]);
+  return result.rows.map((r) => r.id);
 }
 
 async function loadHallCache(client: pg.Client): Promise<Map<string, number>> {
@@ -167,10 +249,37 @@ async function getOrCreateHallId(
   return { id, created: true };
 }
 
+async function legacyProductionIsFullDuplicateOfExistingEvents(
+  client: pg.Client,
+  titel: string,
+  ondertitel: string,
+  mappedProductionId: number,
+  legacyStartsUtc: Date[],
+): Promise<boolean> {
+  const matchingIds = await listProductionIdsByTitleAndArtist(client, titel, ondertitel);
+  const others = matchingIds.filter((id) => id !== mappedProductionId);
+  const productionIdsForDayCheck = others.length > 0 ? others : [mappedProductionId];
+  const dayStrings = new Set<string>();
+  for (const d of legacyStartsUtc) {
+    dayStrings.add(calendarDateBrussels(d));
+  }
+  if (dayStrings.size === 0) return false;
+  const days = [...dayStrings].sort();
+  const result = await client.query<{ exists: boolean }>(SQL_EVENT_EXISTS_ON_PRODUCTIONS_FOR_BRUSSELS_DAYS, [
+    days,
+    productionIdsForDayCheck,
+  ]);
+  return result.rows[0]?.exists === true;
+}
+
 /**
  * Stream legacy events CSV into `event`, halls, and `legacy_event_import_map`.
  * Requires production import map rows for {@link LEGACY_EVENT_PRODUCTION_MAP_SOURCE}.
+ * Groups rows by legacy production id so duplicate calendar days vs API can skip the whole production safely.
  * Caller owns the client (connect / end).
+ *
+ * `args.productionsFilePath` (from `--productions-file` or default) must point at the same productions export
+ * used for title/artist dedupe; when omitted, falls back to repo `data/imports/productions.csv` next to the backend package.
  */
 export async function importEventsLegacy(client: pg.Client, args: ImportArgs): Promise<void> {
   await assertProductionMapTableExists(client);
@@ -179,7 +288,15 @@ export async function importEventsLegacy(client: pg.Client, args: ImportArgs): P
     await ensureIdempotencyTable(client);
   }
 
-  const productionMap = await loadProductionMap(client);
+  const productionsCsvPath = args.productionsFilePath ?? defaultLegacyProductionsCsvPath();
+  if (!fs.existsSync(productionsCsvPath)) {
+    throw new Error(
+      `Productions CSV not found: ${productionsCsvPath}. Pass productionsFilePath or add data/imports/productions.csv.`,
+    );
+  }
+
+  const productionMetaByLegacyId = await loadLegacyProductionMetaFromCsv(productionsCsvPath);
+  let productionMap = await loadProductionMap(client);
   if (productionMap.size === 0) {
     throw new Error("No production mappings found. Import productions first in write mode.");
   }
@@ -198,6 +315,7 @@ export async function importEventsLegacy(client: pg.Client, args: ImportArgs): P
   }
 
   console.log(`CSV file: ${args.filePath}`);
+  console.log(`Productions CSV (title/artist for dedupe): ${productionsCsvPath}`);
   console.log(`Mode: ${args.dryRun ? "dry-run" : "write"}`);
   if (args.limit) console.log(`Row limit: ${args.limit}`);
   console.log(`Known production mappings: ${productionMap.size}`);
@@ -213,10 +331,12 @@ export async function importEventsLegacy(client: pg.Client, args: ImportArgs): P
     skippedDuplicateInFile: 0,
     skippedAlreadyImported: 0,
     skippedValidationFailed: 0,
+    skippedFullDuplicateProductionEvent: 0,
+    deletedOrphanProductionsAfterDuplicate: 0,
     failedRows: 0,
   };
 
-  const seenKeysInFile = new Set<string>();
+  const buffered: BufferedEventRow[] = [];
   const stream = fs.createReadStream(args.filePath);
   const parser = parse({ ...legacyCsvParseOptions });
   stream.pipe(parser);
@@ -225,14 +345,79 @@ export async function importEventsLegacy(client: pg.Client, args: ImportArgs): P
     if (args.limit !== null && stats.totalRows >= args.limit) break;
     stats.totalRows++;
 
-    if (stats.totalRows % LEGACY_IMPORT_PROGRESS_EVERY === 0) {
+    const row = normalizeRow(rowRaw);
+    buffered.push({ row, legacyKey: makeLegacyKey(row) });
+  }
+
+  const byLegacyProduction = new Map<string, BufferedEventRow[]>();
+  for (const item of buffered) {
+    const legacyProdId = cleanValue(item.row["production"]);
+    if (legacyProdId.length === 0) continue;
+    const list = byLegacyProduction.get(legacyProdId);
+    if (list) list.push(item);
+    else byLegacyProduction.set(legacyProdId, [item]);
+  }
+
+  const suppressedLegacyProductionIds = new Set<string>();
+  const scheduledOrphanDeletes = new Map<string, number>();
+
+  for (const [legacyProdId, group] of byLegacyProduction) {
+    const mapEntry = productionMap.get(legacyProdId);
+    if (!mapEntry) continue;
+
+    const meta = productionMetaByLegacyId.get(legacyProdId);
+    const title = meta?.titel?.trim() ?? "";
+    if (title.length === 0) continue;
+
+    const startsUtc: Date[] = [];
+    for (const item of group) {
+      const s = parseCsvDate(item.row["starttime"] ?? "");
+      if (s) startsUtc.push(s);
+    }
+
+    const isDup = await legacyProductionIsFullDuplicateOfExistingEvents(
+      client,
+      title,
+      meta?.ondertitel ?? "",
+      mapEntry.productionId,
+      startsUtc,
+    );
+    if (!isDup) continue;
+
+    suppressedLegacyProductionIds.add(legacyProdId);
+    if (mapEntry.createdNew) {
+      scheduledOrphanDeletes.set(legacyProdId, mapEntry.productionId);
+    }
+  }
+
+  if (!args.dryRun) {
+    for (const [, productionId] of scheduledOrphanDeletes) {
+      try {
+        await client.query(`DELETE FROM production WHERE id = $1`, [productionId]);
+        stats.deletedOrphanProductionsAfterDuplicate++;
+      } catch (error) {
+        stats.failedRows++;
+        console.error(`Failed to delete orphan production ${productionId} after duplicate detection:`, error);
+      }
+    }
+    if (scheduledOrphanDeletes.size > 0) {
+      productionMap = await loadProductionMap(client);
+    }
+  }
+
+  const seenKeysInFile = new Set<string>();
+
+  let progressCounter = 0;
+  for (const item of buffered) {
+    progressCounter++;
+    if (progressCounter % LEGACY_IMPORT_PROGRESS_EVERY === 0) {
       console.log(
-        `Progress ${stats.totalRows} rows | imported=${stats.importedEvents} | failed=${stats.failedRows}`,
+        `Progress ${progressCounter}/${buffered.length} rows | imported=${stats.importedEvents} | failed=${stats.failedRows}`,
       );
     }
 
-    const row = normalizeRow(rowRaw);
-    const legacyKey = makeLegacyKey(row);
+    const row = item.row;
+    const legacyKey = item.legacyKey;
 
     if (seenKeysInFile.has(legacyKey)) {
       stats.skippedDuplicateInFile++;
@@ -263,13 +448,18 @@ export async function importEventsLegacy(client: pg.Client, args: ImportArgs): P
       continue;
     }
 
-    const productionId = productionMap.get(productionLegacyId);
-    if (!productionId) {
-      stats.skippedUnknownProduction++;
+    if (suppressedLegacyProductionIds.has(productionLegacyId)) {
+      stats.skippedFullDuplicateProductionEvent++;
       continue;
     }
 
-    // Legacy CSV has no doors column; `ends_at` is optional (null when endtime missing).
+    const mapEntry = productionMap.get(productionLegacyId);
+    if (!mapEntry) {
+      stats.skippedUnknownProduction++;
+      continue;
+    }
+    const productionId = mapEntry.productionId;
+
     const endsAt = parseCsvDate(row["endtime"] ?? "");
     const doorsAt: Date | null = null;
 
@@ -278,7 +468,7 @@ export async function importEventsLegacy(client: pg.Client, args: ImportArgs): P
     if (!hallParsed.success) {
       stats.skippedValidationFailed++;
       console.error(
-        `Validation failed for hall (row #${stats.totalRows}): ${formatLegacyZodError(hallParsed.error)}`,
+        `Validation failed for hall (legacy key=${legacyKey.slice(0, 8)}…): ${formatLegacyZodError(hallParsed.error)}`,
       );
       continue;
     }
@@ -298,7 +488,7 @@ export async function importEventsLegacy(client: pg.Client, args: ImportArgs): P
     if (!eventParsed.success) {
       stats.skippedValidationFailed++;
       console.error(
-        `Validation failed for event (row #${stats.totalRows}): ${formatLegacyZodError(eventParsed.error)}`,
+        `Validation failed for event (legacy key=${legacyKey.slice(0, 8)}…): ${formatLegacyZodError(eventParsed.error)}`,
       );
       continue;
     }
@@ -318,7 +508,7 @@ export async function importEventsLegacy(client: pg.Client, args: ImportArgs): P
 
       const hallResult = await getOrCreateHallId(client, hallRaw, false, hallCache);
       if (!hallResult.id) {
-        throw new Error(`Could not resolve hall for row ${stats.totalRows}`);
+        throw new Error(`Could not resolve hall for legacy key ${legacyKey}`);
       }
       if (hallResult.created) stats.createdHalls++;
 
@@ -350,7 +540,7 @@ export async function importEventsLegacy(client: pg.Client, args: ImportArgs): P
     } catch (error) {
       await client.query("ROLLBACK");
       stats.failedRows++;
-      console.error(`Failed row #${stats.totalRows}:`, error);
+      console.error(`Failed row (legacy key=${legacyKey.slice(0, 8)}…):`, error);
     }
   }
 
@@ -359,6 +549,10 @@ export async function importEventsLegacy(client: pg.Client, args: ImportArgs): P
   console.log(`  Rows read: ${stats.totalRows}`);
   console.log(`  Imported events: ${stats.importedEvents}`);
   console.log(`  Created halls: ${stats.createdHalls}`);
+  console.log(`  Skipped (full duplicate production vs API calendar day): ${stats.skippedFullDuplicateProductionEvent}`);
+  if (!args.dryRun) {
+    console.log(`  Deleted orphan productions after duplicate detection: ${stats.deletedOrphanProductionsAfterDuplicate}`);
+  }
   console.log(`  Skipped (missing starttime): ${stats.skippedMissingStart}`);
   console.log(`  Skipped (missing hall): ${stats.skippedMissingHall}`);
   console.log(`  Skipped (missing production legacy id): ${stats.skippedMissingProductionLegacyId}`);

--- a/backend/src/legacy-import/import-productions-legacy.ts
+++ b/backend/src/legacy-import/import-productions-legacy.ts
@@ -19,7 +19,7 @@ import {
 import {
   indexLanguageMapValues,
   SQL_FIND_GENRE_TAG_ID_BY_ANY_LANG_NAME,
-  SQL_FIND_PRODUCTION_ID_BY_TITLE_AND_ARTIST,
+  SQL_LIST_PRODUCTION_IDS_BY_TITLE_AND_ARTIST,
 } from "./jsonb-name-match.js";
 
 export const LEGACY_PRODUCTION_IMPORT_SOURCE = "productions-output-csv";
@@ -53,8 +53,13 @@ async function ensureIdempotencyTable(client: pg.Client): Promise<void> {
       legacy_id TEXT NOT NULL,
       production_id INT NOT NULL REFERENCES production(id) ON DELETE CASCADE,
       imported_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      created_new_production BOOLEAN NOT NULL DEFAULT false,
       PRIMARY KEY (source, legacy_id)
     )
+  `);
+  await client.query(`
+    ALTER TABLE legacy_production_import_map
+    ADD COLUMN IF NOT EXISTS created_new_production BOOLEAN NOT NULL DEFAULT false
   `);
 }
 
@@ -137,20 +142,19 @@ async function getOrCreateGenreTagId(
 }
 
 /**
- * Finds a production already in the DB with the same title and artist as the legacy row
- * (any language in `title` / `artist` JSONB). Empty legacy `ondertitel` matches DB rows whose
- * `artist` has no non-empty language value.
+ * Lists production ids with the same title and artist as the legacy row (any language in JSONB).
+ * Empty legacy `ondertitel` matches DB rows whose `artist` has no non-empty language value.
  */
-async function findExistingProductionIdByTitleAndArtist(
+async function listProductionIdsByTitleAndArtist(
   client: pg.Client,
   titel: string,
   ondertitel: string,
-): Promise<number | null> {
+): Promise<number[]> {
   const t = titel.trim();
-  if (t.length === 0) return null;
+  if (t.length === 0) return [];
   const a = ondertitel.trim();
-  const result = await client.query<{ id: number }>(SQL_FIND_PRODUCTION_ID_BY_TITLE_AND_ARTIST, [t, a]);
-  return result.rows[0]?.id ?? null;
+  const result = await client.query<{ id: number }>(SQL_LIST_PRODUCTION_IDS_BY_TITLE_AND_ARTIST, [t, a]);
+  return result.rows.map((r) => r.id);
 }
 
 type ImportStats = {
@@ -160,9 +164,9 @@ type ImportStats = {
   skippedAlreadyImported: number;
   skippedNoTitle: number;
   skippedValidationFailed: number;
-  skippedExistingProductionByTitleAndArtist: number;
   importedProductions: number;
   mappedLegacyIdsToExistingProductions: number;
+  insertedNewProductionAmbiguousOrNoMatch: number;
   createdGenreTags: number;
   linkedProductionTags: number;
   failedRows: number;
@@ -207,9 +211,9 @@ export async function importProductionsLegacy(client: pg.Client, args: ImportArg
     skippedAlreadyImported: 0,
     skippedNoTitle: 0,
     skippedValidationFailed: 0,
-    skippedExistingProductionByTitleAndArtist: 0,
     importedProductions: 0,
     mappedLegacyIdsToExistingProductions: 0,
+    insertedNewProductionAmbiguousOrNoMatch: 0,
     createdGenreTags: 0,
     linkedProductionTags: 0,
     failedRows: 0,
@@ -284,17 +288,17 @@ export async function importProductionsLegacy(client: pg.Client, args: ImportArg
     }
 
     const ondertitel = row["ondertitel"] ?? "";
-    const existingProductionId = await findExistingProductionIdByTitleAndArtist(client, title, ondertitel);
-    if (existingProductionId !== null) {
-      stats.skippedExistingProductionByTitleAndArtist++;
+    const matchingProductionIds = await listProductionIdsByTitleAndArtist(client, title, ondertitel);
+    if (matchingProductionIds.length === 1) {
+      const existingProductionId = matchingProductionIds[0]!;
       if (args.dryRun) {
         stats.mappedLegacyIdsToExistingProductions++;
         continue;
       }
       try {
         await client.query(
-          `INSERT INTO legacy_production_import_map (source, legacy_id, production_id)
-           VALUES ($1, $2, $3)
+          `INSERT INTO legacy_production_import_map (source, legacy_id, production_id, created_new_production)
+           VALUES ($1, $2, $3, false)
            ON CONFLICT (source, legacy_id) DO NOTHING`,
           [LEGACY_PRODUCTION_IMPORT_SOURCE, legacyId, existingProductionId],
         );
@@ -306,6 +310,8 @@ export async function importProductionsLegacy(client: pg.Client, args: ImportArg
       }
       continue;
     }
+
+    stats.insertedNewProductionAmbiguousOrNoMatch++;
 
     if (args.dryRun) {
       for (const genre of genres) {
@@ -378,8 +384,8 @@ export async function importProductionsLegacy(client: pg.Client, args: ImportArg
       }
 
       await client.query(
-        `INSERT INTO legacy_production_import_map (source, legacy_id, production_id)
-         VALUES ($1, $2, $3)`,
+        `INSERT INTO legacy_production_import_map (source, legacy_id, production_id, created_new_production)
+         VALUES ($1, $2, $3, true)`,
         [LEGACY_PRODUCTION_IMPORT_SOURCE, legacyId, productionId],
       );
 
@@ -405,10 +411,10 @@ export async function importProductionsLegacy(client: pg.Client, args: ImportArg
   console.log(`  Skipped (missing title): ${stats.skippedNoTitle}`);
   console.log(`  Skipped (Zod validation failed): ${stats.skippedValidationFailed}`);
   console.log(
-    `  Skipped (production already in DB: same title and artist, any language): ${stats.skippedExistingProductionByTitleAndArtist}`,
+    `  Legacy IDs mapped to existing productions (exactly one title+artist match, no new row): ${stats.mappedLegacyIdsToExistingProductions}`,
   );
   console.log(
-    `  Legacy IDs mapped to existing productions (no new production row): ${stats.mappedLegacyIdsToExistingProductions}`,
+    `  New production rows (zero or multiple title+artist matches): ${stats.insertedNewProductionAmbiguousOrNoMatch}`,
   );
   console.log(`  Failed rows: ${stats.failedRows}`);
 }

--- a/backend/src/legacy-import/import-productions-legacy.ts
+++ b/backend/src/legacy-import/import-productions-legacy.ts
@@ -16,6 +16,11 @@ import {
   legacyProductionRowToCreateBody,
   LegacyTagCreateBodySchema,
 } from "./validate-legacy-inserts.js";
+import {
+  indexLanguageMapValues,
+  SQL_FIND_GENRE_TAG_ID_BY_ANY_LANG_NAME,
+  SQL_FIND_PRODUCTION_ID_BY_TITLE_AND_ARTIST,
+} from "./jsonb-name-match.js";
 
 export const LEGACY_PRODUCTION_IMPORT_SOURCE = "productions-output-csv";
 
@@ -82,15 +87,15 @@ async function getOrCreateTagTypeId(
 
 async function loadGenreTagCache(client: pg.Client, genreTagTypeId: number): Promise<Map<string, number>> {
   const map = new Map<string, number>();
-  const existingTags = await client.query<{ id: number; name: string }>(
-    `SELECT id, name->>'nl' AS name
+  const existingTags = await client.query<{ id: number; name: unknown }>(
+    `SELECT id, name
      FROM tag
      WHERE tag_type = $1`,
     [genreTagTypeId],
   );
 
   for (const tag of existingTags.rows) {
-    map.set(genreKey(tag.name), tag.id);
+    indexLanguageMapValues(map, tag.id, tag.name, genreKey);
   }
   return map;
 }
@@ -106,14 +111,10 @@ async function getOrCreateGenreTagId(
   const cached = cache.get(key);
   if (cached) return { id: cached, created: false };
 
-  const existing = await client.query<{ id: number }>(
-    `SELECT id
-     FROM tag
-     WHERE tag_type = $1
-       AND lower(name->>'nl') = lower($2)
-     LIMIT 1`,
-    [genreTagTypeId, genreName],
-  );
+  const existing = await client.query<{ id: number }>(SQL_FIND_GENRE_TAG_ID_BY_ANY_LANG_NAME, [
+    genreTagTypeId,
+    genreName,
+  ]);
   const existingId = existing.rows[0]?.id;
   if (existingId) {
     cache.set(key, existingId);
@@ -135,6 +136,23 @@ async function getOrCreateGenreTagId(
   return { id: insertedId, created: true };
 }
 
+/**
+ * Finds a production already in the DB with the same title and artist as the legacy row
+ * (any language in `title` / `artist` JSONB). Empty legacy `ondertitel` matches DB rows whose
+ * `artist` has no non-empty language value.
+ */
+async function findExistingProductionIdByTitleAndArtist(
+  client: pg.Client,
+  titel: string,
+  ondertitel: string,
+): Promise<number | null> {
+  const t = titel.trim();
+  if (t.length === 0) return null;
+  const a = ondertitel.trim();
+  const result = await client.query<{ id: number }>(SQL_FIND_PRODUCTION_ID_BY_TITLE_AND_ARTIST, [t, a]);
+  return result.rows[0]?.id ?? null;
+}
+
 type ImportStats = {
   totalRows: number;
   skippedNoLegacyId: number;
@@ -142,7 +160,9 @@ type ImportStats = {
   skippedAlreadyImported: number;
   skippedNoTitle: number;
   skippedValidationFailed: number;
+  skippedExistingProductionByTitleAndArtist: number;
   importedProductions: number;
+  mappedLegacyIdsToExistingProductions: number;
   createdGenreTags: number;
   linkedProductionTags: number;
   failedRows: number;
@@ -187,7 +207,9 @@ export async function importProductionsLegacy(client: pg.Client, args: ImportArg
     skippedAlreadyImported: 0,
     skippedNoTitle: 0,
     skippedValidationFailed: 0,
+    skippedExistingProductionByTitleAndArtist: 0,
     importedProductions: 0,
+    mappedLegacyIdsToExistingProductions: 0,
     createdGenreTags: 0,
     linkedProductionTags: 0,
     failedRows: 0,
@@ -258,6 +280,30 @@ export async function importProductionsLegacy(client: pg.Client, args: ImportArg
     }
     if (!genreValidationOk) {
       stats.skippedValidationFailed++;
+      continue;
+    }
+
+    const ondertitel = row["ondertitel"] ?? "";
+    const existingProductionId = await findExistingProductionIdByTitleAndArtist(client, title, ondertitel);
+    if (existingProductionId !== null) {
+      stats.skippedExistingProductionByTitleAndArtist++;
+      if (args.dryRun) {
+        stats.mappedLegacyIdsToExistingProductions++;
+        continue;
+      }
+      try {
+        await client.query(
+          `INSERT INTO legacy_production_import_map (source, legacy_id, production_id)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (source, legacy_id) DO NOTHING`,
+          [LEGACY_PRODUCTION_IMPORT_SOURCE, legacyId, existingProductionId],
+        );
+        existingImported.add(legacyId);
+        stats.mappedLegacyIdsToExistingProductions++;
+      } catch (error) {
+        stats.failedRows++;
+        console.error(`Failed to map legacy ID ${legacyId} to existing production ${existingProductionId}:`, error);
+      }
       continue;
     }
 
@@ -358,5 +404,11 @@ export async function importProductionsLegacy(client: pg.Client, args: ImportArg
   console.log(`  Skipped (duplicate legacy ID in file): ${stats.skippedDuplicateLegacyIdInFile}`);
   console.log(`  Skipped (missing title): ${stats.skippedNoTitle}`);
   console.log(`  Skipped (Zod validation failed): ${stats.skippedValidationFailed}`);
+  console.log(
+    `  Skipped (production already in DB: same title and artist, any language): ${stats.skippedExistingProductionByTitleAndArtist}`,
+  );
+  console.log(
+    `  Legacy IDs mapped to existing productions (no new production row): ${stats.mappedLegacyIdsToExistingProductions}`,
+  );
   console.log(`  Failed rows: ${stats.failedRows}`);
 }

--- a/backend/src/legacy-import/jsonb-name-match.ts
+++ b/backend/src/legacy-import/jsonb-name-match.ts
@@ -46,12 +46,13 @@ LIMIT 1
 `;
 
 /**
- * Parameters: ($1 legacy titel, $2 legacy ondertitel / artist — may be empty string).
+ * All productions matching legacy title + artist (any language), deterministic order.
+ * Parameters: ($1 titel, $2 ondertitel / artist (may be empty string)).
  * A row matches only if some language in `title` matches $1 AND either:
  * - $2 is non-empty and some language in `artist` matches $2, or
  * - $2 is empty and `artist` has no non-empty language value (scraped + legacy both “no artist”).
  */
-export const SQL_FIND_PRODUCTION_ID_BY_TITLE_AND_ARTIST = `
+export const SQL_LIST_PRODUCTION_IDS_BY_TITLE_AND_ARTIST = `
 SELECT p.id
 FROM production p
 WHERE EXISTS (
@@ -78,5 +79,8 @@ AND (
     )
   )
 )
-LIMIT 1
+ORDER BY p.id
 `;
+
+export const SQL_FIND_PRODUCTION_ID_BY_TITLE_AND_ARTIST =
+  `${SQL_LIST_PRODUCTION_IDS_BY_TITLE_AND_ARTIST.trimEnd()}\nLIMIT 1`;

--- a/backend/src/legacy-import/jsonb-name-match.ts
+++ b/backend/src/legacy-import/jsonb-name-match.ts
@@ -1,0 +1,82 @@
+/**
+ * SQL snippets for matching legacy CSV strings against JSONB language maps (`title`, `name` on production/tag/hall).
+ * Compares case-insensitively after trim; any non-empty language value may match.
+ */
+
+/** Populate a lookup map from all string values in a `name` / `title` JSONB object (used to warm caches). */
+export function indexLanguageMapValues(
+  map: Map<string, number>,
+  id: number,
+  nameJson: unknown,
+  keyFn: (s: string) => string,
+): void {
+  if (nameJson === null || typeof nameJson !== "object") return;
+  for (const v of Object.values(nameJson as Record<string, unknown>)) {
+    if (typeof v === "string" && v.trim().length > 0) {
+      map.set(keyFn(v), id);
+    }
+  }
+}
+
+/** Parameters: ($tagTypeId, $searchString) */
+export const SQL_FIND_GENRE_TAG_ID_BY_ANY_LANG_NAME = `
+SELECT id
+FROM tag
+WHERE tag_type = $1
+  AND EXISTS (
+    SELECT 1 FROM jsonb_each_text(name) kv
+    WHERE kv.value IS NOT NULL
+      AND trim(kv.value) <> ''
+      AND lower(trim(kv.value)) = lower(trim($2::text))
+  )
+LIMIT 1
+`;
+
+/** Parameters: ($searchString) */
+export const SQL_FIND_HALL_ID_BY_ANY_LANG_NAME = `
+SELECT id, address
+FROM hall
+WHERE EXISTS (
+  SELECT 1 FROM jsonb_each_text(name) kv
+  WHERE kv.value IS NOT NULL
+    AND trim(kv.value) <> ''
+    AND lower(trim(kv.value)) = lower(trim($1::text))
+)
+LIMIT 1
+`;
+
+/**
+ * Parameters: ($1 legacy titel, $2 legacy ondertitel / artist — may be empty string).
+ * A row matches only if some language in `title` matches $1 AND either:
+ * - $2 is non-empty and some language in `artist` matches $2, or
+ * - $2 is empty and `artist` has no non-empty language value (scraped + legacy both “no artist”).
+ */
+export const SQL_FIND_PRODUCTION_ID_BY_TITLE_AND_ARTIST = `
+SELECT p.id
+FROM production p
+WHERE EXISTS (
+  SELECT 1 FROM jsonb_each_text(COALESCE(p.title, '{}'::jsonb)) kv_t
+  WHERE kv_t.value IS NOT NULL
+    AND trim(kv_t.value) <> ''
+    AND lower(trim(kv_t.value)) = lower(trim($1::text))
+)
+AND (
+  (
+    trim(COALESCE($2::text, '')) <> ''
+    AND EXISTS (
+      SELECT 1 FROM jsonb_each_text(COALESCE(p.artist, '{}'::jsonb)) kv_a
+      WHERE kv_a.value IS NOT NULL
+        AND trim(kv_a.value) <> ''
+        AND lower(trim(kv_a.value)) = lower(trim($2::text))
+    )
+  )
+  OR (
+    trim(COALESCE($2::text, '')) = ''
+    AND NOT EXISTS (
+      SELECT 1 FROM jsonb_each_text(COALESCE(p.artist, '{}'::jsonb)) kv_a
+      WHERE kv_a.value IS NOT NULL AND trim(kv_a.value) <> ''
+    )
+  )
+)
+LIMIT 1
+`;

--- a/backend/src/legacy-import/shared.ts
+++ b/backend/src/legacy-import/shared.ts
@@ -71,6 +71,11 @@ export type ImportArgs = {
   filePath: string;
   dryRun: boolean;
   limit: number | null;
+  /**
+   * Events import only: productions CSV (`Titel`, `Ondertitel`, `ID`) used for title/artist + calendar-day dedupe.
+   * Set by `parseLegacyImportCli` when `eventsProductionsDefault` is provided.
+   */
+  productionsFilePath?: string;
 };
 
 /**
@@ -123,6 +128,10 @@ export type LegacyImportCliOptions = {
   scriptForUsage: string;
   /** One-line summary for `--help`. */
   description: string;
+  /**
+   * When set (events importer): enables `--productions-file` and defaults `ImportArgs.productionsFilePath` to this path.
+   */
+  eventsProductionsDefault?: string;
 };
 
 /**
@@ -140,6 +149,7 @@ export function argvForLegacyImportYargs(hideBinResult: readonly string[], fromT
 /**
  * Shared yargs CLI for legacy CSV importers: positional path, `--file`, `--dry-run`, `--limit`, `--help` / `-h`.
  * `--file` overrides a positional path; if multiple positionals are given without `--file`, the last wins.
+ * Events importer may also set `eventsProductionsDefault` to enable `--productions-file`.
  *
  * @param argv - Optional argv slice for unit tests. When set, yargs does not call `process.exit` on errors or `--help`.
  */
@@ -152,12 +162,17 @@ export function parseLegacyImportCli(
     ? argvForLegacyImportYargs(argv, true)
     : argvForLegacyImportYargs(hideBin(process.argv), false);
 
-  const parsed = yargs(input)
+  const defaultFilesHelp =
+    options.eventsProductionsDefault !== undefined
+      ? `Default events CSV:\n  ${options.defaultFile}\n\nDefault productions CSV (title/artist for event dedupe):\n  ${options.eventsProductionsDefault}`
+      : `Default CSV:\n  ${options.defaultFile}`;
+
+  let y = yargs(input)
     .locale("en")
     .exitProcess(!fromTest)
     .scriptName(`pnpm run ${options.scriptForUsage}`)
     .usage(
-      `${options.description}\n\nUsage:\n  pnpm run ${options.scriptForUsage} -- [path/to/file.csv] [options]\n  pnpm run ${options.scriptForUsage} -- --file <path> [options]\n\nDefault CSV:\n  ${options.defaultFile}`,
+      `${options.description}\n\nUsage:\n  pnpm run ${options.scriptForUsage} -- [path/to/file.csv] [options]\n  pnpm run ${options.scriptForUsage} -- --file <path> [options]\n\n${defaultFilesHelp}`,
     )
     .option("file", {
       type: "string",
@@ -173,10 +188,26 @@ export function parseLegacyImportCli(
       type: "number",
       requiresArg: true,
       describe: "Stop after reading n data rows from the CSV",
-    })
+    });
+
+  if (options.eventsProductionsDefault !== undefined) {
+    y = y.option("productions-file", {
+      type: "string",
+      describe: "Productions CSV path (Titel, Ondertitel, ID); overrides default for event dedupe",
+    });
+  }
+
+  const parsed = y
     .check((argv) => {
       if (argv.file !== undefined && String(argv.file).trim() === "") {
         throw new Error("Missing value for --file");
+      }
+      if (
+        argv["productionsFile"] !== undefined &&
+        options.eventsProductionsDefault !== undefined &&
+        String(argv["productionsFile"]).trim() === ""
+      ) {
+        throw new Error("Missing value for --productions-file");
       }
       if (argv.limit !== undefined) {
         const n = argv.limit;
@@ -205,6 +236,15 @@ export function parseLegacyImportCli(
 
   const dryRun = parsed.dryRun === true;
   const limit = parsed.limit === undefined ? null : parsed.limit;
+
+  if (options.eventsProductionsDefault !== undefined) {
+    const pfRaw = parsed["productionsFile"];
+    const productionsFilePath =
+      pfRaw !== undefined && String(pfRaw).trim() !== ""
+        ? path.resolve(process.cwd(), String(pfRaw))
+        : options.eventsProductionsDefault;
+    return { filePath, dryRun, limit, productionsFilePath };
+  }
 
   return { filePath, dryRun, limit };
 }

--- a/backend/test/legacy-import/import-events-legacy.test.ts
+++ b/backend/test/legacy-import/import-events-legacy.test.ts
@@ -493,10 +493,10 @@ describe("importEventsLegacy", () => {
       if (sql.includes("FROM legacy_production_import_map")) {
         return Promise.resolve({ rows: [{ legacy_id: "p9", production_id: 7 }] });
       }
-      if (sql.includes("name->>'nl' AS name") && sql.includes("FROM hall")) {
+      if (sql.includes("SELECT id, name FROM hall")) {
         return Promise.resolve({ rows: [] });
       }
-      if (sql.includes("WHERE lower(name->>'nl') = lower($1)")) {
+      if (sql.includes("jsonb_each_text(name)") && sql.includes("FROM hall")) {
         return Promise.resolve({ rows: [{ id: 10, address: null }] });
       }
       if (sql.includes("UPDATE hall SET address")) {

--- a/backend/test/legacy-import/import-events-legacy.test.ts
+++ b/backend/test/legacy-import/import-events-legacy.test.ts
@@ -7,6 +7,7 @@ import z from "zod";
 import { EventCreateSchema } from "@/routes/event/handlers/helper.js";
 import * as validate from "@/legacy-import/validate-legacy-inserts.js";
 import {
+  calendarDateBrussels,
   hallKey,
   importEventsLegacy,
   LEGACY_EVENT_IMPORT_SOURCE,
@@ -73,9 +74,37 @@ describe("hallKey", () => {
   });
 });
 
+describe("calendarDateBrussels", () => {
+  it("uses Europe/Brussels calendar date for UTC instant", () => {
+    const d = new Date("2024-06-01T22:00:00.000Z");
+    expect(calendarDateBrussels(d)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
 describe("importEventsLegacy", () => {
   const makeClient = (query: pg.Client["query"]) =>
     ({ query }) as unknown as pg.Client;
+
+  function writeProductionsCsv(dir: string, lines: string[]): string {
+    const p = path.join(dir, "productions.csv");
+    fs.writeFileSync(p, lines.join("\n"), "utf8");
+    return p;
+  }
+
+  /** Title/artist dedupe + Brussels calendar-day EXISTS (must run before other SQL branches in mocks). */
+  function handleProductionDedupeQueries(
+    sql: string,
+    listProductionRows: { id: number }[],
+    duplicateDayExists: boolean,
+  ): { rows: unknown[] } | undefined {
+    if (sql.includes("FROM production p") && sql.includes("ORDER BY p.id")) {
+      return { rows: listProductionRows };
+    }
+    if (sql.includes("unnest($1::date[])") && sql.includes("FROM event e")) {
+      return { rows: [{ exists: duplicateDayExists }] };
+    }
+    return undefined;
+  }
 
   beforeEach(() => {
     vi.spyOn(console, "log").mockImplementation(() => {});
@@ -88,16 +117,25 @@ describe("importEventsLegacy", () => {
 
   it("throws when legacy_production_import_map table is missing", async () => {
     const query = vi.fn().mockResolvedValue({ rows: [{ exists: null }] });
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-no-map-"));
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID", "X,p1"]);
+    fs.writeFileSync(path.join(dir, "e.csv"), "Starttime,Hall,Production\n", "utf8");
     await expect(
       importEventsLegacy(makeClient(query), {
-        filePath: "/tmp/x.csv",
+        filePath: path.join(dir, "e.csv"),
         dryRun: true,
         limit: null,
+        productionsFilePath: prodCsv,
       }),
     ).rejects.toThrow("legacy_production_import_map");
+    fs.rmSync(dir, { recursive: true });
   });
 
   it("throws when production map is empty", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-empty-map-"));
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID", "X,p1"]);
+    fs.writeFileSync(path.join(dir, "e.csv"), "Starttime,Hall,Production\n2024-01-01 10:00:00,Main,p1\n", "utf8");
+
     const query = vi.fn().mockImplementation((sql: string) => {
       if (sql.includes("to_regclass")) {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
@@ -110,16 +148,19 @@ describe("importEventsLegacy", () => {
 
     await expect(
       importEventsLegacy(makeClient(query), {
-        filePath: "/tmp/x.csv",
+        filePath: path.join(dir, "e.csv"),
         dryRun: true,
         limit: null,
+        productionsFilePath: prodCsv,
       }),
     ).rejects.toThrow("No production mappings");
+    fs.rmSync(dir, { recursive: true });
   });
 
   it("dry-run processes a valid row", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "My Show,p1,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Endtime,Hall,Production\n2024-01-01 10:00:00,,Main,p1\n",
@@ -131,8 +172,12 @@ describe("importEventsLegacy", () => {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p1", production_id: 1 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
+        });
       }
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
       if (sql.includes("FROM hall") && sql.includes("SELECT id")) {
         return Promise.resolve({ rows: [] });
       }
@@ -143,6 +188,7 @@ describe("importEventsLegacy", () => {
       filePath: csvPath,
       dryRun: true,
       limit: null,
+      productionsFilePath: prodCsv,
     });
 
     expect(query).toHaveBeenCalled();
@@ -152,6 +198,7 @@ describe("importEventsLegacy", () => {
   it("write mode inserts event and legacy map", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-w-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Zaaltje Show,p9,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Endtime,Hall,Production\n2024-02-01 20:00:00,,Zaaltje,p9\n",
@@ -159,6 +206,9 @@ describe("importEventsLegacy", () => {
     );
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 7 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("CREATE TABLE IF NOT EXISTS legacy_event_import_map")) {
         return Promise.resolve({ rows: [] });
       }
@@ -166,7 +216,9 @@ describe("importEventsLegacy", () => {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p9", production_id: 7 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p9", production_id: 7, created_new_production: false }],
+        });
       }
       if (sql.includes("FROM hall") && sql.includes("SELECT id") && !sql.includes("UPDATE")) {
         return Promise.resolve({ rows: [] });
@@ -193,6 +245,7 @@ describe("importEventsLegacy", () => {
       filePath: csvPath,
       dryRun: false,
       limit: null,
+      productionsFilePath: prodCsv,
     });
 
     expect(query.mock.calls.some((c) => String(c[0]).includes("INSERT INTO event"))).toBe(true);
@@ -202,6 +255,7 @@ describe("importEventsLegacy", () => {
   it("rolls back on failure inside transaction", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-fail-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Fail Show,p9,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Hall,Production\n2024-03-01 18:00:00,X,p9\n",
@@ -209,6 +263,9 @@ describe("importEventsLegacy", () => {
     );
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 7 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("CREATE TABLE IF NOT EXISTS legacy_event_import_map")) {
         return Promise.resolve({ rows: [] });
       }
@@ -216,7 +273,9 @@ describe("importEventsLegacy", () => {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p9", production_id: 7 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p9", production_id: 7, created_new_production: false }],
+        });
       }
       if (sql.includes("FROM hall") && sql.includes("SELECT id")) {
         return Promise.resolve({ rows: [{ id: 1, name: "X", address: "" }] });
@@ -236,6 +295,7 @@ describe("importEventsLegacy", () => {
       filePath: csvPath,
       dryRun: false,
       limit: null,
+      productionsFilePath: prodCsv,
     });
 
     expect(query.mock.calls.some((c) => String(c[0]).trimStart().startsWith("ROLLBACK"))).toBe(true);
@@ -245,15 +305,21 @@ describe("importEventsLegacy", () => {
   it("dry-run skips second row when duplicate legacy key in file", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-dup-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Dup,p1,"]);
     const line = "2024-01-01 10:00:00,,Main,p1\n";
     fs.writeFileSync(csvPath, `Starttime,Endtime,Hall,Production\n${line}${line}`, "utf8");
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("to_regclass")) {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p1", production_id: 1 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
+        });
       }
       if (sql.includes("FROM hall") && sql.includes("SELECT id")) {
         return Promise.resolve({ rows: [] });
@@ -261,7 +327,12 @@ describe("importEventsLegacy", () => {
       return Promise.resolve({ rows: [] });
     });
 
-    await importEventsLegacy(makeClient(query), { filePath: csvPath, dryRun: true, limit: null });
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: true,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
 
     fs.rmSync(dir, { recursive: true });
   });
@@ -269,6 +340,7 @@ describe("importEventsLegacy", () => {
   it("write mode skips row already in legacy_event_import_map", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-imp-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Imp,p1,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Endtime,Hall,Production\n2024-01-01 10:00:00,,Main,p1\n",
@@ -283,6 +355,9 @@ describe("importEventsLegacy", () => {
     });
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("CREATE TABLE IF NOT EXISTS legacy_event_import_map")) {
         return Promise.resolve({ rows: [] });
       }
@@ -290,7 +365,9 @@ describe("importEventsLegacy", () => {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p1", production_id: 1 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
+        });
       }
       if (sql.includes("name->>'nl' AS name") && sql.includes("FROM hall")) {
         return Promise.resolve({ rows: [] });
@@ -301,7 +378,12 @@ describe("importEventsLegacy", () => {
       return Promise.resolve({ rows: [] });
     });
 
-    await importEventsLegacy(makeClient(query), { filePath: csvPath, dryRun: false, limit: null });
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: false,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
 
     expect(
       query.mock.calls.some((c) => String(c[0]).includes("INSERT INTO event")),
@@ -313,6 +395,7 @@ describe("importEventsLegacy", () => {
   it("dry-run skips row with missing starttime", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Ms,p1,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Endtime,Hall,Production\n,,Main,p1\n",
@@ -320,16 +403,26 @@ describe("importEventsLegacy", () => {
     );
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("to_regclass")) {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p1", production_id: 1 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
+        });
       }
       return Promise.resolve({ rows: [] });
     });
 
-    await importEventsLegacy(makeClient(query), { filePath: csvPath, dryRun: true, limit: null });
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: true,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
 
     fs.rmSync(dir, { recursive: true });
   });
@@ -337,6 +430,7 @@ describe("importEventsLegacy", () => {
   it("dry-run skips row with missing hall", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Mh,p1,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Endtime,Hall,Production\n2024-01-01 10:00:00,,,p1\n",
@@ -344,16 +438,26 @@ describe("importEventsLegacy", () => {
     );
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("to_regclass")) {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p1", production_id: 1 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
+        });
       }
       return Promise.resolve({ rows: [] });
     });
 
-    await importEventsLegacy(makeClient(query), { filePath: csvPath, dryRun: true, limit: null });
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: true,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
 
     fs.rmSync(dir, { recursive: true });
   });
@@ -361,6 +465,7 @@ describe("importEventsLegacy", () => {
   it("dry-run skips row with missing production legacy id", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Mp,p1,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Endtime,Hall,Production\n2024-01-01 10:00:00,,Main,\n",
@@ -368,16 +473,26 @@ describe("importEventsLegacy", () => {
     );
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("to_regclass")) {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p1", production_id: 1 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
+        });
       }
       return Promise.resolve({ rows: [] });
     });
 
-    await importEventsLegacy(makeClient(query), { filePath: csvPath, dryRun: true, limit: null });
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: true,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
 
     fs.rmSync(dir, { recursive: true });
   });
@@ -385,6 +500,7 @@ describe("importEventsLegacy", () => {
   it("dry-run skips row when production mapping is unknown", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Unk,p1,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Endtime,Hall,Production\n2024-01-01 10:00:00,,Main,unknown\n",
@@ -392,16 +508,26 @@ describe("importEventsLegacy", () => {
     );
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("to_regclass")) {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p1", production_id: 1 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
+        });
       }
       return Promise.resolve({ rows: [] });
     });
 
-    await importEventsLegacy(makeClient(query), { filePath: csvPath, dryRun: true, limit: null });
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: true,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
 
     fs.rmSync(dir, { recursive: true });
   });
@@ -409,6 +535,7 @@ describe("importEventsLegacy", () => {
   it("dry-run skips row when hall insert schema rejects", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Hallrej,p1,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Endtime,Hall,Production\n2024-01-01 10:00:00,,Main,p1\n",
@@ -423,11 +550,16 @@ describe("importEventsLegacy", () => {
     );
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("to_regclass")) {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p1", production_id: 1 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
+        });
       }
       if (sql.includes("FROM hall") && sql.includes("SELECT id")) {
         return Promise.resolve({ rows: [] });
@@ -435,7 +567,12 @@ describe("importEventsLegacy", () => {
       return Promise.resolve({ rows: [] });
     });
 
-    await importEventsLegacy(makeClient(query), { filePath: csvPath, dryRun: true, limit: null });
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: true,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
 
     fs.rmSync(dir, { recursive: true });
   });
@@ -443,6 +580,7 @@ describe("importEventsLegacy", () => {
   it("dry-run skips row when event create schema rejects", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Evrej,p1,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Endtime,Hall,Production\n2024-01-01 10:00:00,,Main,p1\n",
@@ -457,11 +595,16 @@ describe("importEventsLegacy", () => {
     );
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("to_regclass")) {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p1", production_id: 1 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
+        });
       }
       if (sql.includes("FROM hall") && sql.includes("SELECT id")) {
         return Promise.resolve({ rows: [] });
@@ -469,7 +612,12 @@ describe("importEventsLegacy", () => {
       return Promise.resolve({ rows: [] });
     });
 
-    await importEventsLegacy(makeClient(query), { filePath: csvPath, dryRun: true, limit: null });
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: true,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
 
     fs.rmSync(dir, { recursive: true });
   });
@@ -477,6 +625,7 @@ describe("importEventsLegacy", () => {
   it("write mode updates hall address when existing hall has none", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-addr-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Addr,p9,"]);
     fs.writeFileSync(
       csvPath,
       "Starttime,Endtime,Hall,Production\n2024-05-01 19:00:00,,\"Theater, New Street 9\",p9\n",
@@ -484,6 +633,9 @@ describe("importEventsLegacy", () => {
     );
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 7 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("CREATE TABLE IF NOT EXISTS legacy_event_import_map")) {
         return Promise.resolve({ rows: [] });
       }
@@ -491,7 +643,9 @@ describe("importEventsLegacy", () => {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p9", production_id: 7 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p9", production_id: 7, created_new_production: false }],
+        });
       }
       if (sql.includes("SELECT id, name FROM hall")) {
         return Promise.resolve({ rows: [] });
@@ -517,7 +671,12 @@ describe("importEventsLegacy", () => {
       return Promise.resolve({ rows: [] });
     });
 
-    await importEventsLegacy(makeClient(query), { filePath: csvPath, dryRun: false, limit: null });
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: false,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
 
     expect(query.mock.calls.some((c) => String(c[0]).includes("UPDATE hall SET address"))).toBe(true);
     fs.rmSync(dir, { recursive: true });
@@ -526,6 +685,7 @@ describe("importEventsLegacy", () => {
   it("dry-run logs progress every progress interval", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-500-"));
     const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Prog,p1,"]);
     const lines = ["Starttime,Endtime,Hall,Production"];
     for (let i = 0; i < 500; i++) {
       lines.push(`2024-01-01 10:00:00,,Hall${i},p1`);
@@ -533,11 +693,16 @@ describe("importEventsLegacy", () => {
     fs.writeFileSync(csvPath, `${lines.join("\n")}\n`, "utf8");
 
     const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
       if (sql.includes("to_regclass")) {
         return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
       }
       if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({ rows: [{ legacy_id: "p1", production_id: 1 }] });
+        return Promise.resolve({
+          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
+        });
       }
       if (sql.includes("FROM hall") && sql.includes("SELECT id")) {
         return Promise.resolve({ rows: [] });
@@ -545,12 +710,63 @@ describe("importEventsLegacy", () => {
       return Promise.resolve({ rows: [] });
     });
 
-    await importEventsLegacy(makeClient(query), { filePath: csvPath, dryRun: true, limit: null });
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: true,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
 
     expect(query).toHaveBeenCalled();
-    expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining("Progress 500 rows"),
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Progress 500/500"));
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it("write mode skips events and deletes orphan production when calendar day matches API", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-fulldup-"));
+    const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Dup Show,leg1,"]);
+    fs.writeFileSync(
+      csvPath,
+      "Starttime,Endtime,Hall,Production\n2024-06-15 20:00:00,,Main,leg1\n",
+      "utf8",
     );
+
+    const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 5 }, { id: 99 }], true);
+      if (dedupe) return Promise.resolve(dedupe);
+
+      if (sql.includes("CREATE TABLE IF NOT EXISTS legacy_event_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("to_regclass")) {
+        return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
+      }
+      if (sql.includes("FROM legacy_production_import_map")) {
+        return Promise.resolve({
+          rows: [{ legacy_id: "leg1", production_id: 99, created_new_production: true }],
+        });
+      }
+      if (sql.includes("DELETE FROM production")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("SELECT legacy_key") && sql.includes("legacy_event_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: false,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
+
+    expect(query.mock.calls.some((c) => String(c[0]).includes("DELETE FROM production"))).toBe(true);
+    expect(
+      query.mock.calls.some((c) => String(c[0]).includes("INSERT INTO event")),
+    ).toBe(false);
     fs.rmSync(dir, { recursive: true });
   });
 });

--- a/backend/test/legacy-import/import-events-legacy.test.ts
+++ b/backend/test/legacy-import/import-events-legacy.test.ts
@@ -682,46 +682,6 @@ describe("importEventsLegacy", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
-  it("dry-run logs progress every progress interval", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-500-"));
-    const csvPath = path.join(dir, "e.csv");
-    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Prog,p1,"]);
-    const lines = ["Starttime,Endtime,Hall,Production"];
-    for (let i = 0; i < 500; i++) {
-      lines.push(`2024-01-01 10:00:00,,Hall${i},p1`);
-    }
-    fs.writeFileSync(csvPath, `${lines.join("\n")}\n`, "utf8");
-
-    const query = vi.fn().mockImplementation((sql: string) => {
-      const dedupe = handleProductionDedupeQueries(sql, [{ id: 1 }], false);
-      if (dedupe) return Promise.resolve(dedupe);
-
-      if (sql.includes("to_regclass")) {
-        return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
-      }
-      if (sql.includes("FROM legacy_production_import_map")) {
-        return Promise.resolve({
-          rows: [{ legacy_id: "p1", production_id: 1, created_new_production: false }],
-        });
-      }
-      if (sql.includes("FROM hall") && sql.includes("SELECT id")) {
-        return Promise.resolve({ rows: [] });
-      }
-      return Promise.resolve({ rows: [] });
-    });
-
-    await importEventsLegacy(makeClient(query), {
-      filePath: csvPath,
-      dryRun: true,
-      limit: null,
-      productionsFilePath: prodCsv,
-    });
-
-    expect(query).toHaveBeenCalled();
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Progress 500/500"));
-    fs.rmSync(dir, { recursive: true });
-  });
-
   it("write mode skips events and deletes orphan production when calendar day matches API", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-fulldup-"));
     const csvPath = path.join(dir, "e.csv");
@@ -767,6 +727,130 @@ describe("importEventsLegacy", () => {
     expect(
       query.mock.calls.some((c) => String(c[0]).includes("INSERT INTO event")),
     ).toBe(false);
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it("throws when default productions CSV path does not exist (no productionsFilePath)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-no-default-prod"));
+    const csvPath = path.join(dir, "e.csv");
+    fs.writeFileSync(csvPath, "Starttime,Hall,Production\n2024-01-01 10:00:00,Main,p1\n", "utf8");
+
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+
+    const query = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes("to_regclass")) {
+        return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await expect(
+      importEventsLegacy(makeClient(query), {
+        filePath: csvPath,
+        dryRun: true,
+        limit: null,
+      }),
+    ).rejects.toThrow("Productions CSV not found");
+
+    existsSpy.mockRestore();
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it("write mode counts failed row when orphan delete rejects", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-del-fail"));
+    const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "Dup2,leg2,"]);
+    fs.writeFileSync(
+      csvPath,
+      "Starttime,Endtime,Hall,Production\n2024-06-15 20:00:00,,Main,leg2\n",
+      "utf8",
+    );
+
+    const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 5 }, { id: 99 }], true);
+      if (dedupe) return Promise.resolve(dedupe);
+
+      if (sql.includes("CREATE TABLE IF NOT EXISTS legacy_event_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("to_regclass")) {
+        return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
+      }
+      if (sql.includes("FROM legacy_production_import_map")) {
+        return Promise.resolve({
+          rows: [{ legacy_id: "leg2", production_id: 99, created_new_production: true }],
+        });
+      }
+      if (sql.includes("DELETE FROM production")) {
+        return Promise.reject(new Error("fk or permission"));
+      }
+      if (sql.includes("SELECT legacy_key") && sql.includes("legacy_event_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: false,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
+
+    expect(query.mock.calls.some((c) => String(c[0]).includes("DELETE FROM production"))).toBe(true);
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it("write mode rolls back when hall insert returns no id", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-ev-hall-null"));
+    const csvPath = path.join(dir, "e.csv");
+    const prodCsv = writeProductionsCsv(dir, ["Titel,ID,Ondertitel", "HallNull,pz,"]);
+    fs.writeFileSync(
+      csvPath,
+      "Starttime,Endtime,Hall,Production\n2024-02-01 20:00:00,,Zaaltje,pz\n",
+      "utf8",
+    );
+
+    const query = vi.fn().mockImplementation((sql: string) => {
+      const dedupe = handleProductionDedupeQueries(sql, [{ id: 7 }], false);
+      if (dedupe) return Promise.resolve(dedupe);
+
+      if (sql.includes("CREATE TABLE IF NOT EXISTS legacy_event_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("to_regclass")) {
+        return Promise.resolve({ rows: [{ exists: "legacy_production_import_map" }] });
+      }
+      if (sql.includes("FROM legacy_production_import_map")) {
+        return Promise.resolve({
+          rows: [{ legacy_id: "pz", production_id: 7, created_new_production: false }],
+        });
+      }
+      if (sql.includes("FROM hall") && sql.includes("SELECT id") && !sql.includes("UPDATE")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("jsonb_each_text(name)") && sql.includes("FROM hall")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("SELECT legacy_key") && sql.includes("legacy_event_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.trimStart().startsWith("BEGIN")) return Promise.resolve({ rows: [] });
+      if (sql.trimStart().startsWith("ROLLBACK")) return Promise.resolve({ rows: [] });
+      if (sql.includes("INSERT INTO hall")) {
+        return Promise.resolve({ rows: [{ id: null as unknown as number }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await importEventsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: false,
+      limit: null,
+      productionsFilePath: prodCsv,
+    });
+
+    expect(query.mock.calls.some((c) => String(c[0]).trimStart().startsWith("ROLLBACK"))).toBe(true);
     fs.rmSync(dir, { recursive: true });
   });
 });

--- a/backend/test/legacy-import/import-productions-legacy.test.ts
+++ b/backend/test/legacy-import/import-productions-legacy.test.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import z from "zod";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type pg from "pg";
+import { CreateProductionBodySchema } from "@/routes/production/handlers/body-schema.js";
 import {
   genreKey,
   importProductionsLegacy,
@@ -438,6 +440,31 @@ describe("importProductionsLegacy", () => {
     });
 
     expect(query.mock.calls.some((c) => String(c[0]).includes("INSERT INTO tag_type"))).toBe(true);
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it("dry-run skips when production body validation fails", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-prod-zod-prod"));
+    const csvPath = path.join(dir, "p.csv");
+    fs.writeFileSync(csvPath, "Titel,ID\nBad,1\n", "utf8");
+
+    const failed = z.string().safeParse(1);
+    expect(failed.success).toBe(false);
+    if (failed.success) throw new Error("expected fail");
+    vi.spyOn(CreateProductionBodySchema, "safeParse").mockReturnValueOnce(
+      failed as unknown as ReturnType<typeof CreateProductionBodySchema.safeParse>,
+    );
+
+    const query = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes("FROM tag_type")) return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
+
+    await importProductionsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: true,
+      limit: null,
+    });
     fs.rmSync(dir, { recursive: true });
   });
 });

--- a/backend/test/legacy-import/import-productions-legacy.test.ts
+++ b/backend/test/legacy-import/import-productions-legacy.test.ts
@@ -127,6 +127,61 @@ describe("importProductionsLegacy", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  it("write mode inserts new production when multiple rows match title and artist (ambiguous)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-prod-amb-"));
+    const csvPath = path.join(dir, "p.csv");
+    fs.writeFileSync(csvPath, "Titel,Ondertitel,ID,Genre\nAmbiguous,A,900,Drama\n", "utf8");
+
+    const query = vi.fn().mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes("CREATE TABLE IF NOT EXISTS legacy_production_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("SELECT legacy_id") && sql.includes("legacy_production_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("FROM production p")) {
+        return Promise.resolve({ rows: [{ id: 10 }, { id: 11 }] });
+      }
+      if (sql.includes("FROM tag_type")) {
+        const name = params?.[0];
+        if (name === "Tag") return Promise.resolve({ rows: [{ id: 10 }] });
+        if (name === "Genre") return Promise.resolve({ rows: [{ id: 20 }] });
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("jsonb_each_text(name)")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("FROM tag") && sql.includes("jsonb_each_text(name)")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.trimStart().startsWith("BEGIN")) return Promise.resolve({ rows: [] });
+      if (sql.trimStart().startsWith("COMMIT")) return Promise.resolve({ rows: [] });
+      if (sql.trimStart().startsWith("ROLLBACK")) return Promise.resolve({ rows: [] });
+      if (sql.includes("INSERT INTO production")) {
+        return Promise.resolve({ rows: [{ id: 1001 }] });
+      }
+      if (sql.includes("INSERT INTO production_tag")) {
+        return Promise.resolve({ rowCount: 0, rows: [] });
+      }
+      if (sql.includes("INSERT INTO legacy_production_import_map")) {
+        expect(String(sql)).toContain("created_new_production");
+        expect(String(sql)).toContain("true");
+        expect(params).toEqual(["productions-output-csv", "900", 1001]);
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await importProductionsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: false,
+      limit: null,
+    });
+
+    expect(query.mock.calls.some((c) => String(c[0]).includes("INSERT INTO production"))).toBe(true);
+    fs.rmSync(dir, { recursive: true });
+  });
+
   it("write mode maps legacy id to existing production when title and artist match, without inserting production", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-prod-dedupe-"));
     const csvPath = path.join(dir, "p.csv");
@@ -152,6 +207,8 @@ describe("importProductionsLegacy", () => {
         return Promise.resolve({ rows: [] });
       }
       if (sql.includes("INSERT INTO legacy_production_import_map")) {
+        expect(String(sql)).toContain("false");
+        expect(params).toEqual(["productions-output-csv", "501", 777]);
         return Promise.resolve({ rows: [] });
       }
       return Promise.resolve({ rows: [] });
@@ -167,7 +224,7 @@ describe("importProductionsLegacy", () => {
     expect(prodInserts.length).toBe(0);
     const mapInsert = query.mock.calls.find((c) => String(c[0]).includes("INSERT INTO legacy_production_import_map"));
     expect(mapInsert).toBeDefined();
-    expect(mapInsert?.[1]).toEqual(expect.arrayContaining(["productions-output-csv", "501", 777]));
+    expect(mapInsert?.[1]).toEqual(["productions-output-csv", "501", 777]);
     fs.rmSync(dir, { recursive: true });
   });
 

--- a/backend/test/legacy-import/import-productions-legacy.test.ts
+++ b/backend/test/legacy-import/import-productions-legacy.test.ts
@@ -83,16 +83,19 @@ describe("importProductionsLegacy", () => {
       if (sql.includes("SELECT legacy_id") && sql.includes("legacy_production_import_map")) {
         return Promise.resolve({ rows: [] });
       }
+      if (sql.includes("FROM production p")) {
+        return Promise.resolve({ rows: [] });
+      }
       if (sql.includes("FROM tag_type")) {
         const name = params?.[0];
         if (name === "Tag") return Promise.resolve({ rows: [{ id: 10 }] });
         if (name === "Genre") return Promise.resolve({ rows: [{ id: 20 }] });
         return Promise.resolve({ rows: [] });
       }
-      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("lower(name")) {
+      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("jsonb_each_text(name)")) {
         return Promise.resolve({ rows: [] });
       }
-      if (sql.includes("FROM tag") && sql.includes("lower(name->>'nl')")) {
+      if (sql.includes("FROM tag") && sql.includes("jsonb_each_text(name)")) {
         return Promise.resolve({ rows: [] });
       }
       if (sql.trimStart().startsWith("INSERT INTO tag (")) {
@@ -124,6 +127,50 @@ describe("importProductionsLegacy", () => {
     fs.rmSync(dir, { recursive: true });
   });
 
+  it("write mode maps legacy id to existing production when title and artist match, without inserting production", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-prod-dedupe-"));
+    const csvPath = path.join(dir, "p.csv");
+    fs.writeFileSync(csvPath, "Titel,ID,Genre\nSame Show,501,Drama\n", "utf8");
+
+    const query = vi.fn().mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes("CREATE TABLE IF NOT EXISTS legacy_production_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("SELECT legacy_id") && sql.includes("legacy_production_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("FROM production p")) {
+        return Promise.resolve({ rows: [{ id: 777 }] });
+      }
+      if (sql.includes("FROM tag_type")) {
+        const name = params?.[0];
+        if (name === "Tag") return Promise.resolve({ rows: [{ id: 10 }] });
+        if (name === "Genre") return Promise.resolve({ rows: [{ id: 20 }] });
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("jsonb_each_text(name)")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("INSERT INTO legacy_production_import_map")) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await importProductionsLegacy(makeClient(query), {
+      filePath: csvPath,
+      dryRun: false,
+      limit: null,
+    });
+
+    const prodInserts = query.mock.calls.filter((c) => String(c[0]).includes("INSERT INTO production"));
+    expect(prodInserts.length).toBe(0);
+    const mapInsert = query.mock.calls.find((c) => String(c[0]).includes("INSERT INTO legacy_production_import_map"));
+    expect(mapInsert).toBeDefined();
+    expect(mapInsert?.[1]).toEqual(expect.arrayContaining(["productions-output-csv", "501", 777]));
+    fs.rmSync(dir, { recursive: true });
+  });
+
   it("rolls back and counts failed row on production insert error", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "legacy-prod-fail-"));
     const csvPath = path.join(dir, "p.csv");
@@ -136,13 +183,19 @@ describe("importProductionsLegacy", () => {
       if (sql.includes("SELECT legacy_id") && sql.includes("legacy_production_import_map")) {
         return Promise.resolve({ rows: [] });
       }
+      if (sql.includes("FROM production p")) {
+        return Promise.resolve({ rows: [] });
+      }
       if (sql.includes("FROM tag_type")) {
         const name = params?.[0];
         if (name === "Tag") return Promise.resolve({ rows: [{ id: 10 }] });
         if (name === "Genre") return Promise.resolve({ rows: [{ id: 20 }] });
         return Promise.resolve({ rows: [] });
       }
-      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("lower(name")) {
+      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("jsonb_each_text(name)")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("FROM tag") && sql.includes("jsonb_each_text(name)")) {
         return Promise.resolve({ rows: [] });
       }
       if (sql.trimStart().startsWith("BEGIN")) return Promise.resolve({ rows: [] });
@@ -236,13 +289,19 @@ describe("importProductionsLegacy", () => {
       if (sql.includes("SELECT legacy_id") && sql.includes("legacy_production_import_map")) {
         return Promise.resolve({ rows: [] });
       }
+      if (sql.includes("FROM production p")) {
+        return Promise.resolve({ rows: [] });
+      }
       if (sql.includes("FROM tag_type")) {
         const name = params?.[0];
         if (name === "Tag") return Promise.resolve({ rows: [{ id: 10 }] });
         if (name === "Genre") return Promise.resolve({ rows: [{ id: 20 }] });
         return Promise.resolve({ rows: [] });
       }
-      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("lower(name")) {
+      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("jsonb_each_text(name)")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("FROM tag") && sql.includes("jsonb_each_text(name)")) {
         return Promise.resolve({ rows: [] });
       }
       if (sql.trimStart().startsWith("BEGIN")) return Promise.resolve({ rows: [] });
@@ -294,7 +353,13 @@ describe("importProductionsLegacy", () => {
         const id = parsed.nl === "Tag" ? 10 : 20;
         return Promise.resolve({ rows: [{ id }] });
       }
-      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("lower(name")) {
+      if (sql.includes("FROM production p")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("FROM tag") && sql.includes("tag_type = $1") && !sql.includes("jsonb_each_text(name)")) {
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes("FROM tag") && sql.includes("jsonb_each_text(name)")) {
         return Promise.resolve({ rows: [] });
       }
       if (sql.trimStart().startsWith("BEGIN")) return Promise.resolve({ rows: [] });

--- a/backend/test/legacy-import/jsonb-name-match.test.ts
+++ b/backend/test/legacy-import/jsonb-name-match.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { indexLanguageMapValues } from "@/legacy-import/jsonb-name-match.js";
+
+describe("indexLanguageMapValues", () => {
+  it("indexes every non-empty string value with keyFn", () => {
+    const map = new Map<string, number>();
+    indexLanguageMapValues(map, 3, { nl: "A", en: "B", fr: "" }, (s) => s.toLowerCase());
+    expect(map.get("a")).toBe(3);
+    expect(map.get("b")).toBe(3);
+    expect(map.size).toBe(2);
+  });
+});

--- a/backend/test/legacy-import/shared.test.ts
+++ b/backend/test/legacy-import/shared.test.ts
@@ -279,6 +279,53 @@ describe("parseLegacyImportCli", () => {
   it("throws on unknown flag", () => {
     expect(() => parseLegacyImportCli(baseOptions, ["--nope"])).toThrow(/Unknown argument/);
   });
+
+  it("throws on unknown flag when events productions default is set", () => {
+    expect(() =>
+      parseLegacyImportCli(
+        { ...baseOptions, eventsProductionsDefault: "/default/prod.csv" },
+        ["--nope"],
+      ),
+    ).toThrow(/Unknown argument/);
+  });
+
+  it("events CLI: defaults productionsFilePath to eventsProductionsDefault", () => {
+    expect(
+      parseLegacyImportCli(
+        { ...baseOptions, eventsProductionsDefault: "/repo/data/imports/productions.csv" },
+        [],
+      ),
+    ).toEqual({
+      filePath: baseOptions.defaultFile,
+      dryRun: false,
+      limit: null,
+      productionsFilePath: "/repo/data/imports/productions.csv",
+    });
+  });
+
+  it("events CLI: --productions-file overrides default", () => {
+    const cwd = process.cwd();
+    expect(
+      parseLegacyImportCli(
+        { ...baseOptions, eventsProductionsDefault: "/default/prod.csv" },
+        ["--productions-file", "./other-prod.csv"],
+      ),
+    ).toEqual({
+      filePath: baseOptions.defaultFile,
+      dryRun: false,
+      limit: null,
+      productionsFilePath: path.resolve(cwd, "./other-prod.csv"),
+    });
+  });
+
+  it("throws when --productions-file is empty", () => {
+    expect(() =>
+      parseLegacyImportCli(
+        { ...baseOptions, eventsProductionsDefault: "/default/prod.csv" },
+        ["--productions-file", ""],
+      ),
+    ).toThrow("Missing value for --productions-file");
+  });
 });
 
 describe("assertCsvFileExists", () => {

--- a/data/imports/README.md
+++ b/data/imports/README.md
@@ -25,8 +25,9 @@ Place legacy CSV files for import scripts in this folder.
     - `ID`
     - `Planning ID`
 - **CLI entry:** `backend/scripts/import-events-legacy.ts` → `importEventsLegacy` in `src/legacy-import/import-events-legacy.ts`
-  - Default file: `data/imports/events.csv`
-  - Expected columns:
+  - Default **events** file: `data/imports/events.csv` (positional path or `--file` overrides this, same as productions).
+  - Default **productions** file (for title/artist + calendar-day dedupe): `data/imports/productions.csv`. Override with **`--productions-file <path>`** (resolved from the current working directory, usually `backend` when you `cd backend`). The events importer reads **`Titel`**, **`Ondertitel`**, and **`ID`** from this file so each legacy production id in the events CSV can be matched against the database the same way as the production import.
+  - Expected columns on the **events** CSV:
     - `Starttime`
     - `Endtime`
     - `Hall`
@@ -54,8 +55,9 @@ Events use `legacy_production_import_map` to resolve production foreign keys, so
 
 - Each row needs a non-empty **`ID`** (CSV column `ID`) as the **legacy production id**, and a non-empty **`Titel`**.
 - Duplicate **`ID`** in the same file is skipped; rows whose legacy id is **already in the idempotency map** for this import source are skipped.
-- If the database already has a production whose **`title`** and **`artist`** (CSV **`Titel`** / **`Ondertitel`**) match **any** language in the JSON `title` / `artist` columns (case-insensitive, trimmed) no new `production` row is inserted; only a **`legacy_production_import_map`** row is written so legacy ids still resolve for events. If **`Ondertitel`** is empty, “match” requires the existing row to have no non-empty **`artist`** text in any language.
-- Otherwise a new row is inserted into **`production`** (titles/descriptions mapped into the JSON `jsonb` language fields as Dutch `nl` where applicable).
+- The importer lists **all** database productions with the same **`title`** and **`artist`** rules as above (any language, case-insensitive; empty **`Ondertitel`** matches rows with no non-empty **`artist`** in any language).
+  - If **exactly one** such production exists, **no** new `production` row is inserted; only **`legacy_production_import_map`** is written (`created_new_production = false`).
+  - If **zero** or **more than one** match, a **new** `production` row is inserted and mapped (`created_new_production = true`) so recurring/ambiguous shows do not collapse onto a single API edition.
 
 **Genres → `tag` + `production_tag`**
 
@@ -77,6 +79,7 @@ Events use `legacy_production_import_map` to resolve production foreign keys, so
 
 - The table **`legacy_production_import_map` must exist** and must contain rows for **`source = productions-output-csv`**. Otherwise the script errors: run **productions** import in **write** mode first.
 - The script creates **`legacy_event_import_map`** if needed (same pattern as productions’ map).
+- A **productions** CSV must be available at the default path or via **`--productions-file`**. It should be the same export you used (or would use) for the production import, so **`ID`** / **`Titel`** / **`Ondertitel`** align with the events **`Production`** column. If this file is missing, the importer exits with an error before connecting to the database.
 
 **Row identity (idempotency)**
 
@@ -92,10 +95,11 @@ Events use `legacy_production_import_map` to resolve production foreign keys, so
 
 - The **`Production`** cell is the **legacy production id** (same value as productions CSV **`ID`**). It is **not** the numeric `production.id` in Postgres.
 - The script loads **`legacy_production_import_map`** for **`productions-output-csv`** into memory and maps that string → **`production_id`**. If there is no mapping, the row is skipped as an unknown production.
+- **Dedupe vs existing API data:** Rows are grouped by legacy production id. Using title/artist from the **productions** CSV and **`created_new_production`** on the map, the importer can skip an entire legacy production when a **Brussels calendar day** already exists on a matching API production, and it may **delete** an orphan **`production`** row that was only inserted for an ambiguous title/artist match. See `import-events-legacy.ts` for the exact rules.
 
 **Event row**
 
-- **`event.starts_at`** comes from **`Starttime`** (invalid / empty / sentinel datetimes are skipped). **`ends_at`** uses **`Endtime`** when valid, otherwise it defaults to **`starts_at`**. **`doors_at`** is set equal to **`starts_at`** for this import.
+- **`event.starts_at`** comes from **`Starttime`** (invalid / empty / sentinel datetimes are skipped). **`ends_at`** uses **`Endtime`** when valid, otherwise **`null`**. The legacy CSV has no doors column, so **`doors_at`** is **`null`**.
 - The new **`event`** references **`production`** and **`hall`** by the resolved ids above. On success, **`legacy_event_import_map`** stores **`(source, legacy_key, event_id)`**.
 
 ## Run Examples
@@ -110,6 +114,8 @@ Events use `legacy_production_import_map` to resolve production foreign keys, so
   - `cd backend && pnpm run import:events`
 - Event import with custom path:
   - `cd backend && pnpm run import:events -- "../data/imports/Events - voorstellingen.csv"`
+- Event import with a non-default **productions** path (e.g. your export is not named `productions.csv`):
+  - `cd backend && pnpm run import:events -- "../data/imports/Events - voorstellingen.csv" --productions-file "../data/imports/Productions - output.csv"`
 
 ### Optional flags
 
@@ -118,6 +124,10 @@ Both importers accept these flags (after `--` when using `pnpm run …`):
 - **`--dry-run`**: Parse the CSV and run validation / lookups only; **no rows are written** to the database (no `INSERT`/`UPDATE` for productions, events, halls, tags, or idempotency maps). Use this to check that the file path and column layout are correct before a real import.
 
 - **`--limit <n>`**: Stop after processing **the first _n_ data rows** from the CSV (rows are still read in file order). Useful for a quick smoke test on a huge file without importing everything. Omit this flag to import the full file.
+
+**Events importer only**
+
+- **`--productions-file <path>`**: Productions CSV used for **`Titel` / `Ondertitel` / `ID`** when classifying duplicate nights against the API. Defaults to **`data/imports/productions.csv`** relative to the **monorepo root** (same default as `import:productions`). Paths are resolved from the **current working directory** (typically `backend` if you `cd backend` first); use an absolute path or a correct relative path from there.
 
 Examples:
 
@@ -130,6 +140,9 @@ cd backend && pnpm run import:productions -- --limit 10
 
 # Combine: parse and validate 50 rows, but do not write
 cd backend && pnpm run import:events -- "../data/imports/events.csv" --dry-run --limit 50
+
+# Events: custom productions file + dry-run
+cd backend && pnpm run import:events -- "../data/imports/Events - voorstellingen.csv" --productions-file "../data/imports/Productions - output.csv" --dry-run
 ```
 
 ## Verification

--- a/data/imports/README.md
+++ b/data/imports/README.md
@@ -54,12 +54,13 @@ Events use `legacy_production_import_map` to resolve production foreign keys, so
 
 - Each row needs a non-empty **`ID`** (CSV column `ID`) as the **legacy production id**, and a non-empty **`Titel`**.
 - Duplicate **`ID`** in the same file is skipped; rows whose legacy id is **already in the idempotency map** for this import source are skipped.
-- A new row is inserted into **`production`** (titles/descriptions mapped into the JSON `jsonb` language fields as Dutch `nl` where applicable).
+- If the database already has a production whose **`title`** and **`artist`** (CSV **`Titel`** / **`Ondertitel`**) match **any** language in the JSON `title` / `artist` columns (case-insensitive, trimmed) no new `production` row is inserted; only a **`legacy_production_import_map`** row is written so legacy ids still resolve for events. If **`Ondertitel`** is empty, “match” requires the existing row to have no non-empty **`artist`** text in any language.
+- Otherwise a new row is inserted into **`production`** (titles/descriptions mapped into the JSON `jsonb` language fields as Dutch `nl` where applicable).
 
 **Genres → `tag` + `production_tag`**
 
 - The **`Genre`** column may list **several genres separated by commas**. Each part is trimmed and deduplicated.
-- For each genre name, the script looks for an existing **`tag`** with that **`name->>'nl'`** (case-insensitive) and **`tag_type`** = the Genre tag type.
+- For each genre name, the script looks for an existing **`tag`** with that name in **any** language field on **`name`** (case-insensitive) and **`tag_type`** = the Genre tag type.
   - If **found**, that tag id is reused.
   - If **not found**, a new **`tag`** is created (`tag_type` = Genre, `public` = true) and cached for the rest of the run.
 - Each production is linked with **`INSERT INTO production_tag (production, tag) … ON CONFLICT DO NOTHING`** so duplicate links are harmless.
@@ -84,7 +85,7 @@ Events use `legacy_production_import_map` to resolve production foreign keys, so
 **Halls**
 
 - **`Hall`** is parsed as **`name`** and optional **`address`**: if there is a comma, text before the first comma is the name and the rest is the address; otherwise the whole value is the name and address is empty.
-- Halls are matched by **`lower(name->>'nl')`**. If a hall exists, it is reused; if the CSV has a non-empty address and the DB row had an empty address, the address may be **updated**.
+- Halls are matched if the CSV hall name equals **any** language string on **`hall.name`** (case-insensitive). If a hall exists, it is reused; if the CSV has a non-empty address and the DB row had an empty address, the address may be **updated**.
 - If no hall exists, a new **`hall`** row is inserted (`name` as JSON `nl`, plain `address` column).
 
 **Link to production**


### PR DESCRIPTION
**Issue(s)**

____

**Description**

This pr is to improve the way legacy production imports happen, when the db is already populated with scraped data from the official api. For each row in the csv data files we now first check if there is a production present in the database that has the same title and artist, and if so, this production skipped and not inserted.

There is still a problem with this approach though. VIERNULVIER has a few recurring events, mostly raves etc., and some of them have hundreds of productions in the api/legacy data, like 'New Wave Classix' and 'Hindu Nights'. The problem is that the production title for these is always the same, and the artist too (empty most of the time), so by just matching on these two fields, a ton of productions are not added.

So, you would also need to  match on event dates, but that gets a little complicated, so I'm not sure what the best way is to handle that yet.

____

**Sources**