### PR TITLE
Productions page loading placeholders

### DIFF
--- a/frontend/src/components/productions/ProductionListCard.vue
+++ b/frontend/src/components/productions/ProductionListCard.vue
@@ -5,7 +5,8 @@
       params: { lang: locale, id: production.id },
     }"
     class="production-list-card group -mx-3 flex items-stretch gap-4 border-b border-surface-3 px-3 py-8 transition-colors last:border-b-0 hover:bg-surface-1/60 sm:-mx-4 sm:gap-6 sm:px-4 md:-mx-5 md:gap-8 md:px-5"
-    :style="{ '--production-list-stagger': `${staggerDelayMs}ms` }"
+    :class="{ 'is-animated': animate }"
+    :style="animate ? { '--production-list-stagger': `${staggerDelayMs}ms` } : undefined"
   >
     <div
       class="relative h-28 w-24 shrink-0 overflow-hidden rounded-md bg-surface-2 sm:h-32 sm:w-28 md:h-36 md:w-32"
@@ -108,10 +109,13 @@ const props = withDefaults(
     dateSummary: ProductionDateSummary;
     tagChips: ProductionTagChip[];
     hallsText: string;
-    /** Used to stagger the row entrance animation on the productions list. */
     rowIndex?: number;
+    animate?: boolean;
   }>(),
-  { rowIndex: 0 },
+  {
+    rowIndex: 0,
+    animate: true,
+  },
 );
 
 const { t, locale } = useI18n();
