### PR TITLE
Refactor productions list page into archive editorial idiom

### DIFF
--- a/frontend/src/assets/stylesheets/design-tokens.css
+++ b/frontend/src/assets/stylesheets/design-tokens.css
@@ -40,9 +40,10 @@
   --photo-overlay: #2B2826;
   --photo-opacity: 0.55;
 
-  /* ---- Tag chips (archive list — genre vs outline, Vooruit-style) ---- */
-  --tag-genre-bg: #8224e3;
-  --tag-genre-text: #f5f0e8;
+  /* ---- Tag chips (archive list — genre vs outline) ---- */
+  /* Solid ink, not a hue. Differentiate tags by label, not by colour (§2.5). */
+  --tag-genre-bg: #2B2826;
+  --tag-genre-text: #F5F0E8;
 }
 
 /* ---- Dark mode ---- */
@@ -74,6 +75,6 @@
   --photo-overlay: #1C1A17;
   --photo-opacity: 0.65;
 
-  --tag-genre-bg: #8224e3;
-  --tag-genre-text: #f5f0e8;
+  --tag-genre-bg: #EDE8DF;
+  --tag-genre-text: #1C1A17;
 }

--- a/frontend/src/components/productions/ProductionListCard.vue
+++ b/frontend/src/components/productions/ProductionListCard.vue
@@ -56,7 +56,7 @@
         </span>
       </div>
 
-      <div class="min-w-0">
+      <div class="-mt-0.5 min-w-0">
         <h2
           class="font-serif text-2xl font-semibold leading-tight tracking-tight text-ink-primary md:text-2xl"
           :class="dateSummary.line ? 'pr-[13rem] sm:pr-[15rem]' : ''"
@@ -73,7 +73,7 @@
 
         <p
           v-if="hallsText"
-          class="mt-4 flex items-start gap-1 text-sm text-ink-secondary"
+          class="mt-3 flex items-start gap-1 text-sm text-ink-secondary"
         >
           <svg
             class="mt-0.5 size-[0.9rem] shrink-0 text-ink-tertiary"
@@ -94,7 +94,7 @@
 
       <div
         v-if="tagChips.length"
-        class="mt-auto flex flex-wrap items-center gap-2 pt-5"
+        class="mt-auto flex flex-wrap items-center gap-2 pt-4.5"
       >
         <span
           v-for="chip in tagChips"

--- a/frontend/src/components/productions/ProductionListCard.vue
+++ b/frontend/src/components/productions/ProductionListCard.vue
@@ -97,7 +97,7 @@
         class="mt-auto flex flex-wrap items-center gap-2 pt-4.5"
       >
         <span
-          v-for="chip in tagChips"
+          v-for="chip in visibleTagChips"
           :key="chip.tagId"
           class="rounded-sm px-2.5 py-1 text-xs font-medium uppercase tracking-wide"
           :class="
@@ -107,6 +107,12 @@
           "
         >
           {{ chip.label }}
+        </span>
+        <span
+          v-if="hiddenTagCount > 0"
+          class="text-xs font-medium tabular-nums tracking-wide text-ink-tertiary"
+        >
+          {{ t("productionsPage.moreListTags", { n: hiddenTagCount }) }}
         </span>
       </div>
     </div>
@@ -124,6 +130,9 @@ import { localizeOrEmpty } from "@/utils/language-utils";
 import type { ProductionDateSummary } from "@/utils/productionsOverview";
 import type { ProductionTagChip } from "@/utils/tagDisplay";
 
