### PR TITLE
fix(production-detail): scope drop-cap to direct first child

### DIFF
--- a/frontend/src/components/production/DetailsSection.vue
+++ b/frontend/src/components/production/DetailsSection.vue
@@ -243,16 +243,19 @@ const mainContentClass = computed(() => {
 }
 
 /*
- * Drop cap on the lead paragraph. We target the first letter of the first
- * child element because v-html wraps the description in a <p>, so plain
- * `.article-lead::first-letter` would otherwise miss it.
+ * Drop cap on the lead paragraph. The `> :first-child` variant covers the
+ * case where v-html wraps the description in a <p>; the bare selector
+ * covers plain-text content. Using a direct-child combinator (not a
+ * descendant selector) is essential — otherwise every element that
+ * happens to be a first child (e.g. an <a> that is the only child of its
+ * parent <p>) would also get a drop cap.
  *
  * Modern browsers (Safari, Chrome 110+) honour `initial-letter`, which
  * sizes the cap so it spans exactly N body lines AND aligns the cap's
  * top to the first line's top and its baseline to the Nth line's baseline.
  * Older browsers fall back to a float-based cap.
  */
-.article-lead :first-child::first-letter,
+.article-lead > :first-child::first-letter,
 .article-lead::first-letter {
   font-family: var(--font-serif);
   font-weight: 700;
@@ -263,7 +266,7 @@ const mainContentClass = computed(() => {
 }
 
 @supports not ((initial-letter: 3) or (-webkit-initial-letter: 3)) {
-  .article-lead :first-child::first-letter,
+  .article-lead > :first-child::first-letter,
   .article-lead::first-letter {
     float: left;
     font-size: 4.8em;


### PR DESCRIPTION
**Issue(s)**

https://github.com/SELab-2/viernulvier-1/issues/425

____

**Description**

The `.article-lead :first-child::first-letter` descendant selector matched any element that happened to be a first child inside the lead container, including an `<a>` that is the only child of a following `<p>`. This caused a second drop cap to appear (e.g. the "K" of "Klik hier..."). Use a direct-child combinator so only the lead's first direct child is targeted.

____

**Sources**

N/A