@@ -130,7 +134,7 @@ const artist = computed(() =>
 </script>
 
 <style scoped>
-.production-list-card {
+.production-list-card.is-animated {
   animation: production-list-card-in 0.42s ease-out both;
   animation-delay: var(--production-list-stagger, 0ms);
 }

--- a/frontend/src/components/productions/ProductionListCardSkeleton.vue
+++ b/frontend/src/components/productions/ProductionListCardSkeleton.vue
@@ -1,0 +1,39 @@
+<template>
+  <div
+    class="group -mx-3 flex items-stretch gap-4 border-b border-surface-3 px-3 py-8 transition-colors last:border-b-0 sm:-mx-4 sm:gap-6 sm:px-4 md:-mx-5 md:gap-8 md:px-5 animate-pulse"
+  >
+    <!-- Image Placeholder -->
+    <div
+      class="h-28 w-24 shrink-0 rounded-md bg-surface-2 sm:h-32 sm:w-28 md:h-36 md:w-32"
+    />
+
+    <div class="relative flex min-h-0 min-w-0 flex-1 flex-col">
+      <!-- Date Placeholder -->
+      <div class="absolute right-0 top-0 flex flex-col items-end">
+        <div class="h-4 w-24 bg-surface-2 rounded mb-1"></div>
+        <div class="h-3 w-16 bg-surface-1 rounded"></div>
+      </div>
+
+      <div class="min-w-0">
+        <!-- Title Placeholder -->
+        <div class="h-7 w-1/2 bg-surface-2 rounded mb-2 md:h-8"></div>
+
+        <!-- Artist Placeholder -->
+        <div class="h-5 w-1/3 bg-surface-1 rounded mb-6"></div>
+
+        <!-- Hall Placeholder -->
+        <div class="flex items-center gap-2 mt-4">
+          <div class="size-4 rounded-full bg-surface-1"></div>
+          <div class="h-4 w-32 bg-surface-1 rounded"></div>
+        </div>
+      </div>
+
+      <!-- Tags Placeholder -->
+      <div class="mt-auto flex flex-wrap items-center gap-2 pt-4">
+        <div class="h-6 w-16 bg-surface-1 rounded-full"></div>
+        <div class="h-6 w-20 bg-surface-1 rounded-full"></div>
+        <div class="h-6 w-14 bg-surface-1 rounded-full"></div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -270,93 +270,96 @@
             {{ filteredResultsCountLabel }}
           </p>
 
-          <p
-            v-if="totalCount === 0 && !loading"
-            class="py-16 text-center text-sm text-ink-secondary"
+          <div 
+            class="production-list-wrapper transition-opacity duration-200"
+            :class="{ 'opacity-50 pointer-events-none': listLoading }"
           >
-            {{ emptyStateMessage }}
-          </p>
+          
+            <template v-if="(loading || listLoading) && productions.length === 0">
+              <ProductionListCardSkeleton v-for="i in 5" :key="i" />
+            </template>
 
-          <div v-else>
-            <div class="production-list-wrapper">
-              <template v-if="loading || listLoading">
-                <ProductionListCardSkeleton v-for="i in 5" :key="i" />
-              </template>
-    
-              <template v-else>
-                <ProductionListCard
-                  v-for="(p, idx) in productions"
-                  :key="`${currentPage}-${idx}-${p.id}`"
-                  :row-index="idx"
-                  :production="p"
-                  :date-summary="dateSummaryFor(p.id)"
-                  :tag-chips="tagChipsFor(p)"
-                  :halls-text="hallsTextFor(p.id)"
-                />
-              </template>
-            </div>
-
-            <nav
-              v-if="totalPages > 1"
-              class="mt-10 grid grid-cols-1 justify-items-center gap-y-6 border-t border-surface-3 pt-8 sm:grid-cols-[1fr_auto] sm:items-center sm:justify-items-start sm:gap-x-12 sm:gap-y-0"
-              aria-label="Pagination"
+            <p
+              v-else-if="!listLoading && totalCount === 0"
+              class="py-16 text-center text-sm text-ink-secondary"
             >
-              <p class="text-center text-sm text-ink-secondary sm:text-left">
-                {{
-                  t("productionsPage.showingRange", {
-                    from: rangeFrom,
-                    to: rangeTo,
-                    total: totalCount,
-                  })
-                }}
-              </p>
-              <div
-                class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 sm:justify-self-end"
-                role="group"
-                :aria-label="t('productionsPage.goToPage')"
-              >
-                <button
-                  type="button"
-                  class="cursor-pointer rounded-md border border-accent-outline bg-surface-0 px-3 py-1.5 text-sm font-medium text-ink-primary transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
-                  :disabled="currentPage <= 0 || listLoading"
-                  @click="goToPage(currentPage - 1)"
-                >
-                  {{ t("productionsPage.prevPage") }}
-                </button>
-                <div
-                  class="flex items-center gap-2 text-sm tabular-nums text-ink-secondary"
-                >
-                  <span class="whitespace-nowrap">{{
-                    t("productionsPage.pageWord")
-                  }}</span>
-                  <input
-                    :value="pageNumberInput"
-                    type="text"
-                    inputmode="numeric"
-                    autocomplete="off"
-                    maxlength="6"
-                    :disabled="listLoading"
-                    :aria-label="t('productionsPage.goToPage')"
-                    class="min-w-6 max-w-8 shrink-0 border-0 border-b border-surface-3 bg-transparent px-0 pb-px text-center text-sm tabular-nums text-ink-secondary focus:border-ink-primary focus:text-ink-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
-                    @input="onPageNumberInput"
-                    @keydown.enter.prevent="commitPageNumberInput"
-                    @blur="commitPageNumberInput"
-                  />
-                  <span class="whitespace-nowrap">{{
-                    t("productionsPage.pageOfTotal", { total: totalPages })
-                  }}</span>
-                </div>
-                <button
-                  type="button"
-                  class="cursor-pointer rounded-md border border-accent-outline bg-surface-0 px-3 py-1.5 text-sm font-medium text-ink-primary transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
-                  :disabled="currentPage >= totalPages - 1 || listLoading"
-                  @click="goToPage(currentPage + 1)"
-                >
-                  {{ t("productionsPage.nextPage") }}
-                </button>
-              </div>
-            </nav>
+              {{ emptyStateMessage }}
+            </p>
+
+            <template v-else>
+              <ProductionListCard
+                v-for="(p, idx) in productions"
+                :key="`${currentPage}-${idx}-${p.id}`"
+                :row-index="idx"
+                :production="p"
+                :date-summary="dateSummaryFor(p.id)"
+                :tag-chips="tagChipsFor(p)"
+                :halls-text="hallsTextFor(p.id)"
+              />
+            </template>
           </div>
+
+          <nav
+            v-if="totalPages > 1"
+            class="mt-10 grid grid-cols-1 justify-items-center gap-y-6 border-t border-surface-3 pt-8 sm:grid-cols-[1fr_auto] sm:items-center sm:justify-items-start sm:gap-x-12 sm:gap-y-0"
+            aria-label="Pagination"
+          >
+            <p class="text-center text-sm text-ink-secondary sm:text-left">
+              {{
+                t("productionsPage.showingRange", {
+                  from: rangeFrom,
+                  to: rangeTo,
+                  total: totalCount,
+                })
+              }}
+            </p>
+            <div
+              class="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 sm:justify-self-end"
+              role="group"
+              :aria-label="t('productionsPage.goToPage')"
+            >
+              <button
+                type="button"
+                class="cursor-pointer rounded-md border border-accent-outline bg-surface-0 px-3 py-1.5 text-sm font-medium text-ink-primary transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
+                :disabled="currentPage <= 0 || listLoading"
+                @click="goToPage(currentPage - 1)"
+              >
+                {{ t("productionsPage.prevPage") }}
+              </button>
+              <div
+                class="flex items-center gap-2 text-sm tabular-nums text-ink-secondary"
+              >
+                <span class="whitespace-nowrap">{{
+                  t("productionsPage.pageWord")
+                }}</span>
+                <input
+                  :value="pageNumberInput"
+                  type="text"
+                  inputmode="numeric"
+                  autocomplete="off"
+                  maxlength="6"
+                  :disabled="listLoading"
+                  :aria-label="t('productionsPage.goToPage')"
+                  class="min-w-6 max-w-8 shrink-0 border-0 border-b border-surface-3 bg-transparent px-0 pb-px text-center text-sm tabular-nums text-ink-secondary focus:border-ink-primary focus:text-ink-primary focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+                  @input="onPageNumberInput"
+                  @keydown.enter.prevent="commitPageNumberInput"
+                  @blur="commitPageNumberInput"
+                />
+                <span class="whitespace-nowrap">{{
+                  t("productionsPage.pageOfTotal", { total: totalPages })
+                }}</span>
+              </div>
+              <button
+                type="button"
+                class="cursor-pointer rounded-md border border-accent-outline bg-surface-0 px-3 py-1.5 text-sm font-medium text-ink-primary transition hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
+                :disabled="currentPage >= totalPages - 1 || listLoading"
+                @click="goToPage(currentPage + 1)"
+              >
+                {{ t("productionsPage.nextPage") }}
+              </button>
+            </div>
+          </nav>
+
         </div>
       </section>
     </main>

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -271,7 +271,7 @@
           </p>
 
           <p
-            v-else-if="totalCount === 0 && !loading"
+            v-if="totalCount === 0 && !loading"
             class="py-16 text-center text-sm text-ink-secondary"
           >
             {{ emptyStateMessage }}

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -986,7 +986,7 @@ async function commitPageNumberInput() {
     return;
   }
 
-  pageTopAnchor.value?.scrollIntoView({ behavior: "smooth", block: "start" });
+  scrollProductionsPageToTop();
 
   await goToPage(pageOneBased - 1);
   pageNumberInput.value = String(currentPage.value + 1);
@@ -1230,10 +1230,7 @@ watch(
 async function goToPage(page: number) {
   if (page < 0 || page >= totalPages.value) return;
 
-  const el = pageTopAnchor.value;
-  if (el) {
-    el.scrollIntoView({ behavior: "smooth", block: "start" });
-  }
+  scrollProductionsPageToTop();
 
   listLoading.value = true;
   beginListAttempt();

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -21,7 +21,7 @@
       </section>
 
       <section class="mx-auto max-w-4xl px-6 pb-20 pt-8 lg:px-10">
-        <div v-if="!loading" class="mb-4 space-y-3">
+        <div class="mb-4 space-y-3">
           <div
             class="flex flex-col gap-2 pb-0.5 sm:flex-row sm:items-stretch sm:gap-3"
           >
@@ -257,12 +257,6 @@
           {{ loadErrorDetail ?? t("productionsPage.error") }}
         </p>
 
-        <p
-          v-else-if="loading"
-          class="py-16 text-center text-sm text-ink-secondary"
-        >
-          {{ t("productionsPage.loading") }}
-        </p>
 
         <div v-else>
           <p
@@ -277,28 +271,30 @@
           </p>
 
           <p
-            v-if="totalCount === 0 && listLoading"
-            class="py-16 text-center text-sm text-ink-secondary"
-          >
-            {{ t("productionsPage.loading") }}
-          </p>
-          <p
-            v-else-if="totalCount === 0"
+            v-else-if="totalCount === 0 && !loading"
             class="py-16 text-center text-sm text-ink-secondary"
           >
             {{ emptyStateMessage }}
           </p>
 
           <div v-else>
-            <ProductionListCard
-              v-for="(p, idx) in productions"
-              :key="`${currentPage}-${idx}-${p.id}`"
-              :row-index="idx"
-              :production="p"
-              :date-summary="dateSummaryFor(p.id)"
-              :tag-chips="tagChipsFor(p)"
-              :halls-text="hallsTextFor(p.id)"
-            />
+            <div class="production-list-wrapper">
+              <template v-if="loading || listLoading">
+                <ProductionListCardSkeleton v-for="i in 5" :key="i" />
+              </template>
+    
+              <template v-else>
+                <ProductionListCard
+                  v-for="(p, idx) in productions"
+                  :key="`${currentPage}-${idx}-${p.id}`"
+                  :row-index="idx"
+                  :production="p"
+                  :date-summary="dateSummaryFor(p.id)"
+                  :tag-chips="tagChipsFor(p)"
+                  :halls-text="hallsTextFor(p.id)"
+                />
+              </template>
+            </div>
 
             <nav
               v-if="totalPages > 1"
@@ -393,6 +389,7 @@ import {
 import AppFooter from "@/components/AppFooter.vue";
 import AppNavbar from "@/components/AppNavbar.vue";
 import ProductionListCard from "@/components/productions/ProductionListCard.vue";
+import ProductionListCardSkeleton from "@/components/productions/ProductionListCardSkeleton.vue";
 import ProductionsDateFilter from "@/components/productions/ProductionsDateFilter.vue";
 import { useDarkMode } from "@/composables/useDarkMode";
 import { i18n, type SupportedLang } from "@/i18n";
@@ -989,6 +986,8 @@ async function commitPageNumberInput() {
     return;
   }
 
+  pageTopAnchor.value?.scrollIntoView({ behavior: "smooth", block: "start" });
+
   await goToPage(pageOneBased - 1);
   pageNumberInput.value = String(currentPage.value + 1);
 }
@@ -1230,12 +1229,17 @@ watch(
 
 async function goToPage(page: number) {
   if (page < 0 || page >= totalPages.value) return;
+
+  const el = pageTopAnchor.value;
+  if (el) {
+    el.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
   listLoading.value = true;
   beginListAttempt();
   try {
     await fetchProductionsPageData(page);
     await replaceRouteForPage0(page);
-    scrollAfterPageChange();
   } catch (err) {
     failListAttempt(err);
   } finally {

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -295,6 +295,7 @@
                 :date-summary="dateSummaryFor(p.id)"
                 :tag-chips="tagChipsFor(p)"
                 :halls-text="hallsTextFor(p.id)"
+                :animate="false"
               />
             </template>
           </div>

--- a/frontend/test/views/ProductionsView.test.ts
+++ b/frontend/test/views/ProductionsView.test.ts
@@ -176,7 +176,7 @@ describe("ProductionsView.vue", () => {
     wrapper.unmount();
   });
 
-  it("shows loading then empty state when the API returns no productions", async () => {
+  it("shows skeleton state then empty state when the API returns no productions", async () => {
     let finishFetch!: (value: ProductionListPage) => void;
     const deferred = new Promise<ProductionListPage>((resolve) => {
       finishFetch = resolve;
@@ -193,12 +193,14 @@ describe("ProductionsView.vue", () => {
     });
 
     await nextTick();
-    expect(wrapper.text()).toContain("laden");
+    
+    expect(wrapper.find(".animate-pulse").exists()).toBe(true);
 
     finishFetch({ items: [], total: 0 });
     await flushPromises();
 
     expect(wrapper.text()).toContain("nog geen producties");
+    
     wrapper.unmount();
     document.body.innerHTML = "";
   });


### PR DESCRIPTION
**Issue(s)**

Closes #299 

____

**Description**

I created pulsing placeholders (skeleton states) for the production cards that are shown while the productions are loading. There is still a layout shift caused by the filters being fetched. A skeleton state could also be implemented for this but I haven’t done that yet since we are still planning to adjust the filter layout anyway.
I’ll create an issue for the filter layout update and the corresponding skeleton state.

The skeleton state is only used on the initial page load. For filter changes skeletons caused too much flicker so I switched to a lighter loading state where existing productions are slightly faded to indicate new data is loading without a disruptive visual change.
____

**Sources**

<!-- If applicable, add sources (e.g. links, screenshots ...) to show your work. -->
