### PR TITLE
footer fixes

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex min-h-screen flex-col bg-surface-0">
     <AppNavbar :is-dark="isDark" @toggle-dark="toggleDark" />
-    <main>
+    <main class="flex-1">
       <HeroSection />
       <StatsSection />
       <BentoGrid />

--- a/frontend/src/views/ProductionDetailView.vue
+++ b/frontend/src/views/ProductionDetailView.vue
@@ -36,7 +36,7 @@
       </template>
     </main>
 
-    <AppFooter />
+    <AppFooter v-if="!loading" />
   </div>
 </template>
 

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -364,7 +364,7 @@
         </div>
       </section>
     </main>
-    <AppFooter />
+    <AppFooter v-if="!loading" />
   </div>
 </template>
 

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex min-h-screen flex-col bg-surface-0">
     <AppNavbar :is-dark="isDark" @toggle-dark="toggleDark" />
-    <main>
+    <main class="flex-1">
       <section
         ref="pageTopAnchor"
         class="scroll-mt-16 border-b border-surface-3 bg-surface-1 py-12 md:py-16"


### PR DESCRIPTION
**Issue(s)**

Closes #334, #393 

____

**Description**

- applied `class="flex-1"` in missing places so footer can't show somewhere else than the bottom of the screen
- footer is now hidden while loading

When loading the productions page or a detail page among others, the footer was shown for a split second during the loading. This layout change looks a bit weird. While it is technically possible that the content of the loading page really is less that 1 'screen' long, in which case you would actually want the footer to show, this is basically never the case. So, the footer is now not shown at all while a page is loading.

The other option to handle this layout shift would be to use skeleton content while loading the actual content. This way, the footer would be present during the loading without causing a layout shift. This can be quite some work though, and also needs to be done for every view. If we find time to add this it could look more professional, and make for better perceived performance, but I think that for now this very cheap fix will do.

It's also important to mention that the footer should only be hidden during the initial load, not for every refresh, because than the footer could cause layout shifts for small refetches. 

This change should also be applied to the blogpost page when it's made.


Edit:
It appears Trixie is already working on skeletons for the productions page.

____

**Sources**