### PR TITLE
Feat/productions page improvements

### DIFF
--- a/backend/src/routes/production/handlers/fetch.ts
+++ b/backend/src/routes/production/handlers/fetch.ts
@@ -157,7 +157,7 @@ export type PaginatedProductions = {
  * - With `limit`: returns a page `{ items, total }` where `total` is the matching row count.
  * - Optional `search`: comma-separated terms (`search=a,b`), AND semantics (same encoding style
  *   as `tags`). Repeating the `search` key is still accepted for older clients.
- * - Optional `tags`: comma-separated tag IDs — production must include **every** tag.
+ * - Optional `tags`: comma-separated tag IDs — production must include at least one of these tags.
  * - Optional `yearMin` / `yearMax` (inclusive) — event year must fall in that span.
  * - Optional `from` / `to` (`YYYY-MM-DD`) — production must have an event in that range (venue TZ).
  * - Optional `old_id` — legacy id; when set, only `p.old_id` (same as staging; other filters ignored).

--- a/backend/src/routes/production/helpers/list-where.ts
+++ b/backend/src/routes/production/helpers/list-where.ts
@@ -61,12 +61,12 @@ export function buildProductionListWhere(
     params.push(pattern);
   }
 
-  for (const id of tagIds) {
+  if (tagIds.length > 0) {
     const idx = params.length + 1;
     parts.push(
-      `EXISTS (SELECT 1 FROM production_tag pt WHERE pt.production = p.id AND pt.tag = $${idx})`,
+      `EXISTS (SELECT 1 FROM production_tag pt WHERE pt.production = p.id AND pt.tag = ANY($${idx}::int[]))`,
     );
-    params.push(id);
+    params.push(tagIds);
   }
 
   if (yearRange !== undefined) {

--- a/backend/test/routes/production/helpers/list-where.test.ts
+++ b/backend/test/routes/production/helpers/list-where.test.ts
@@ -45,7 +45,7 @@ describe("buildProductionListWhere", () => {
     expect(r.whereSql).toContain("ILIKE $1");
   });
 
-  test("AND-merges search, tags, year span, and date span", () => {
+  test("AND-merges search, year span, and date span; tags match any id (OR)", () => {
     const r = buildProductionListWhere(
       ["ham"],
       [5, 7],
@@ -55,16 +55,15 @@ describe("buildProductionListWhere", () => {
     );
     expect(r.params).toEqual([
       "%ham%",
-      5,
-      7,
+      [5, 7],
       2015,
       2020,
       "2024-01-01",
       "2024-12-31",
     ]);
     expect(r.whereSql.startsWith(" WHERE ")).toBe(true);
-    // Inner EXISTS clauses also use "AND"; do not split naïvely on " AND ".
     expect(r.whereSql).toContain("production_tag pt");
+    expect(r.whereSql).toContain("ANY($2::int[])");
     expect(r.whereSql).toContain("EXTRACT(YEAR FROM");
     expect(r.whereSql).toContain("::date >=");
   });

--- a/frontend/src/utils/tagDisplay.ts
+++ b/frontend/src/utils/tagDisplay.ts
@@ -22,3 +22,12 @@ export function tagTypeIsGenre(tagType: TagType | undefined): boolean {
   }
   return false;
 }
+
+/** Genres first; order within each group follows the input (stable sort). */
+export function sortProductionTagChipsGenresFirst(
+  chips: readonly ProductionTagChip[],
+): ProductionTagChip[] {
+  return [...chips].sort(
+    (a, b) => Number(b.isGenre) - Number(a.isGenre),
+  );
+}

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -194,8 +194,8 @@
           <div
             v-if="
               filterBannerTagIds.length > 0 ||
-              filterBannerYearRange !== null ||
-              (filterBannerDateFrom && filterBannerDateTo)
+                filterBannerYearRange !== null ||
+                (filterBannerDateFrom && filterBannerDateTo)
             "
             class="mb-4 mt-4 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 gap-y-2 border-t border-surface-3 pt-5"
           >

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -401,7 +401,11 @@ import { ApiError } from "@/services/api";
 import { getProductions } from "@/services/productions";
 import { getTags, getTagTypes } from "@/services/tags";
 import { localizeOrEmpty } from "@/utils/i18n";
-import { tagTypeIsGenre, type ProductionTagChip } from "@/utils/tagDisplay";
+import {
+  sortProductionTagChipsGenresFirst,
+  tagTypeIsGenre,
+  type ProductionTagChip,
+} from "@/utils/tagDisplay";
 import {
   distinctHallNames,
   groupEventsByProductionId,
@@ -1264,6 +1268,6 @@ function tagChipsFor(production: ProductionWithBackwardsRefs): ProductionTagChip
       isGenre: tagTypeIsGenre(tagType),
     });
   }
-  return chips;
+  return sortProductionTagChipsGenresFirst(chips);
 }
 </script>

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -757,20 +757,21 @@ function productionsListArgs(page: number) {
 
 async function fetchProductionsPageData(page0: number) {
   const { items, total } = await getProductions(productionsListArgs(page0));
+  const ids = items.map((p) => p.id);
+  const eventsMap =
+    ids.length === 0
+      ? new Map<number, ProductionEvent[]>()
+      : groupEventsByProductionId(await getEventsForProductions(ids));
+
+  // Apply list + events together so cards never render with new productions but
+  // stale/empty per-production events (avoids layout shift on title vs date/hall lines).
   productions.value = items;
   totalCount.value = total;
   currentPage.value = page0;
   displayedFilteredTotal.value = hasActiveListFilters.value ? total : null;
   searchBannerTerms.value = [...appliedSearchTerms.value];
   syncFilterBannerFromApplied();
-
-  const ids = items.map((p) => p.id);
-  if (ids.length === 0) {
-    eventsByProduction.value = new Map();
-  } else {
-    const events = await getEventsForProductions(ids);
-    eventsByProduction.value = groupEventsByProductionId(events);
-  }
+  eventsByProduction.value = eventsMap;
 }
 
 function toggleTag(id: number) {

--- a/frontend/test/utils/tagDisplay.test.ts
+++ b/frontend/test/utils/tagDisplay.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type { TagType } from "@viernulvier/shared";
-import { tagTypeIsGenre } from "@/utils/tagDisplay";
+import {
+  sortProductionTagChipsGenresFirst,
+  tagTypeIsGenre,
+} from "@/utils/tagDisplay";
 
 describe("tagDisplay", () => {
   it("detects Genre from localized names", () => {
@@ -15,5 +18,15 @@ describe("tagDisplay", () => {
     );
     expect(tagTypeIsGenre(undefined)).toBe(false);
     expect(tagTypeIsGenre({ id: 1, name: {} } as TagType)).toBe(false);
+  });
+
+  it("sorts production tag chips with genres first", () => {
+    expect(
+      sortProductionTagChipsGenresFirst([
+        { tagId: 1, label: "Drama", isGenre: false },
+        { tagId: 2, label: "Theater", isGenre: true },
+        { tagId: 3, label: "Festival", isGenre: false },
+      ]).map((c) => c.tagId),
+    ).toEqual([2, 1, 3]);
   });
 });


### PR DESCRIPTION
**Issue(s)**

____

**Description**

Just some small improvements to the productions page

- avoid layout issues by waiting for events on the current page to be finished fetching, before production cards are shown
- all genres are shown first on the production cards
- tag filters are now OR instead of AND

____

**Sources**