### PR TITLE
fix: docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM node:24 AS base
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10.30.3
 
 WORKDIR /app
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=deps /app /app
 
 COPY . .
 
-RUN pnpm install --ignore-scripts
+RUN pnpm install
 RUN pnpm --filter frontend build
 
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM node:24 AS base
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10.30.3
 WORKDIR /app
 
 
@@ -20,7 +20,7 @@ COPY --from=deps /app /app
 
 COPY . .
 
-RUN pnpm install
+RUN pnpm install --ignore-scripts
 RUN pnpm --filter frontend build
 
 


### PR DESCRIPTION
**Issue(s)**

<!-- List the issue(s) for this PR here. -->

____

**Description**

The docker build in the staging branch was failing. I fixed it by pinning the `pnpm` version in the `Dockerfile`s and `adding --ignore-scripts` to the frontend `Dockerfile`.

I tested it locally by running these 2 commands:

```sh
# backend
docker buildx build --file ./backend/Dockerfile --platform linux/amd64 .

# frontend
docker buildx build --file ./frontend/Dockerfile --platform linux/amd64 .
```
____

**Sources**

<!-- If applicable, add sources (e.g. links, screenshots ...) to show your work. -->
