### PR TITLE
Batch operation for fetching productions media

### DIFF
--- a/backend/src/routes/media/handlers/fetch.ts
+++ b/backend/src/routes/media/handlers/fetch.ts
@@ -190,7 +190,7 @@ export async function fetchImagesByProduction(
     [productionId],
   );
   const images = parseSchema(server, z.array(ImageSchema), imgResult.rows, ParseContext.Database);
-  return attachCropsToImages(server, images);
+  return await attachCropsToImages(server, images);
 }
 
 const MAX_BATCH_PRODUCTION_IMAGE_IDS = 50;
@@ -233,8 +233,7 @@ export async function fetchImagesByProductionIdsBatch(
   const query = request.query as Record<string, unknown> | undefined;
   const ids = parseCommaSeparatedProductionIds(query?.["ids"]);
 
-  const byProductionId: Record<string, (Image & { crops: Crop[] })[]> = {};
-  if (ids.length === 0) return { byProductionId };
+  if (ids.length === 0) return { byProductionId: {} };
 
   const imgResult = await server.pg.query(
     `${ImageSelect} WHERE i.production = ANY($1::int[]) ORDER BY i.production ASC, i.id ASC`,
@@ -255,10 +254,14 @@ export async function fetchImagesByProductionIdsBatch(
     list.push(img);
   }
 
-  for (const id of ids) {
-    const key = String(id);
-    byProductionId[key] = grouped.get(id) ?? [];
-  }
+  const byProductionId: Record<string, (Image & { crops: Crop[] })[]> = Object.fromEntries(
+    ids.map(
+      (id): [string, (Image & { crops: Crop[] })[]] => [
+        String(id),
+        grouped.get(id) ?? [],
+      ],
+    ),
+  );
 
   return { byProductionId };
 }

--- a/backend/src/routes/media/handlers/fetch.ts
+++ b/backend/src/routes/media/handlers/fetch.ts
@@ -182,7 +182,7 @@ export async function getCropById(
 export async function fetchImagesByProduction(
   server: FastifyInstance,
   request: FastifyRequest,
-): Promise<(Image & { crops: Crop[] })[] | null> {
+): Promise<(Image & { crops: Crop[] })[]> {
   const { productionId } = parseParams(request, z.object({ productionId: stringToInt }));
 
   const imgResult = await server.pg.query(
@@ -190,28 +190,77 @@ export async function fetchImagesByProduction(
     [productionId],
   );
   const images = parseSchema(server, z.array(ImageSchema), imgResult.rows, ParseContext.Database);
+  return attachCropsToImages(server, images);
+}
 
-  if (images.length === 0) return [];
+const MAX_BATCH_PRODUCTION_IMAGE_IDS = 50;
 
-  const imageIds = images.map((img) => img.id);
-  const cropsResult = await server.pg.query(
-    `${CropSelect} WHERE c.image = ANY($1::int[]) ORDER BY c.image ASC, c.id ASC`,
-    [imageIds],
+function parseCommaSeparatedProductionIds(idsParam: unknown): number[] {
+  const raw =
+    idsParam === undefined || idsParam === null
+      ? ""
+      : Array.isArray(idsParam)
+        ? idsParam.filter((x): x is string => typeof x === "string").join(",")
+        : String(idsParam);
+
+  const out: number[] = [];
+  const seen = new Set<number>();
+  for (const part of raw.split(",")) {
+    const trimmed = part.trim();
+    if (trimmed.length === 0) continue;
+
+    const n = Number.parseInt(trimmed, 10);
+    if (trimmed !== String(n) || Number.isNaN(n) || n < 1 || n > 2_147_483_647) continue;
+    if (seen.has(n)) continue;
+
+    seen.add(n);
+    out.push(n);
+    if (out.length >= MAX_BATCH_PRODUCTION_IMAGE_IDS) break;
+  }
+  return out;
+}
+
+/**
+ * GET /api/v1/production/images?ids=1,2,3
+ *
+ * Fetches images with crops for many productions in one query. Response maps
+ * every requested id (string key) to an array (possibly empty).
+ */
+export async function fetchImagesByProductionIdsBatch(
+  server: FastifyInstance,
+  request: FastifyRequest,
+): Promise<{ byProductionId: Record<string, (Image & { crops: Crop[] })[]> }> {
+  const query = request.query as Record<string, unknown> | undefined;
+  const ids = parseCommaSeparatedProductionIds(query?.["ids"]);
+
+  const byProductionId: Record<string, (Image & { crops: Crop[] })[]> = {};
+  if (ids.length === 0) return { byProductionId };
+
+  const imgResult = await server.pg.query(
+    `${ImageSelect} WHERE i.production = ANY($1::int[]) ORDER BY i.production ASC, i.id ASC`,
+    [ids],
   );
-  const allCrops = parseSchema(server, z.array(CropSchema), cropsResult.rows, ParseContext.Database);
 
-  const cropsByImage = new Map<number, Crop[]>();
-  for (const crop of allCrops) {
-    const imageId = crop.image as number;
-    const list = cropsByImage.get(imageId) ?? [];
-    list.push(crop);
-    cropsByImage.set(imageId, list);
+  const images = parseSchema(server, z.array(ImageSchema), imgResult.rows, ParseContext.Database);
+  const withCrops = await attachCropsToImages(server, images);
+
+  const grouped = new Map<number, (Image & { crops: Crop[] })[]>();
+  for (const img of withCrops) {
+    const prodId = img.production as number;
+    let list = grouped.get(prodId);
+    if (list === undefined) {
+      list = [];
+      grouped.set(prodId, list);
+    }
+    list.push(img);
   }
 
-  return images.map((img) => ({
-    ...img,
-    crops: cropsByImage.get(img.id) ?? [],
-  }));
+  for (const id of ids) {
+    const key = String(id);
+    byProductionId[key] = grouped.get(id) ?? [];
+  }
+
+  return { byProductionId };
 }
 
 /**

--- a/backend/src/routes/media/handlers/index.ts
+++ b/backend/src/routes/media/handlers/index.ts
@@ -1,5 +1,6 @@
 export {
   fetchImagesByProduction,
+  fetchImagesByProductionIdsBatch,
   fetchImage,
   fetchAllImages,
   fetchImageWithMeta,

--- a/backend/src/routes/media/media.ts
+++ b/backend/src/routes/media/media.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { replyHandler } from "@/routes/helpers.js";
 import {
   fetchImagesByProduction,
+  fetchImagesByProductionIdsBatch,
   fetchImage,
   fetchAllImages,
   fetchImageWithMeta,
@@ -23,9 +24,10 @@ import cropProxyRoute from "./proxy.js";
  *
  * @remarks
  * **Images**
- * - `GET    /api/v1/production/:productionId/image`  — list images (with crops) for a production
+ * - `GET    /api/v1/production/images`                — batch list images by production ids (`?ids=1,2`)
+ * - `GET    /api/v1/production/:productionId/image`   — list images (with crops) for a production
  * - `GET    /api/v1/image/:id`                        — single image with its crops
- * - `GET    /api/v1/image`                           — list images with crops
+ * - `GET    /api/v1/image`                            — list images with crops
  * - `GET    /api/v1/image/:id/meta`                   — single image with metadata 🔒
  * - `POST   /api/v1/production/:productionId/image`   — create image (+ oneshot crops via multipart) 🔒
  * - `PATCH  /api/v1/image/:id`                        — edit image metadata 🔒
@@ -46,6 +48,7 @@ export default function mediaRoutes(server: FastifyInstance) {
   const protect = { preHandler: [server.authorize()] };
 
   // ── Images ──
+  server.get("/api/v1/production/images", replyHandler(server, fetchImagesByProductionIdsBatch));
   server.get("/api/v1/production/:productionId/image", replyHandler(server, fetchImagesByProduction));
   server.get("/api/v1/image/:id", replyHandler(server, fetchImage));
   server.get("/api/v1/image/:id/meta", protect, replyHandler(server, fetchImageWithMeta));

--- a/backend/src/routes/registerRoutes.ts
+++ b/backend/src/routes/registerRoutes.ts
@@ -16,6 +16,8 @@ import blogPostRoutes from "./blogpost/blogpost.js";
  * @param server - The Fastify instance to register routes on.
  */
 export default async function registerRoutes(server: FastifyInstance) {
+  // Media before production: `GET /api/v1/production/images` must not be
+  // captured by `GET /api/v1/production/:id` (which would treat "images" as an id).
   await server.register(mediaRoutes);
   await server.register(productionRoutes);
   await server.register(authRoutes);

--- a/backend/src/routes/registerRoutes.ts
+++ b/backend/src/routes/registerRoutes.ts
@@ -16,6 +16,7 @@ import blogPostRoutes from "./blogpost/blogpost.js";
  * @param server - The Fastify instance to register routes on.
  */
 export default async function registerRoutes(server: FastifyInstance) {
+  await server.register(mediaRoutes);
   await server.register(productionRoutes);
   await server.register(authRoutes);
   await server.register(eventRoutes);
@@ -24,6 +25,5 @@ export default async function registerRoutes(server: FastifyInstance) {
   await server.register(tagTypeRoutes);
   await server.register(hallRoutes);
   await server.register(blogRoutes);
-  await server.register(mediaRoutes);
   await server.register(blogPostRoutes);
 }

--- a/backend/test/routes/media/fetch.test.ts
+++ b/backend/test/routes/media/fetch.test.ts
@@ -10,7 +10,7 @@ import {
   MOCK_META,
   imageWithCrops,
 } from "./fixtures.js";
-import { getImageByOldId } from "@/routes/media/handlers/fetch.js";
+import { getCropById, getImageByOldId } from "@/routes/media/handlers/fetch.js";
 
 let server: FastifyInstance;
 let sessionCookie: string;
@@ -83,6 +83,18 @@ beforeAll(async () => {
       });
     }
 
+    // ── Images by productions (batch, ANY array) ──
+    if (upper.includes("FROM IMAGE I") && upper.includes("I.PRODUCTION = ANY($1::INT[])")) {
+      const prodIds = params?.[0] as number[];
+      const want = new Set(prodIds);
+      const rows = [MOCK_IMAGE_1, MOCK_IMAGE_2]
+        .filter((i) => want.has(i.production))
+        .sort((a, b) =>
+          a.production !== b.production ? a.production - b.production : a.id - b.id,
+        );
+      return Promise.resolve({ rows, rowCount: rows.length });
+    }
+
     // ── Images by production ──
     if (upper.includes("FROM IMAGE I") && upper.includes("WHERE I.PRODUCTION = \$1")) {
       const prodId = Number(params?.[0]);
@@ -99,6 +111,16 @@ beforeAll(async () => {
         ids.includes(c.image),
       );
       return Promise.resolve({ rows: crops, rowCount: crops.length });
+    }
+
+    // ── Crop by primary key id ──
+    if (upper.includes("FROM CROP C") && upper.includes("WHERE C.ID = \$1")) {
+      const cropId = Number(params?.[0]);
+      const crop = [MOCK_CROP_1, MOCK_CROP_2, MOCK_CROP_3].find((c) => c.id === cropId);
+      return Promise.resolve({
+        rows: crop ? [crop] : [],
+        rowCount: crop ? 1 : 0,
+      });
     }
 
     // ── Crop by image + oldId ── CHECK THIS BEFORE IMAGE ONLY!
@@ -174,6 +196,120 @@ describe("Image fetch routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual([]);
+  });
+
+  test("GET /api/v1/production/images -> returns keyed images with crops for multiple productions", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/production/images?ids=1,9999",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      byProductionId: {
+        "1": [
+          imageWithCrops(MOCK_IMAGE_1, [MOCK_CROP_1, MOCK_CROP_2]),
+          imageWithCrops(MOCK_IMAGE_2, [MOCK_CROP_3]),
+        ],
+        "9999": [],
+      },
+    });
+  });
+
+  test("GET /api/v1/production/images -> returns empty object without ids query", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/production/images",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ byProductionId: {} });
+  });
+
+  test("GET /api/v1/production/images -> empty byProductionId when ids are all unparsable", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/production/images?ids=foo,,-1,007,2147483648,x",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ byProductionId: {} });
+  });
+
+  test("GET /api/v1/production/images -> trims tokens, dedupes ids, skips junk between commas", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/production/images?ids=1,bad,1,9999",
+    });
+
+    expect(response.statusCode).toBe(200);
+    const json = response.json() as { byProductionId: Record<string, unknown> };
+    expect(Object.keys(json.byProductionId).sort()).toEqual(["1", "9999"]);
+    expect(json.byProductionId["1"]).toEqual([
+      imageWithCrops(MOCK_IMAGE_1, [MOCK_CROP_1, MOCK_CROP_2]),
+      imageWithCrops(MOCK_IMAGE_2, [MOCK_CROP_3]),
+    ]);
+    expect(json.byProductionId["9999"]).toEqual([]);
+  });
+
+  test("GET /api/v1/production/images -> only unknown productions still runs batch (empty image set)", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/production/images?ids=9998,9999",
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      byProductionId: {
+        "9998": [],
+        "9999": [],
+      },
+    });
+  });
+
+  test("GET /api/v1/production/images -> caps at 50 ids (extra discarded)", async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => String(i + 1)).join(",");
+    const response = await server.inject({
+      method: "GET",
+      url: `/api/v1/production/images?ids=${encodeURIComponent(ids)}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const keys = Object.keys((response.json() as { byProductionId: Record<string, unknown> }).byProductionId);
+    expect(keys).toHaveLength(50);
+    expect(keys).not.toContain("51");
+  });
+
+  test("GET /api/v1/production/images -> accepts ids as repeated string query params (array branch)", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/production/images",
+      query: { ids: ["1", "9999"] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      byProductionId: {
+        "1": [
+          imageWithCrops(MOCK_IMAGE_1, [MOCK_CROP_1, MOCK_CROP_2]),
+          imageWithCrops(MOCK_IMAGE_2, [MOCK_CROP_3]),
+        ],
+        "9999": [],
+      },
+    });
+  });
+
+  test("GET /api/v1/production/images -> array ids skips empty trimmed segments", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/production/images",
+      query: { ids: [" \t ", "", "1", "9999", "   "] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const keys = Object.keys((response.json() as { byProductionId: Record<string, unknown> }).byProductionId)
+      .sort();
+    expect(keys).toEqual(["1", "9999"]);
   });
 
   test("GET /api/v1/image/:id -> returns a single image with crops", async () => {
@@ -604,6 +740,16 @@ describe("Branch coverage for edge cases", () => {
     expect(res).toBeNull();
 
     server.pg.query = originalQuery;
+  });
+
+  test("direct: getCropById -> returns crop when row exists", async () => {
+    const res = await getCropById(server, MOCK_CROP_2.id);
+    expect(res).toEqual(MOCK_CROP_2);
+  });
+
+  test("direct: getCropById -> returns null when row missing", async () => {
+    const res = await getCropById(server, 99_999);
+    expect(res).toBeNull();
   });
 
   test("direct: getImageByOldId -> returns image with crops when present (covers withCrops[0] branch)", async () => {

--- a/frontend/src/services/media.ts
+++ b/frontend/src/services/media.ts
@@ -9,6 +9,12 @@ import { apiFetch, ApiError } from "./api";
 
 export type ImageWithCrops = Image & { crops: Crop[] };
 
+export type ProductionImagesBatchResponse = {
+  byProductionId: Record<string, ImageWithCrops[]>;
+};
+
+const MAX_IDS_PER_PRODUCTION_IMAGE_BATCH = 50;
+
 /**
  * All images (with nested crops) for a production.
  *
@@ -53,4 +59,67 @@ export async function getImagesForProductionOrEmpty(
   return await getImagesForProduction(productionId).catch((err: unknown) =>
     handleProductionImagesFetchError(productionId, err),
   );
+}
+
+function handleProductionImagesBatchFetchError(
+  productionIds: readonly number[],
+  err: unknown,
+): void {
+  if (err instanceof ApiError && err.status === 404) {
+    return;
+  }
+  const slug =
+    productionIds.length <= 5
+      ? `[production ids: ${productionIds.join(",")}]`
+      : `[production ids: (${productionIds.length} ids)]`;
+  if (err instanceof ApiError) {
+    console.warn(
+      `${slug} GET /production/images failed: HTTP ${err.status} — ${err.message}`,
+    );
+    return;
+  }
+  console.warn(`${slug} GET /production/images failed (non-ApiError)`, err);
+}
+
+/**
+ * Batch-fetch images (with crops) for many productions in one HTTP round-trip.
+ * Missing or failed lookups yield an empty array for that id (same spirit as
+ * {@link getImagesForProductionOrEmpty}).
+ */
+export async function getImagesForProductionsOrEmpty(
+  productionIds: number[],
+): Promise<Map<number, ImageWithCrops[]>> {
+  const unique: number[] = [];
+  const seen = new Set<number>();
+  for (const id of productionIds) {
+    if (typeof id !== "number" || !Number.isFinite(id) || id < 1) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    unique.push(id);
+    if (unique.length >= MAX_IDS_PER_PRODUCTION_IMAGE_BATCH) break;
+  }
+
+  function emptyListsMap(): Map<number, ImageWithCrops[]> {
+    return new Map(unique.map((id) => [id, []]));
+  }
+
+  if (unique.length === 0) {
+    return new Map();
+  }
+
+  try {
+    const params = new URLSearchParams({ ids: unique.join(",") });
+    const body = await apiFetch<ProductionImagesBatchResponse>(
+      `/production/images?${params.toString()}`,
+    );
+    const out = new Map<number, ImageWithCrops[]>();
+    for (const id of unique) {
+      const list = body.byProductionId[String(id)];
+      out.set(id, Array.isArray(list) ? list : []);
+    }
+    return out;
+  } catch (err: unknown) {
+    handleProductionImagesBatchFetchError(unique, err);
+    return emptyListsMap();
+  }
 }

--- a/frontend/src/services/media.ts
+++ b/frontend/src/services/media.ts
@@ -65,9 +65,6 @@ function handleProductionImagesBatchFetchError(
   productionIds: readonly number[],
   err: unknown,
 ): void {
-  if (err instanceof ApiError && err.status === 404) {
-    return;
-  }
   const slug =
     productionIds.length <= 5
       ? `[production ids: ${productionIds.join(",")}]`
@@ -83,8 +80,9 @@ function handleProductionImagesBatchFetchError(
 
 /**
  * Batch-fetch images (with crops) for many productions in one HTTP round-trip.
- * Missing or failed lookups yield an empty array for that id (same spirit as
- * {@link getImagesForProductionOrEmpty}).
+ * Successful responses map each id to an array (possibly empty). Request failures
+ * (including 404 on this route, which signals routing/deploy mismatch) log with 
+ * {@link console.warn} and degrade to empty lists per id.
  */
 export async function getImagesForProductionsOrEmpty(
   productionIds: number[],

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -853,7 +853,7 @@ async function applyProductionsSortChange(parsed: {
   try {
     await fetchProductionsPageData(0);
     await replaceRouteForPage0(0);
-    scrollAfterPageChange();
+    await scrollAfterPageChange();
   } catch (err) {
     failListAttempt(err);
   } finally {
@@ -1061,7 +1061,7 @@ async function applyFilterChange() {
   try {
     await fetchProductionsPageData(0);
     await replaceRouteForPage0(0);
-    scrollAfterPageChange();
+    await scrollAfterPageChange();
   } catch (err) {
     failListAttempt(err);
     syncFilterBannerFromApplied();
@@ -1095,7 +1095,7 @@ async function submitSearch() {
   try {
     await fetchProductionsPageData(0);
     await replaceRouteForPage0(0);
-    scrollAfterPageChange();
+    await scrollAfterPageChange();
   } catch (err) {
     failListAttempt(err);
   } finally {
@@ -1113,7 +1113,7 @@ async function removeSearchTermAt(index: number) {
   try {
     await fetchProductionsPageData(0);
     await replaceRouteForPage0(0);
-    scrollAfterPageChange();
+    await scrollAfterPageChange();
   } catch (err) {
     failListAttempt(err);
   } finally {
@@ -1462,7 +1462,7 @@ watch(
     beginListAttempt();
     try {
       await fetchProductionsPageData(page0);
-      scrollAfterPageChange();
+      await scrollAfterPageChange();
     } catch (err) {
       failListAttempt(err);
     } finally {
@@ -1500,7 +1500,7 @@ async function goToPage(page: number) {
   try {
     await fetchProductionsPageData(page);
     await replaceRouteForPage0(page);
-    scrollAfterPageChange();
+    await scrollAfterPageChange();
   } catch (err) {
     failListAttempt(err);
   } finally {

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -973,7 +973,7 @@ async function fetchProductionsPageData(page0: number) {
   syncFilterBannerFromApplied();
   eventsByProduction.value = eventsMap;
   thumbnailUrlByProductionId.value = new Map();
-  await loadThumbnailsForProductionIds(ids);
+  void loadThumbnailsForProductionIds(ids);
 }
 
 function toggleTag(id: number) {

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -794,9 +794,12 @@ function urlNeedsSyncForPage0(page0: number): boolean {
   return cur !== want;
 }
 
-/** List jumps use instant scroll — `smooth` fights layout reflow (thumbnails resolving). Fallback scrolls doc only (not doc+body doubles). */
+/**
+ * Scroll to hero anchor after list page/filter changes (`smooth` by default).
+ * Fallback uses `documentElement` only (no duplicate `document.body` scroll).
+ */
 function scrollProductionsPageToTop(
-  behavior: ScrollBehavior = "auto",
+  behavior: ScrollBehavior = "smooth",
 ): void {
   const el = pageTopAnchor.value;
   if (el && typeof el.scrollIntoView === "function") {

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -517,7 +517,7 @@ import { i18n, type SupportedLang } from "@/i18n";
 import { getEventsForProductions } from "@/services/events";
 import { getHalls } from "@/services/halls";
 import { ApiError } from "@/services/api";
-import { getImagesForProductionOrEmpty } from "@/services/media";
+import { getImagesForProductionsOrEmpty } from "@/services/media";
 import {
   getProductions,
   type ProductionSortBy,
@@ -794,23 +794,20 @@ function urlNeedsSyncForPage0(page0: number): boolean {
   return cur !== want;
 }
 
-function scrollProductionsPageToTop() {
+/** List jumps use instant scroll — `smooth` fights layout reflow (thumbnails resolving). Fallback scrolls doc only (not doc+body doubles). */
+function scrollProductionsPageToTop(
+  behavior: ScrollBehavior = "auto",
+): void {
   const el = pageTopAnchor.value;
   if (el && typeof el.scrollIntoView === "function") {
-    el.scrollIntoView({ behavior: "smooth", block: "start" });
+    el.scrollIntoView({ behavior, block: "start" });
     return;
   }
   const doc = document.documentElement;
-  const body = document.body;
   if (typeof doc.scrollTo === "function") {
-    doc.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+    doc.scrollTo({ top: 0, left: 0, behavior });
   } else {
     doc.scrollTop = 0;
-  }
-  if (typeof body.scrollTo === "function") {
-    body.scrollTo({ top: 0, left: 0, behavior: "smooth" });
-  } else {
-    body.scrollTop = 0;
   }
 }
 
@@ -870,11 +867,11 @@ const hasActiveListFilters = computed(() => {
 });
 
 const eventsByProduction = ref(new Map<number, ProductionEvent[]>());
-/** Set after `GET /production/:id/image` for each row on the current list page. */
+/** Set after `GET /production/images` for thumbnails on the current list page. */
 const thumbnailUrlByProductionId = ref(
   new Map<number, string | null>(),
 );
-/** Bumps on each thumbnail load; stale `Promise.all` runs must not overwrite the map after a newer interaction. */
+/** Bumps on each thumbnail load; stale batches must not overwrite the map after a newer interaction. */
 let thumbnailLoadGeneration = 0;
 const tagsById = ref(new Map<number, Tag>());
 const tagTypesById = ref(new Map<number, TagType>());
@@ -894,15 +891,16 @@ async function loadThumbnailsForProductionIds(ids: number[]): Promise<void> {
     thumbnailUrlByProductionId.value = new Map();
     return;
   }
-  const next = new Map<number, string | null>();
-  await Promise.all(
-    ids.map(async (id) => {
-      const images = await getImagesForProductionOrEmpty(id);
-      next.set(id, pickProductionListThumbnailUrl(images));
-    }),
-  );
+  const byProduction = await getImagesForProductionsOrEmpty(ids);
   if (gen !== thumbnailLoadGeneration) {
     return;
+  }
+  const next = new Map<number, string | null>();
+  for (const id of ids) {
+    next.set(
+      id,
+      pickProductionListThumbnailUrl(byProduction.get(id) ?? []),
+    );
   }
   thumbnailUrlByProductionId.value = next;
 }
@@ -972,7 +970,7 @@ async function fetchProductionsPageData(page0: number) {
   syncFilterBannerFromApplied();
   eventsByProduction.value = eventsMap;
   thumbnailUrlByProductionId.value = new Map();
-  void loadThumbnailsForProductionIds(ids);
+  await loadThumbnailsForProductionIds(ids);
 }
 
 function toggleTag(id: number) {
@@ -995,11 +993,14 @@ function clearDateRange() {
   filterDateTo.value = null;
 }
 
-function scrollAfterPageChange() {
-  void nextTick();
-  requestAnimationFrame(() => {
-    scrollProductionsPageToTop();
+async function scrollAfterPageChange(): Promise<void> {
+  await nextTick();
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
   });
+  scrollProductionsPageToTop();
 }
 
 async function replaceRouteForPage0(page0: number) {
@@ -1229,7 +1230,7 @@ const {
   visibleItems: compactGenreTagsForRow,
 } = useFittingPills(compactGenreTagCandidates, {
   gapPx: 8,
-  trailingControlGapPx: 8,
+  trailingControlGapPx: 4,
   fallbackVisibleCount: COMPACT_GENRE_FALLBACK_MAX,
 });
 

--- a/frontend/test/services/media.test.ts
+++ b/frontend/test/services/media.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   getImagesForProduction,
   getImagesForProductionOrEmpty,
+  getImagesForProductionsOrEmpty,
+  type ProductionImagesBatchResponse,
 } from "@/services/media";
 import type { ImageWithCrops } from "@/services/media";
 
@@ -75,6 +77,53 @@ describe("getImagesForProductionOrEmpty", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const out = await getImagesForProductionOrEmpty(9);
     expect(out).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+});
+
+describe("getImagesForProductionsOrEmpty", () => {
+  it("GETs /api/v1/production/images with encoded ids", async () => {
+    const payload: ProductionImagesBatchResponse = {
+      byProductionId: {
+        "9": [
+          {
+            id: 1,
+            old_id: null,
+            production: 9,
+            res: null,
+            crops: [],
+          },
+        ],
+        "11": [],
+      },
+    };
+    vi.stubGlobal("fetch", mockJsonFetch(payload));
+    const out = await getImagesForProductionsOrEmpty([9, 11]);
+    expect(lastFetchUrl()).toMatch(/\/api\/v1\/production\/images\?ids=9%2C11$/);
+    expect(out.get(9)).toEqual(payload.byProductionId["9"]);
+    expect(out.get(11)).toEqual([]);
+  });
+
+  it("dedupes ids and preserves first-seen order in query", async () => {
+    vi.stubGlobal("fetch", mockJsonFetch({ byProductionId: {} }));
+    await getImagesForProductionsOrEmpty([2, 1, 2]);
+    expect(lastFetchUrl()).toMatch(/ids=2%2C1/);
+  });
+
+  it("returns empty Map without calling fetch when ids are empty", async () => {
+    const f = vi.fn();
+    vi.stubGlobal("fetch", f);
+    const out = await getImagesForProductionsOrEmpty([]);
+    expect(out.size).toBe(0);
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it("returns empty lists and warns on non-404 HTTP errors", async () => {
+    vi.stubGlobal("fetch", mockErrorFetch(503, { error: "Unavailable" }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const out = await getImagesForProductionsOrEmpty([9]);
+    expect(out.get(9)).toEqual([]);
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });

--- a/frontend/test/services/media.test.ts
+++ b/frontend/test/services/media.test.ts
@@ -119,7 +119,17 @@ describe("getImagesForProductionsOrEmpty", () => {
     expect(f).not.toHaveBeenCalled();
   });
 
-  it("returns empty lists and warns on non-404 HTTP errors", async () => {
+  it("returns empty lists and warns on HTTP 404", async () => {
+    vi.stubGlobal("fetch", mockErrorFetch(404, { error: "Not Found" }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const out = await getImagesForProductionsOrEmpty([9]);
+    expect(out.get(9)).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]![0])).toContain("404");
+    warn.mockRestore();
+  });
+
+  it("returns empty lists and warns on HTTP 503", async () => {
     vi.stubGlobal("fetch", mockErrorFetch(503, { error: "Unavailable" }));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const out = await getImagesForProductionsOrEmpty([9]);

--- a/frontend/test/views/ProductionsView.test.ts
+++ b/frontend/test/views/ProductionsView.test.ts
@@ -108,8 +108,8 @@ describe("ProductionsView.vue", () => {
       items: [mockProduction],
       total: 1,
     });
-    vi.spyOn(mediaService, "getImagesForProductionOrEmpty").mockResolvedValue(
-      [],
+    vi.spyOn(mediaService, "getImagesForProductionsOrEmpty").mockResolvedValue(
+      new Map([[mockProduction.id, []]]),
     );
     vi.spyOn(tagsService, "getTags").mockResolvedValue([mockTag]);
     vi.spyOn(tagsService, "getTagTypes").mockResolvedValue([mockTagTypeGenre]);


### PR DESCRIPTION
**Issue(s)**

Closes #390 

____

**Description**

Implemented a batch operation for fetching productions media on the productions page, instead of making individual parallel requests, as suggested by @Simon-VdB in #365 

The scroll to top animation now feels a bit buggy and inconsistent on firefox I've noticed, on chrome it feels great, so this might need to be done differently but there already exists and issue for this.

____

**Sources**