+/** Beyond this count, remaining tags are summarized as localized “+n more”. */
+const MAX_VISIBLE_LIST_TAGS = 5;
+
 const props = withDefaults(
   defineProps<{
     production: ProductionWithBackwardsRefs;
@@ -139,6 +148,14 @@ const props = withDefaults(
 );
 
 const { t, locale } = useI18n();
+
+const visibleTagChips = computed(() =>
+  props.tagChips.slice(0, MAX_VISIBLE_LIST_TAGS),
+);
+
+const hiddenTagCount = computed(() =>
+  Math.max(0, props.tagChips.length - MAX_VISIBLE_LIST_TAGS),
+);
 
 /** Cap delay so long pages do not stretch the sequence too far. */
 const staggerDelayMs = computed(() =>

--- a/frontend/src/components/productions/ProductionListCard.vue
+++ b/frontend/src/components/productions/ProductionListCard.vue
@@ -41,12 +41,12 @@
       -->
       <div
         v-if="dateSummary.line"
-        class="absolute right-0 top-0 z-10 max-w-[11rem] text-right font-serif text-sm text-ink-secondary tabular-nums sm:max-w-[13rem]"
+        class="absolute right-0 top-0 z-10 max-w-[12rem] text-right font-serif text-base font-semibold leading-tight text-ink-secondary tabular-nums sm:max-w-[14rem] md:text-lg"
       >
         <span class="whitespace-nowrap">{{ dateSummary.line }}</span>
         <span
           v-if="dateSummary.moreCount > 0"
-          class="mt-0.5 block font-sans text-xs not-italic text-ink-tertiary"
+          class="mt-1 block font-sans text-xs font-normal not-italic text-ink-tertiary"
         >
           {{
             t("productionsPage.morePerformances", {
@@ -58,22 +58,22 @@
 
       <div class="min-w-0">
         <h2
-          class="font-serif text-xl font-semibold leading-tight tracking-tight text-ink-primary md:text-2xl"
-          :class="dateSummary.line ? 'pr-[12rem] sm:pr-[14rem]' : ''"
+          class="font-serif text-2xl font-semibold leading-tight tracking-tight text-ink-primary md:text-3xl"
+          :class="dateSummary.line ? 'pr-[13rem] sm:pr-[15rem]' : ''"
         >
           {{ title }}
         </h2>
 
         <p
           v-if="artist"
-          class="mt-1 font-serif text-base italic text-ink-secondary md:text-lg"
+          class="mt-2 font-serif text-lg italic text-ink-secondary md:text-xl"
         >
           {{ artist }}
         </p>
 
         <p
           v-if="hallsText"
-          class="mt-4 flex items-start gap-1 text-sm text-ink-secondary"
+          class="mt-4 flex items-start gap-1.5 text-base text-ink-secondary"
         >
           <svg
             class="mt-0.5 size-[0.9rem] shrink-0 text-ink-tertiary"
@@ -94,12 +94,12 @@
 
       <div
         v-if="tagChips.length"
-        class="mt-auto flex flex-wrap items-center gap-2 pt-4"
+        class="mt-auto flex flex-wrap items-center gap-2 pt-5"
       >
         <span
           v-for="chip in tagChips"
           :key="chip.tagId"
-          class="rounded-sm px-2.5 py-1 text-[10px] font-medium uppercase tracking-wide"
+          class="rounded-sm px-2.5 py-1 text-xs font-medium uppercase tracking-wide"
           :class="
             chip.isGenre
               ? 'bg-tag-genre-bg text-tag-genre-text'

--- a/frontend/src/components/productions/ProductionListCard.vue
+++ b/frontend/src/components/productions/ProductionListCard.vue
@@ -12,7 +12,7 @@
       Placeholder grey + min-height only when there is no thumbnail. max-h caps extreme ratios.
     -->
     <div
-      class="relative w-48 shrink-0 self-start sm:w-56 md:w-64"
+      class="relative w-52 shrink-0 self-start sm:w-60 md:w-72"
       aria-hidden="true"
     >
       <div

--- a/frontend/src/components/productions/ProductionListCard.vue
+++ b/frontend/src/components/productions/ProductionListCard.vue
@@ -41,12 +41,12 @@
       -->
       <div
         v-if="dateSummary.line"
-        class="absolute right-0 top-0 z-10 max-w-[11rem] text-right text-sm text-ink-secondary sm:max-w-[13rem]"
+        class="absolute right-0 top-0 z-10 max-w-[11rem] text-right font-serif text-sm text-ink-secondary tabular-nums sm:max-w-[13rem]"
       >
         <span class="whitespace-nowrap">{{ dateSummary.line }}</span>
         <span
           v-if="dateSummary.moreCount > 0"
-          class="mt-0.5 block text-xs text-ink-tertiary"
+          class="mt-0.5 block font-sans text-xs not-italic text-ink-tertiary"
         >
           {{
             t("productionsPage.morePerformances", {
@@ -58,7 +58,7 @@
 
       <div class="min-w-0">
         <h2
-          class="text-xl font-bold leading-tight tracking-tight text-ink-primary md:text-2xl"
+          class="font-serif text-xl font-semibold leading-tight tracking-tight text-ink-primary md:text-2xl"
           :class="dateSummary.line ? 'pr-[12rem] sm:pr-[14rem]' : ''"
         >
           {{ title }}
@@ -66,7 +66,7 @@
 
         <p
           v-if="artist"
-          class="mt-1 text-base font-medium text-ink-secondary md:text-lg"
+          class="mt-1 font-serif text-base italic text-ink-secondary md:text-lg"
         >
           {{ artist }}
         </p>
@@ -94,16 +94,16 @@
 
       <div
         v-if="tagChips.length"
-        class="mt-auto flex flex-wrap items-center gap-2 pt-4 text-xs"
+        class="mt-auto flex flex-wrap items-center gap-2 pt-4"
       >
         <span
           v-for="chip in tagChips"
           :key="chip.tagId"
-          class="rounded-full px-2.5 py-1 font-medium"
+          class="rounded-sm px-2.5 py-1 text-[10px] font-medium uppercase tracking-wide"
           :class="
             chip.isGenre
               ? 'bg-tag-genre-bg text-tag-genre-text'
-              : 'border border-ink-primary bg-transparent text-ink-primary'
+              : 'border border-surface-3 bg-surface-1 text-ink-secondary'
           "
         >
           {{ chip.label }}

--- a/frontend/src/components/productions/ProductionListCard.vue
+++ b/frontend/src/components/productions/ProductionListCard.vue
@@ -40,7 +40,6 @@
         grow the title row and push the artist down.
       -->
       <div
-        v-if="dateSummary.line"
         class="absolute right-0 top-0 z-10 max-w-[12rem] text-right font-serif text-base leading-tight text-ink-secondary tabular-nums sm:max-w-[14rem] md:text-lg"
       >
         <span class="whitespace-nowrap">{{ dateSummary.line }}</span>
@@ -58,15 +57,14 @@
 
       <div class="-mt-0.5 min-w-0">
         <h2
-          class="font-serif text-2xl font-semibold leading-tight tracking-tight text-ink-primary md:text-2xl"
-          :class="dateSummary.line ? 'pr-[13rem] sm:pr-[15rem]' : ''"
+          class="pr-[12rem] font-serif text-2xl font-semibold leading-tight tracking-tight text-ink-primary sm:pr-[14rem] md:text-2xl"
         >
           {{ title }}
         </h2>
 
         <p
           v-if="artist"
-          class="mt-1 font-serif text-lg italic text-ink-secondary md:text-lg"
+          class="mt-1 pr-[12rem] font-serif text-lg italic text-ink-secondary sm:pr-[14rem] md:text-lg"
         >
           {{ artist }}
         </p>

--- a/frontend/src/components/productions/ProductionListCard.vue
+++ b/frontend/src/components/productions/ProductionListCard.vue
@@ -41,7 +41,7 @@
       -->
       <div
         v-if="dateSummary.line"
-        class="absolute right-0 top-0 z-10 max-w-[12rem] text-right font-serif text-base font-semibold leading-tight text-ink-secondary tabular-nums sm:max-w-[14rem] md:text-lg"
+        class="absolute right-0 top-0 z-10 max-w-[12rem] text-right font-serif text-base leading-tight text-ink-secondary tabular-nums sm:max-w-[14rem] md:text-lg"
       >
         <span class="whitespace-nowrap">{{ dateSummary.line }}</span>
         <span
@@ -58,7 +58,7 @@
 
       <div class="min-w-0">
         <h2
-          class="font-serif text-2xl font-semibold leading-tight tracking-tight text-ink-primary md:text-3xl"
+          class="font-serif text-2xl font-semibold leading-tight tracking-tight text-ink-primary md:text-2xl"
           :class="dateSummary.line ? 'pr-[13rem] sm:pr-[15rem]' : ''"
         >
           {{ title }}
@@ -66,14 +66,14 @@
 
         <p
           v-if="artist"
-          class="mt-2 font-serif text-lg italic text-ink-secondary md:text-xl"
+          class="mt-1 font-serif text-lg italic text-ink-secondary md:text-lg"
         >
           {{ artist }}
         </p>
 
         <p
           v-if="hallsText"
-          class="mt-4 flex items-start gap-1.5 text-base text-ink-secondary"
+          class="mt-4 flex items-start gap-1 text-sm text-ink-secondary"
         >
           <svg
             class="mt-0.5 size-[0.9rem] shrink-0 text-ink-tertiary"

--- a/frontend/src/components/productions/ProductionsDateFilter.vue
+++ b/frontend/src/components/productions/ProductionsDateFilter.vue
@@ -29,13 +29,15 @@
 
     <div
       v-if="panelOpen"
-      class="absolute left-0 z-30 mt-2 w-[min(100vw-2rem,36rem)] max-h-[min(85vh,32rem)] origin-top-left overflow-y-auto rounded-xl border border-surface-3 bg-surface-1 p-4 shadow-lg"
+      class="absolute left-0 z-30 mt-2 w-[min(100vw-2rem,36rem)] max-h-[min(85vh,32rem)] origin-top-left overflow-y-auto rounded-lg border border-surface-3 bg-surface-1 p-4 shadow-lg"
       role="dialog"
       :aria-label="t('productionsPage.selectDates')"
       @click.stop
     >
       <section class="space-y-3">
-        <h3 class="text-sm font-semibold text-ink-primary">
+        <h3
+          class="text-xs font-semibold uppercase tracking-[0.2em] text-ink-secondary"
+        >
           {{ t("productionsPage.filterByYearRange") }}
         </h3>
         <p class="text-xs leading-snug text-ink-secondary">
@@ -115,23 +117,25 @@
         :aria-label="t('productionsPage.dateFilterOrDividerAria')"
       >
         <div
-          class="h-px min-w-0 flex-1 bg-ink-secondary/25 dark:bg-ink-secondary/30"
+          class="h-px min-w-0 flex-1 bg-ink-tertiary opacity-50"
           aria-hidden="true"
         />
         <span
-          class="shrink-0 px-3 text-xs font-bold uppercase tracking-wide text-ink-secondary select-none"
+          class="shrink-0 select-none px-3 text-xs font-bold uppercase tracking-[0.25em] text-ink-secondary"
           aria-hidden="true"
         >
           {{ t("productionsPage.dateFilterOrDivider") }}
         </span>
         <div
-          class="h-px min-w-0 flex-1 bg-ink-secondary/25 dark:bg-ink-secondary/30"
+          class="h-px min-w-0 flex-1 bg-ink-tertiary opacity-50"
           aria-hidden="true"
         />
       </div>
 
       <section class="space-y-3">
-        <h3 class="text-sm font-semibold text-ink-primary">
+        <h3
+          class="text-xs font-semibold uppercase tracking-[0.2em] text-ink-secondary"
+        >
           {{ t("productionsPage.filterByDateRange") }}
         </h3>
         <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">

--- a/frontend/src/components/productions/ProductionsDateFilter.vue
+++ b/frontend/src/components/productions/ProductionsDateFilter.vue
@@ -36,7 +36,7 @@
     >
       <section class="space-y-3">
         <h3
-          class="text-xs font-semibold uppercase tracking-[0.2em] text-ink-secondary"
+          class="text-xs font-semibold uppercase tracking-[0.15em] text-ink-primary"
         >
           {{ t("productionsPage.filterByYearRange") }}
         </h3>
@@ -134,7 +134,7 @@
 
       <section class="space-y-3">
         <h3
-          class="text-xs font-semibold uppercase tracking-[0.2em] text-ink-secondary"
+          class="text-xs font-semibold uppercase tracking-[0.15em] text-ink-primary"
         >
           {{ t("productionsPage.filterByDateRange") }}
         </h3>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -204,6 +204,7 @@ export default {
     },
   },
   productionsPage: {
+    kicker: "The archive",
     heading: "Productions",
     intro:
       "Every show in the archive at a glance.",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -216,6 +216,7 @@ export default {
       "The first year must be on or before the last year. Adjust the range or fix the link and try again.",
     empty: "No productions in the archive yet.",
     morePerformances: "{n} more",
+    moreListTags: "+{n} more",
     showingRange: "{from}–{to} of {total}",
     prevPage: "Previous",
     nextPage: "Next",

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -203,6 +203,7 @@ export default {
     },
   },
   productionsPage: {
+    kicker: "Les archives",
     heading: "Productions",
     intro:
       "Tous les spectacles de l’archive en un coup d’œil.",

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -216,6 +216,7 @@ export default {
       "La première année doit être antérieure ou égale à la dernière. Ajustez la plage ou le lien et réessayez.",
     empty: "Aucune production dans les archives pour l’instant.",
     morePerformances: "{n} de plus",
+    moreListTags: "+{n} de plus",
     showingRange: "{from}–{to} sur {total}",
     prevPage: "Précédent",
     nextPage: "Suivant",

--- a/frontend/src/i18n/locales/nl.ts
+++ b/frontend/src/i18n/locales/nl.ts
@@ -203,6 +203,7 @@ export default {
     },
   },
   productionsPage: {
+    kicker: "Het archief",
     heading: "Producties",
     intro:
       "Alle voorstellingen uit het archief op een rij.",

--- a/frontend/src/i18n/locales/nl.ts
+++ b/frontend/src/i18n/locales/nl.ts
@@ -216,6 +216,7 @@ export default {
       "Het eerste jaar moet op of vóór het laatste jaar liggen. Pas het bereik aan of corrigeer de link en probeer opnieuw.",
     empty: "Er staan nog geen producties in het archief.",
     morePerformances: "nog {n}",
+    moreListTags: "+{n} meer",
     showingRange: "{from}–{to} van {total}",
     prevPage: "Vorige",
     nextPage: "Volgende",

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -37,7 +37,7 @@
         </div>
       </section>
 
-      <section class="mx-auto max-w-7xl px-6 pb-20 pt-10 lg:px-10">
+      <section class="mx-auto max-w-[82rem] px-6 pb-20 pt-10 lg:px-10">
         <div v-if="!loading" class="mb-4 space-y-3">
           <div
             class="flex flex-col gap-2 pb-0.5 sm:flex-row sm:items-stretch sm:gap-3"
@@ -333,7 +333,7 @@
           >
             <div class="flex min-w-0 flex-wrap items-center gap-2">
               <span
-                class="text-xs font-bold uppercase tracking-[0.25em] text-ink-secondary"
+                class="text-[15px] pr-1 text-ink-secondary"
               >{{ t("productionsPage.activeFiltersLabel") }}</span>
               <button
                 v-for="tid in filterBannerTagIds"
@@ -400,7 +400,7 @@
           <p
             v-if="displayedFilteredTotal !== null"
             :class="[
-              'mb-3 font-serif text-lg italic leading-normal text-ink-secondary tabular-nums',
+              'mb-2 text-sm italic leading-normal text-ink-secondary tabular-nums',
               !filterBannerHasNonSearchChips() && 'mt-6',
             ]"
             aria-live="polite"
@@ -439,7 +439,7 @@
               aria-label="Pagination"
             >
               <p
-                class="text-center font-serif text-base italic text-ink-secondary tabular-nums sm:text-left"
+                class="text-center text-sm text-ink-secondary tabular-nums sm:text-left"
               >
                 {{
                   t("productionsPage.showingRange", {
@@ -463,7 +463,7 @@
                   {{ t("productionsPage.prevPage") }}
                 </button>
                 <div
-                  class="flex items-center gap-2 font-serif text-base tabular-nums text-ink-secondary"
+                  class="flex items-center gap-2 text-sm tabular-nums text-ink-secondary"
                 >
                   <span class="whitespace-nowrap">{{
                     t("productionsPage.pageWord")
@@ -1561,17 +1561,20 @@ function tagChipsFor(production: ProductionWithBackwardsRefs): ProductionTagChip
   min-width: 6rem;
 }
 
-.productions-view__genre-collapsed-row-pill,
-.productions-view__tag-filter-panel-pill {
-  @apply cursor-pointer rounded-sm border px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-100;
-}
+.productions-view__genre-collapsed-row-pill {  
+  @apply cursor-pointer rounded-sm border px-3 py-1.5 text-[12px] font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-100;  
+}  
+
+.productions-view__tag-filter-panel-pill {  
+  @apply cursor-pointer rounded-sm border px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-100;  
+} 
 
 .productions-view__search-field {
   @apply box-border flex min-h-11 min-w-0 w-full flex-wrap items-center gap-1.5 rounded-md border border-surface-3 bg-surface-0 py-1.5 pl-2 pr-11 text-ink-primary transition focus-within:border-accent-outline dark:bg-surface-1;
 }
 
 .productions-view__search-input {
-  @apply min-h-7 min-w-28 flex-1 border-0 bg-transparent px-1 py-0 text-base leading-normal text-ink-primary placeholder:font-serif placeholder:italic placeholder:text-ink-tertiary focus:outline-none disabled:cursor-not-allowed disabled:opacity-100;
+  @apply min-h-7 min-w-28 flex-1 border-0 bg-transparent px-1 py-0 text-base leading-normal text-ink-primary placeholder:text-ink-tertiary focus:outline-none disabled:cursor-not-allowed disabled:opacity-100;
 }
 
 .productions-view__search-input::-webkit-search-cancel-button,
@@ -1593,11 +1596,11 @@ function tagChipsFor(production: ProductionWithBackwardsRefs): ProductionTagChip
 }
 
 .productions-view__filter-banner {
-  @apply mb-6 mt-6 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 gap-y-3 rounded-md border border-surface-3 bg-surface-1 px-5 py-4 dark:bg-surface-1/60;
+  @apply mb-4 mt-4 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 gap-y-2 border-t border-surface-3 pt-5;
 }
 
 .productions-view__active-chip {
-  @apply inline-flex cursor-pointer items-center gap-1.5 rounded-sm border border-surface-3 bg-surface-0 py-1.5 pl-3 pr-2 text-sm text-ink-primary transition hover:bg-surface-2 disabled:opacity-100 dark:bg-surface-1;
+  @apply inline-flex cursor-pointer items-center gap-1.5 rounded-sm border border-surface-3 bg-surface-0 py-1 pl-2.5 pr-1.5 text-[13px] text-ink-primary transition hover:bg-surface-2 disabled:opacity-100 dark:bg-surface-1;
 }
 
 .productions-view__alert {

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -4,32 +4,32 @@
     <main class="flex-1">
       <section
         ref="pageTopAnchor"
-        class="scroll-mt-16 border-b border-surface-3 bg-surface-1 py-14 md:py-20"
+        class="scroll-mt-16 border-b border-surface-3 bg-surface-1 py-20 md:py-28"
       >
         <div class="mx-auto max-w-5xl px-6 lg:px-10">
           <div class="mx-auto max-w-3xl text-center">
             <div
-              class="mb-6 flex items-center justify-center gap-3 text-xs font-bold uppercase tracking-[0.25em] text-ink-secondary"
+              class="mb-8 flex items-center justify-center gap-3 text-xs font-bold uppercase tracking-[0.25em] text-ink-secondary"
             >
               <span
-                class="h-px w-8 bg-ink-tertiary opacity-50"
+                class="h-px w-10 bg-ink-tertiary opacity-50"
                 aria-hidden="true"
               />
               <span class="whitespace-nowrap">{{
                 t("productionsPage.kicker")
               }}</span>
               <span
-                class="h-px w-8 bg-ink-tertiary opacity-50"
+                class="h-px w-10 bg-ink-tertiary opacity-50"
                 aria-hidden="true"
               />
             </div>
             <h1
-              class="font-serif text-3xl font-semibold leading-tight tracking-tight text-ink-primary md:text-4xl"
+              class="font-serif text-4xl font-semibold leading-[1.05] tracking-tight text-ink-primary md:text-5xl lg:text-6xl"
             >
               {{ t("productionsPage.heading") }}
             </h1>
             <p
-              class="mx-auto mt-4 max-w-2xl font-serif text-lg italic leading-snug text-ink-secondary md:text-xl"
+              class="mx-auto mt-6 max-w-2xl font-serif text-xl italic leading-relaxed text-ink-secondary md:text-2xl"
             >
               {{ t("productionsPage.intro") }}
             </p>
@@ -333,7 +333,7 @@
           >
             <div class="flex min-w-0 flex-wrap items-center gap-2">
               <span
-                class="text-[10px] font-bold uppercase tracking-[0.25em] text-ink-secondary"
+                class="text-xs font-bold uppercase tracking-[0.25em] text-ink-secondary"
               >{{ t("productionsPage.activeFiltersLabel") }}</span>
               <button
                 v-for="tid in filterBannerTagIds"
@@ -400,7 +400,7 @@
           <p
             v-if="displayedFilteredTotal !== null"
             :class="[
-              'mb-2 font-serif text-base italic leading-normal text-ink-secondary tabular-nums',
+              'mb-3 font-serif text-lg italic leading-normal text-ink-secondary tabular-nums',
               !filterBannerHasNonSearchChips() && 'mt-6',
             ]"
             aria-live="polite"
@@ -439,7 +439,7 @@
               aria-label="Pagination"
             >
               <p
-                class="text-center font-serif text-sm italic text-ink-secondary tabular-nums sm:text-left"
+                class="text-center font-serif text-base italic text-ink-secondary tabular-nums sm:text-left"
               >
                 {{
                   t("productionsPage.showingRange", {
@@ -463,7 +463,7 @@
                   {{ t("productionsPage.prevPage") }}
                 </button>
                 <div
-                  class="flex items-center gap-2 font-serif text-sm tabular-nums text-ink-secondary"
+                  class="flex items-center gap-2 font-serif text-base tabular-nums text-ink-secondary"
                 >
                   <span class="whitespace-nowrap">{{
                     t("productionsPage.pageWord")
@@ -1563,7 +1563,7 @@ function tagChipsFor(production: ProductionWithBackwardsRefs): ProductionTagChip
 
 .productions-view__genre-collapsed-row-pill,
 .productions-view__tag-filter-panel-pill {
-  @apply cursor-pointer rounded-sm border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-100;
+  @apply cursor-pointer rounded-sm border px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-100;
 }
 
 .productions-view__search-field {
@@ -1597,7 +1597,7 @@ function tagChipsFor(production: ProductionWithBackwardsRefs): ProductionTagChip
 }
 
 .productions-view__active-chip {
-  @apply inline-flex cursor-pointer items-center gap-1 rounded-sm border border-surface-3 bg-surface-0 py-1 pl-2.5 pr-1.5 text-xs text-ink-primary transition hover:bg-surface-2 disabled:opacity-100 dark:bg-surface-1;
+  @apply inline-flex cursor-pointer items-center gap-1.5 rounded-sm border border-surface-3 bg-surface-0 py-1.5 pl-3 pr-2 text-sm text-ink-primary transition hover:bg-surface-2 disabled:opacity-100 dark:bg-surface-1;
 }
 
 .productions-view__alert {

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -1531,7 +1531,7 @@ function dateSummaryFor(productionId: number) {
 function hallsTextFor(productionId: number) {
   const evs = eventsByProduction.value.get(productionId);
   const names = distinctHallNames(evs, hallsById.value, locale.value);
-  return names.join(" · ");
+  return names[0] ?? "";
 }
 
 function tagChipsFor(production: ProductionWithBackwardsRefs): ProductionTagChip[] {

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -4,32 +4,32 @@
     <main class="flex-1">
       <section
         ref="pageTopAnchor"
-        class="scroll-mt-16 border-b border-surface-3 bg-surface-1 py-20 md:py-28"
+        class="scroll-mt-16 border-b border-surface-3 bg-surface-1 py-10 md:py-14"
       >
-        <div class="mx-auto max-w-5xl px-6 lg:px-10">
+        <div class="mx-auto max-w-6xl px-6 lg:px-10">
           <div class="mx-auto max-w-3xl text-center">
             <div
-              class="mb-8 flex items-center justify-center gap-3 text-xs font-bold uppercase tracking-[0.25em] text-ink-secondary"
+              class="mb-5 flex items-center justify-center gap-3 text-xs font-bold uppercase tracking-[0.25em] text-ink-secondary"
             >
               <span
-                class="h-px w-10 bg-ink-tertiary opacity-50"
+                class="h-px w-8 bg-ink-tertiary opacity-50"
                 aria-hidden="true"
               />
               <span class="whitespace-nowrap">{{
                 t("productionsPage.kicker")
               }}</span>
               <span
-                class="h-px w-10 bg-ink-tertiary opacity-50"
+                class="h-px w-8 bg-ink-tertiary opacity-50"
                 aria-hidden="true"
               />
             </div>
             <h1
-              class="font-serif text-4xl font-semibold leading-[1.05] tracking-tight text-ink-primary md:text-5xl lg:text-6xl"
+              class="font-serif text-3xl font-semibold leading-tight tracking-tight text-ink-primary md:text-4xl"
             >
               {{ t("productionsPage.heading") }}
             </h1>
             <p
-              class="mx-auto mt-6 max-w-2xl font-serif text-xl italic leading-relaxed text-ink-secondary md:text-2xl"
+              class="mx-auto mt-3 max-w-2xl font-serif text-lg italic leading-snug text-ink-secondary md:text-xl"
             >
               {{ t("productionsPage.intro") }}
             </p>

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -4,19 +4,36 @@
     <main class="flex-1">
       <section
         ref="pageTopAnchor"
-        class="scroll-mt-16 border-b border-surface-3 bg-surface-1 py-12 md:py-16"
+        class="scroll-mt-16 border-b border-surface-3 bg-surface-1 py-14 md:py-20"
       >
-        <div class="mx-auto max-w-3xl px-6 text-center lg:px-10">
-          <h1
-            class="text-2xl font-bold tracking-tight text-ink-primary md:text-3xl"
-          >
-            {{ t("productionsPage.heading") }}
-          </h1>
-          <p
-            class="mt-4 text-sm leading-relaxed text-ink-secondary md:text-base"
-          >
-            {{ t("productionsPage.intro") }}
-          </p>
+        <div class="mx-auto max-w-5xl px-6 lg:px-10">
+          <div class="mx-auto max-w-3xl text-center">
+            <div
+              class="mb-6 flex items-center justify-center gap-3 text-xs font-bold uppercase tracking-[0.25em] text-ink-secondary"
+            >
+              <span
+                class="h-px w-8 bg-ink-tertiary opacity-50"
+                aria-hidden="true"
+              />
+              <span class="whitespace-nowrap">{{
+                t("productionsPage.kicker")
+              }}</span>
+              <span
+                class="h-px w-8 bg-ink-tertiary opacity-50"
+                aria-hidden="true"
+              />
+            </div>
+            <h1
+              class="font-serif text-3xl font-semibold leading-tight tracking-tight text-ink-primary md:text-4xl"
+            >
+              {{ t("productionsPage.heading") }}
+            </h1>
+            <p
+              class="mx-auto mt-4 max-w-2xl font-serif text-lg italic leading-snug text-ink-secondary md:text-xl"
+            >
+              {{ t("productionsPage.intro") }}
+            </p>
+          </div>
         </div>
       </section>
 
@@ -169,14 +186,14 @@
           <div
             v-if="filtersPanelExpanded"
             id="productions-extended-filters"
-            class="mt-4 space-y-4 rounded-lg border border-surface-3 bg-surface-1/50 px-4 py-4 shadow-sm ring-1 ring-inset ring-surface-3/40 dark:bg-surface-1/25"
+            class="mt-4 space-y-4 rounded-md border border-surface-3 bg-surface-1 px-4 py-4 dark:bg-surface-1/60"
           >
             <div
               v-if="genreTagsForFilter.length > 0"
               class="space-y-3"
             >
               <p
-                class="text-xs font-medium uppercase tracking-wide text-ink-secondary"
+                class="text-xs font-semibold uppercase tracking-[0.2em] text-ink-secondary"
               >
                 {{ t("productionsPage.genreFiltersHeading") }}
               </p>
@@ -231,7 +248,7 @@
               "
             >
               <p
-                class="text-xs font-medium uppercase tracking-wide text-ink-secondary"
+                class="text-xs font-semibold uppercase tracking-[0.2em] text-ink-secondary"
               >
                 {{ t("productionsPage.tagFiltersHeading") }}
               </p>
@@ -315,9 +332,9 @@
             class="productions-view__filter-banner"
           >
             <div class="flex min-w-0 flex-wrap items-center gap-2">
-              <span class="text-sm text-ink-secondary">{{
-                t("productionsPage.activeFiltersLabel")
-              }}</span>
+              <span
+                class="text-[10px] font-bold uppercase tracking-[0.25em] text-ink-secondary"
+              >{{ t("productionsPage.activeFiltersLabel") }}</span>
               <button
                 v-for="tid in filterBannerTagIds"
                 :key="'tag-' + tid"
@@ -383,7 +400,7 @@
           <p
             v-if="displayedFilteredTotal !== null"
             :class="[
-              'mb-2 text-sm leading-normal text-ink-secondary tabular-nums',
+              'mb-2 font-serif text-base italic leading-normal text-ink-secondary tabular-nums',
               !filterBannerHasNonSearchChips() && 'mt-6',
             ]"
             aria-live="polite"
@@ -421,7 +438,9 @@
               class="productions-view__pagination"
               aria-label="Pagination"
             >
-              <p class="text-center text-sm text-ink-secondary sm:text-left">
+              <p
+                class="text-center font-serif text-sm italic text-ink-secondary tabular-nums sm:text-left"
+              >
                 {{
                   t("productionsPage.showingRange", {
                     from: rangeFrom,
@@ -444,7 +463,7 @@
                   {{ t("productionsPage.prevPage") }}
                 </button>
                 <div
-                  class="flex items-center gap-2 text-sm tabular-nums text-ink-secondary"
+                  class="flex items-center gap-2 font-serif text-sm tabular-nums text-ink-secondary"
                 >
                   <span class="whitespace-nowrap">{{
                     t("productionsPage.pageWord")
@@ -1542,12 +1561,9 @@ function tagChipsFor(production: ProductionWithBackwardsRefs): ProductionTagChip
   min-width: 6rem;
 }
 
-.productions-view__genre-collapsed-row-pill {
-  @apply rounded-full border px-3 py-1 text-[0.95rem] transition disabled:opacity-100;
-}
-
+.productions-view__genre-collapsed-row-pill,
 .productions-view__tag-filter-panel-pill {
-  @apply rounded-full border px-2.75 py-1 text-sm transition disabled:opacity-100;
+  @apply cursor-pointer rounded-sm border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-100;
 }
 
 .productions-view__search-field {
@@ -1581,7 +1597,7 @@ function tagChipsFor(production: ProductionWithBackwardsRefs): ProductionTagChip
 }
 
 .productions-view__active-chip {
-  @apply inline-flex cursor-pointer items-center gap-1 rounded-full border border-surface-3 bg-surface-0 py-1 pl-2.5 pr-1.5 text-sm text-ink-primary shadow-sm ring-1 ring-inset ring-accent-outline/25 transition hover:bg-surface-2 disabled:opacity-100 dark:bg-surface-1;
+  @apply inline-flex cursor-pointer items-center gap-1 rounded-sm border border-surface-3 bg-surface-0 py-1 pl-2.5 pr-1.5 text-xs text-ink-primary transition hover:bg-surface-2 disabled:opacity-100 dark:bg-surface-1;
 }
 
 .productions-view__alert {

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -37,7 +37,7 @@
         </div>
       </section>
 
-      <section class="mx-auto max-w-5xl px-6 pb-20 pt-8 lg:px-10">
+      <section class="mx-auto max-w-4xl px-6 pb-20 pt-10 lg:px-10">
         <div v-if="!loading" class="mb-4 space-y-3">
           <div
             class="flex flex-col gap-2 pb-0.5 sm:flex-row sm:items-stretch sm:gap-3"
@@ -1571,7 +1571,7 @@ function tagChipsFor(production: ProductionWithBackwardsRefs): ProductionTagChip
 }
 
 .productions-view__search-input {
-  @apply min-h-7 min-w-28 flex-1 border-0 bg-transparent px-1 py-0 text-base leading-normal text-ink-primary placeholder:text-ink-secondary focus:outline-none disabled:cursor-not-allowed disabled:opacity-100;
+  @apply min-h-7 min-w-28 flex-1 border-0 bg-transparent px-1 py-0 text-base leading-normal text-ink-primary placeholder:font-serif placeholder:italic placeholder:text-ink-tertiary focus:outline-none disabled:cursor-not-allowed disabled:opacity-100;
 }
 
 .productions-view__search-input::-webkit-search-cancel-button,
@@ -1589,11 +1589,11 @@ function tagChipsFor(production: ProductionWithBackwardsRefs): ProductionTagChip
 }
 
 .productions-view__banner-action {
-  @apply col-start-2 row-start-1 shrink-0 cursor-pointer justify-self-end self-start pt-0.5 text-sm font-medium text-accent-outline underline decoration-from-font underline-offset-2 hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-100;
+  @apply col-start-2 row-start-1 shrink-0 cursor-pointer justify-self-end self-center text-sm font-medium text-accent-outline underline decoration-from-font underline-offset-2 hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-100;
 }
 
 .productions-view__filter-banner {
-  @apply mb-4 mt-4 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 gap-y-2 border-t border-surface-3 pt-5;
+  @apply mb-6 mt-6 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 gap-y-3 rounded-md border border-surface-3 bg-surface-1 px-5 py-4 dark:bg-surface-1/60;
 }
 
 .productions-view__active-chip {

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -37,7 +37,7 @@
         </div>
       </section>
 
-      <section class="mx-auto max-w-4xl px-6 pb-20 pt-10 lg:px-10">
+      <section class="mx-auto max-w-7xl px-6 pb-20 pt-10 lg:px-10">
         <div v-if="!loading" class="mb-4 space-y-3">
           <div
             class="flex flex-col gap-2 pb-0.5 sm:flex-row sm:items-stretch sm:gap-3"

--- a/frontend/test/components/productions/ProductionListCard.test.ts
+++ b/frontend/test/components/productions/ProductionListCard.test.ts
@@ -63,8 +63,8 @@ describe("ProductionListCard.vue", () => {
     });
     const h2 = wrapper.get("h2");
     expect(h2.text()).toContain("Titel");
-    expect(h2.classes().some((c) => c.includes("pr-[12.5rem]"))).toBe(true);
-    expect(h2.classes().some((c) => c.includes("sm:pr-[14.5rem]"))).toBe(true);
+    expect(h2.classes().some((c) => c.includes("pr-[12rem]"))).toBe(true);
+    expect(h2.classes().some((c) => c.includes("sm:pr-[14rem]"))).toBe(true);
     wrapper.unmount();
   });
 

--- a/frontend/test/components/productions/ProductionListCard.test.ts
+++ b/frontend/test/components/productions/ProductionListCard.test.ts
@@ -116,6 +116,30 @@ describe("ProductionListCard.vue", () => {
     wrapper.unmount();
   });
 
+  it("shows at most five tag pills and summarizes the rest with +n more", async () => {
+    const tagChips: ProductionTagChip[] = Array.from({ length: 7 }, (_, i) => ({
+      tagId: i + 1,
+      label: `Tag ${i + 1}`,
+      isGenre: false,
+    }));
+    const wrapper = await mountCard({ tagChips });
+    expect(wrapper.findAll("span.rounded-sm")).toHaveLength(5);
+    expect(wrapper.text()).toContain("+2 meer");
+    wrapper.unmount();
+  });
+
+  it("shows every tag pill when there are five or fewer tags", async () => {
+    const tagChips: ProductionTagChip[] = [1, 2, 3, 4, 5].map((id) => ({
+      tagId: id,
+      label: `T${id}`,
+      isGenre: false,
+    }));
+    const wrapper = await mountCard({ tagChips });
+    expect(wrapper.findAll("span.rounded-sm")).toHaveLength(5);
+    expect(wrapper.text()).not.toContain("+");
+    wrapper.unmount();
+  });
+
   it("renders no tag row when tagChips is empty", async () => {
     const wrapper = await mountCard({ tagChips: [] });
     expect(wrapper.findAll("span.rounded-sm")).toHaveLength(0);

--- a/frontend/test/components/productions/ProductionListCard.test.ts
+++ b/frontend/test/components/productions/ProductionListCard.test.ts
@@ -110,15 +110,15 @@ describe("ProductionListCard.vue", () => {
         { tagId: 2, label: "Vooruit", isGenre: false },
       ],
     });
-    const chips = wrapper.findAll("span.rounded-full");
+    const chips = wrapper.findAll("span.rounded-sm");
     expect(chips[0]!.classes().join(" ")).toMatch(/tag-genre-bg/);
-    expect(chips[1]!.classes().join(" ")).toMatch(/border-ink-primary/);
+    expect(chips[1]!.classes().join(" ")).toMatch(/border-surface-3/);
     wrapper.unmount();
   });
 
   it("renders no tag row when tagChips is empty", async () => {
     const wrapper = await mountCard({ tagChips: [] });
-    expect(wrapper.findAll("span.rounded-full")).toHaveLength(0);
+    expect(wrapper.findAll("span.rounded-sm")).toHaveLength(0);
     wrapper.unmount();
   });
 });

--- a/frontend/test/components/productions/ProductionListCard.test.ts
+++ b/frontend/test/components/productions/ProductionListCard.test.ts
@@ -43,7 +43,7 @@ async function mountCard(props: {
   const wrapper = mount(ProductionListCard, {
     props: {
       production: props.production ?? baseProduction,
-      dateSummary: props.dateSummary ?? { line: null, moreCount: 0 },
+      dateSummary: props.dateSummary ?? { line: "zo 01.01.2000", moreCount: 0 },
       tagChips: props.tagChips ?? [],
       hallsText: props.hallsText ?? "",
     },
@@ -57,22 +57,14 @@ describe("ProductionListCard.vue", () => {
     i18n.global.locale.value = "nl";
   });
 
-  it("renders title and applies title padding when a date line exists", async () => {
+  it("renders title with right gutter clearing the date column", async () => {
     const wrapper = await mountCard({
       dateSummary: { line: "wo 01.01.2000", moreCount: 0 },
     });
     const h2 = wrapper.get("h2");
     expect(h2.text()).toContain("Titel");
-    expect(h2.classes().some((c) => c.includes("pr-["))).toBe(true);
-    wrapper.unmount();
-  });
-
-  it("omits title padding when there is no date line", async () => {
-    const wrapper = await mountCard({
-      dateSummary: { line: null, moreCount: 0 },
-    });
-    const h2 = wrapper.get("h2");
-    expect(h2.classes().some((c) => c.includes("pr-[12rem]"))).toBe(false);
+    expect(h2.classes().some((c) => c.includes("pr-[12.5rem]"))).toBe(true);
+    expect(h2.classes().some((c) => c.includes("sm:pr-[14.5rem]"))).toBe(true);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
**Issue(s)**

https://github.com/SELab-2/viernulvier-1/issues/433

____

**Description**

Brings ProductionsView in line with DESIGN.md §11–§12: kicker thin-rule hero with serif h1 + italic deck, §12.3 small-caps tag chips, kicker eyebrows on filter panel headings and active-filters strip, serif italic results-count and pagination strip. ProductionListCard gets a serif semibold title, italic-serif artist, font-serif tabular-nums date overlay, and the canonical §12.3 chip styles. ProductionsDateFilter popover drops the rounded-xl violation and lifts its section headings to small-caps kickers.

Why: the productions page was the last public view still reading as a generic catalogue/SaaS list (sans-serif hero, rounded-full pills, shadow-sm filter panel). Brought it onto the same paper-and-rules grammar as the home page and production detail. Filter, search, sort and pagination logic is untouched; only typography, chip vocabulary, panel chrome and divider tokens change.

____

**Sources**

DESIGN.md
