### PR TITLE
Add CMS UI to create new tag types

### DIFF
--- a/frontend/src/components/admin/cms/tags/CmsCreateTagTypeModal.vue
+++ b/frontend/src/components/admin/cms/tags/CmsCreateTagTypeModal.vue
@@ -1,8 +1,8 @@
 <template>
-  <div v-if="open" class="cms-modal-overlay" @click.self="emit('close')">
+  <div v-if="open" class="cms-modal-overlay" data-testid="cms-create-tag-type-modal" @click.self="emit('close')">
     <section class="cms-modal" role="dialog" aria-modal="true">
       <header class="cms-modal-header">
-        <h2 class="text-xl font-bold text-ink-primary">{{ t("cms.create.tagTitle") }}</h2>
+        <h2 class="text-xl font-bold text-ink-primary">{{ t("cms.create.tagTypeTitle") }}</h2>
         <button type="button" class="cms-side-close" @click="emit('close')">
           {{ t("cms.panel.close") }}
         </button>
@@ -16,16 +16,16 @@
             <button
               type="button"
               class="cms-language-pill"
-              :class="{ active: createExtraLangs.en }"
-              @click="emit('update-extra-lang', 'en', !createExtraLangs.en)"
+              :class="{ active: extraLangs.en }"
+              @click="toggleExtraLang('en')"
             >
               EN
             </button>
             <button
               type="button"
               class="cms-language-pill"
-              :class="{ active: createExtraLangs.fr }"
-              @click="emit('update-extra-lang', 'fr', !createExtraLangs.fr)"
+              :class="{ active: extraLangs.fr }"
+              @click="toggleExtraLang('fr')"
             >
               FR
             </button>
@@ -34,51 +34,25 @@
 
         <fieldset class="cms-form-block">
           <legend class="cms-form-legend">
-            {{ t("cms.columns.tagName") }}
+            {{ t("cms.columns.tagType") }}
             <span class="cms-required">*</span>
           </legend>
 
           <div :class="langGridClass">
-            <label v-for="lang in visibleCreateLangs" :key="`name-${lang}`" class="cms-form-lang-field">
+            <label v-for="lang in visibleLangs" :key="`name-${lang}`" class="cms-form-lang-field">
               <span class="cms-lang-label">{{ lang.toUpperCase() }}</span>
               <input
-                :value="createForm.name[lang]"
+                v-model="name[lang]"
                 type="text"
                 class="cms-text-input"
-                :data-testid="`cms-create-tag-name-${lang}`"
-                @input="emit('update-name', lang, ($event.target as HTMLInputElement).value)"
+                :data-testid="`cms-create-tag-type-name-${lang}`"
               />
             </label>
           </div>
         </fieldset>
 
-        <fieldset class="cms-form-block">
-          <legend class="cms-form-legend">
-            {{ t("cms.columns.tagType") }}
-            <span class="cms-required">*</span>
-          </legend>
-          <TagTypePicker
-            :model-value="createForm.tagTypeId"
-            :tag-types="tagTypes"
-            :localize="(map) => localizeValue(map)"
-            data-testid="cms-create-tag-type"
-            @update:model-value="(id) => emit('update-tag-type', id)"
-            @create-request="(initial) => emit('request-create-tag-type', initial)"
-          />
-        </fieldset>
-
-        <label class="cms-toggle-row">
-          <input
-            :checked="createForm.public"
-            type="checkbox"
-            data-testid="cms-create-tag-public"
-            @change="emit('update-public', ($event.target as HTMLInputElement).checked)"
-          />
-          <span>{{ t("cms.columns.public") }}</span>
-        </label>
-
-        <p v-if="createError" class="text-sm text-red-700">
-          {{ createError }}
+        <p v-if="error" class="text-sm text-red-700" data-testid="cms-create-tag-type-error">
+          {{ error }}
         </p>
       </div>
 
@@ -89,10 +63,11 @@
         <button
           type="button"
           class="cms-side-save"
+          data-testid="cms-create-tag-type-submit"
           :disabled="isCreating"
-          @click="emit('submit')"
+          @click="submit"
         >
-          {{ isCreating ? t("general.saving") : t("cms.create.submitTag") }}
+          {{ isCreating ? t("general.saving") : t("cms.create.submitTagType") }}
         </button>
       </footer>
     </section>
@@ -100,47 +75,87 @@
 </template>
 
 <script setup lang="ts">
+import { computed, reactive, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { TagType } from "@viernulvier/shared";
-import type { CreateTagFormState } from "@/services/cms";
 import type { SupportedLang } from "@/i18n";
+import { emptyLangRecord } from "@/services/cms/helpers";
+import { toLanguageMap } from "@/services/cms";
 import type { LanguageMap } from "@/utils/language-utils";
-import TagTypePicker from "@/components/admin/cms/tags/TagTypePicker.vue";
 
-defineProps<{
+const props = defineProps<{
   open: boolean;
-  createForm: CreateTagFormState;
-  createExtraLangs: { en: boolean; fr: boolean };
-  visibleCreateLangs: SupportedLang[];
-  langGridClass: string;
-  tagTypes: TagType[];
-  createError: string | null;
+  /** Pre-fill the active language input when opening (e.g. text typed into the picker). */
+  initialName?: string;
+  /** Which language `initialName` belongs to. Defaults to "nl". */
+  initialLang?: SupportedLang;
   isCreating: boolean;
-  localizeValue: (map: LanguageMap | null | undefined) => string;
+  error: string | null;
 }>();
 
 const emit = defineEmits<{
   (e: "close"): void;
-  (e: "submit"): void;
-  (e: "update-name", lang: SupportedLang, value: string): void;
-  (e: "update-tag-type", id: number | null): void;
-  (e: "update-public", value: boolean): void;
-  (e: "update-extra-lang", lang: "en" | "fr", value: boolean): void;
-  (e: "request-create-tag-type", initialName: string): void;
+  (e: "submit", payload: { name: LanguageMap }): void;
 }>();
 
 const { t } = useI18n();
+
+const name = reactive<Record<SupportedLang, string>>(emptyLangRecord());
+const extraLangs = ref({ en: false, fr: false });
+
+const visibleLangs = computed<SupportedLang[]>(() => {
+  const result: SupportedLang[] = ["nl"];
+  if (extraLangs.value.en) result.push("en");
+  if (extraLangs.value.fr) result.push("fr");
+  return result;
+});
+
+const langGridClass = computed(() => {
+  const count = visibleLangs.value.length;
+  if (count <= 1) return "cms-lang-grid cms-lang-grid-single";
+  if (count === 2) return "cms-lang-grid cms-lang-grid-double";
+  return "cms-lang-grid";
+});
+
+function toggleExtraLang(lang: "en" | "fr"): void {
+  extraLangs.value = { ...extraLangs.value, [lang]: !extraLangs.value[lang] };
+}
+
+function resetForm(): void {
+  const fresh = emptyLangRecord();
+  for (const key of Object.keys(name) as SupportedLang[]) {
+    name[key] = fresh[key];
+  }
+  extraLangs.value = { en: false, fr: false };
+}
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (isOpen) {
+      resetForm();
+      const lang = props.initialLang ?? "nl";
+      if (props.initialName !== undefined) {
+        name[lang] = props.initialName;
+      }
+    }
+  },
+  { immediate: true },
+);
+
+function submit(): void {
+  emit("submit", { name: toLanguageMap(name) });
+}
 </script>
 
 <style scoped>
 @reference "@/style.css";
 
 .cms-modal-overlay {
-  @apply fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4;
+  @apply fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4;
 }
 
 .cms-modal {
-  @apply flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-surface-3 bg-surface-0;
+  @apply flex max-h-[85vh] w-full max-w-xl flex-col overflow-hidden rounded-xl border border-surface-3 bg-surface-0;
 }
 
 .cms-modal-header {
@@ -201,10 +216,6 @@ const { t } = useI18n();
 
 .cms-text-input {
   @apply rounded-md border border-surface-3 bg-surface-0 px-3 py-2 text-sm text-ink-primary;
-}
-
-.cms-toggle-row {
-  @apply flex items-center gap-2 text-sm text-ink-primary;
 }
 
 .cms-side-close {

--- a/frontend/src/components/admin/cms/tags/CmsTagsTab.vue
+++ b/frontend/src/components/admin/cms/tags/CmsTagsTab.vue
@@ -121,6 +121,7 @@ import { useCmsRemove } from "@/composables/useCmsRemove";
 import { useCmsTagGrid } from "@/composables/useCmsTagGrid";
 import { useDarkMode } from "@/composables/useDarkMode";
 import { i18n, type SupportedLang } from "@/i18n";
+import { ApiError } from "@/services/api";
 import { createTag, createTagType, deleteTag, getAllTags, getTagTypes, updateTag } from "@/services/tags";
 import { localizeOrEmpty, type LanguageMap } from "@/utils/language-utils";
 import {
@@ -361,9 +362,27 @@ function closeTagTypeModal(): void {
   tagTypeModalOrigin.value = null;
 }
 
+function findDuplicateTagType(name: LanguageMap): TagType | null {
+  const entries = (Object.entries(name) as Array<[SupportedLang, string | undefined]>)
+    .map(([lang, value]) => [lang, value?.trim().toLowerCase() ?? ""] as const)
+    .filter(([, value]) => value.length > 0);
+  if (entries.length === 0) return null;
+  return (
+    tagTypesData.value.find((type) => {
+      const existing: LanguageMap = type.name ?? {};
+      return entries.some(([lang, value]) => existing[lang]?.trim().toLowerCase() === value);
+    }) ?? null
+  );
+}
+
 async function submitCreateTagType(payload: { name: LanguageMap }): Promise<void> {
   if (Object.keys(payload.name).length === 0) {
     tagTypeModalError.value = t("cms.create.validation.tagTypeNameRequired");
+    return;
+  }
+
+  if (findDuplicateTagType(payload.name)) {
+    tagTypeModalError.value = t("cms.create.validation.tagTypeNameConflict");
     return;
   }
 
@@ -390,8 +409,7 @@ async function submitCreateTagType(payload: { name: LanguageMap }): Promise<void
 
     closeTagTypeModal();
   } catch (error) {
-    const message = error instanceof Error ? error.message : "";
-    if (message.toLowerCase().includes("conflict") || message.includes("409")) {
+    if (error instanceof ApiError && error.isConflict) {
       tagTypeModalError.value = t("cms.create.validation.tagTypeNameConflict");
     } else {
       tagTypeModalError.value = error instanceof Error

--- a/frontend/src/components/admin/cms/tags/CmsTagsTab.vue
+++ b/frontend/src/components/admin/cms/tags/CmsTagsTab.vue
@@ -92,6 +92,16 @@
         @update-tag-type="setCreateTagType"
         @update-public="setCreatePublic"
         @update-extra-lang="setCreateExtraLang"
+        @request-create-tag-type="openTagTypeModalFromCreate"
+      />
+
+      <CmsCreateTagTypeModal
+        :open="tagTypeModalOpen"
+        :initial-name="tagTypeModalInitialName"
+        :is-creating="isCreatingTagType"
+        :error="tagTypeModalError"
+        @close="closeTagTypeModal"
+        @submit="submitCreateTagType"
       />
     </template>
   </CmsTabShell>
@@ -106,11 +116,12 @@ import type { Tag, TagType } from "@viernulvier/shared";
 import CmsRemoveConfirmModal from "@/components/admin/cms/CmsRemoveConfirmModal.vue";
 import CmsTabShell from "@/components/admin/cms/CmsTabShell.vue";
 import CmsCreateTagModal from "@/components/admin/cms/tags/CmsCreateTagModal.vue";
+import CmsCreateTagTypeModal from "@/components/admin/cms/tags/CmsCreateTagTypeModal.vue";
 import { useCmsRemove } from "@/composables/useCmsRemove";
 import { useCmsTagGrid } from "@/composables/useCmsTagGrid";
 import { useDarkMode } from "@/composables/useDarkMode";
 import { i18n, type SupportedLang } from "@/i18n";
-import { createTag, deleteTag, getAllTags, getTagTypes, updateTag } from "@/services/tags";
+import { createTag, createTagType, deleteTag, getAllTags, getTagTypes, updateTag } from "@/services/tags";
 import { localizeOrEmpty, type LanguageMap } from "@/utils/language-utils";
 import {
   applyUpdatedTagToRow,
@@ -124,6 +135,30 @@ import {
 
 const { t } = useI18n();
 const { isDark } = useDarkMode();
+
+const isLoading = ref(false);
+const isSaving = ref(false);
+const isCreating = ref(false);
+const loadError = ref<string | null>(null);
+const saveError = ref<string | null>(null);
+const createError = ref<string | null>(null);
+const rowData = ref<CmsTagGridRow[]>([]);
+const tagsData = ref<Tag[]>([]);
+const tagTypesData = ref<TagType[]>([]);
+
+const createModalOpen = ref(false);
+const createForm = ref<CreateTagFormState>(buildEmptyTagForm());
+const createExtraLangs = ref({ en: false, fr: false });
+
+const tagTypeModalOpen = ref(false);
+const tagTypeModalInitialName = ref("");
+const tagTypeModalError = ref<string | null>(null);
+const isCreatingTagType = ref(false);
+/** Tracks the originator of the tag-type modal so we re-select the new type in the right place. */
+type TagTypeModalOrigin =
+  | { kind: "createTagModal" }
+  | { kind: "gridRow"; rowId: number };
+const tagTypeModalOrigin = ref<TagTypeModalOrigin | null>(null);
 
 const {
   agThemeVars,
@@ -147,21 +182,15 @@ const {
   applyQuickFilter,
   persistGridState,
   gridApi,
-} = useCmsTagGrid({ isDark, t });
-
-const isLoading = ref(false);
-const isSaving = ref(false);
-const isCreating = ref(false);
-const loadError = ref<string | null>(null);
-const saveError = ref<string | null>(null);
-const createError = ref<string | null>(null);
-const rowData = ref<CmsTagGridRow[]>([]);
-const tagsData = ref<Tag[]>([]);
-const tagTypesData = ref<TagType[]>([]);
-
-const createModalOpen = ref(false);
-const createForm = ref<CreateTagFormState>(buildEmptyTagForm());
-const createExtraLangs = ref({ en: false, fr: false });
+} = useCmsTagGrid({
+  isDark,
+  t,
+  getTagTypes: () => tagTypesData.value,
+  localize: (map) => localizeValue(map),
+  onCreateTagTypeRequest: ({ rowId, initialName }) => {
+    openTagTypeModal(initialName, { kind: "gridRow", rowId });
+  },
+});
 const visibleCreateLangs = computed<SupportedLang[]>(() => {
   const result: SupportedLang[] = ["nl"];
   if (createExtraLangs.value.en) result.push("en");
@@ -231,10 +260,11 @@ async function persistTagPatch(
 async function onCellEditingStopped(
   event: CellEditingStoppedEvent<CmsTagGridRow>,
 ): Promise<void> {
-  if (!event.data || !event.colDef.field) {
+  if (!event.data) {
     return;
   }
 
+  const colId = event.column?.getColId();
   const field = event.colDef.field;
   const newValue = event.value;
   const oldValue = event.oldValue;
@@ -254,12 +284,21 @@ async function onCellEditingStopped(
       await persistTagPatch(event.data, { name: nextMap });
     } else if (field === "public") {
       await persistTagPatch(event.data, { public: Boolean(newValue) });
-    } else {
+    } else if (colId === "tagType") {
+      const newId = typeof newValue === "number" ? newValue : Number(newValue);
+      if (!Number.isFinite(newId) || newId <= 0) {
+        return;
+      }
+      await persistTagPatch(event.data, { tag_type: newId });
+      event.api.refreshCells({ rowNodes: [event.node], columns: ["tagType"], force: true });
+    } else if (field) {
       event.node.setDataValue(field, oldValue);
       return;
     }
   } catch {
-    event.node.setDataValue(field, oldValue);
+    if (field) {
+      event.node.setDataValue(field, oldValue);
+    }
   } finally {
     isSaving.value = false;
     persistGridState();
@@ -302,6 +341,66 @@ function setCreatePublic(value: boolean): void {
 
 function setCreateExtraLang(lang: "en" | "fr", value: boolean): void {
   createExtraLangs.value = { ...createExtraLangs.value, [lang]: value };
+}
+
+function openTagTypeModal(initialName: string, origin: TagTypeModalOrigin): void {
+  tagTypeModalInitialName.value = initialName;
+  tagTypeModalOrigin.value = origin;
+  tagTypeModalError.value = null;
+  tagTypeModalOpen.value = true;
+}
+
+function openTagTypeModalFromCreate(initialName: string): void {
+  openTagTypeModal(initialName, { kind: "createTagModal" });
+}
+
+function closeTagTypeModal(): void {
+  tagTypeModalOpen.value = false;
+  tagTypeModalError.value = null;
+  tagTypeModalInitialName.value = "";
+  tagTypeModalOrigin.value = null;
+}
+
+async function submitCreateTagType(payload: { name: LanguageMap }): Promise<void> {
+  if (Object.keys(payload.name).length === 0) {
+    tagTypeModalError.value = t("cms.create.validation.tagTypeNameRequired");
+    return;
+  }
+
+  isCreatingTagType.value = true;
+  tagTypeModalError.value = null;
+  try {
+    const created = await createTagType({ name: payload.name });
+    tagTypesData.value = [...tagTypesData.value, created];
+
+    const origin = tagTypeModalOrigin.value;
+    if (origin?.kind === "createTagModal") {
+      createForm.value = { ...createForm.value, tagTypeId: created.id };
+    } else if (origin?.kind === "gridRow") {
+      const row = rowData.value.find((r) => r.id === origin.rowId);
+      if (row) {
+        try {
+          await persistTagPatch(row, { tag_type: created.id });
+          gridApi.value?.refreshCells({ columns: ["tagType"], force: true });
+        } catch {
+          // saveError already set by persistTagPatch
+        }
+      }
+    }
+
+    closeTagTypeModal();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.toLowerCase().includes("conflict") || message.includes("409")) {
+      tagTypeModalError.value = t("cms.create.validation.tagTypeNameConflict");
+    } else {
+      tagTypeModalError.value = error instanceof Error
+        ? t("cms.errors.saveFailed", { message: error.message })
+        : t("cms.errors.saveGeneric");
+    }
+  } finally {
+    isCreatingTagType.value = false;
+  }
 }
 
 async function submitCreateTag(): Promise<void> {
@@ -377,6 +476,14 @@ defineExpose({
     setCreateTagType,
     setCreatePublic,
     setCreateExtraLang,
+    tagTypeModalOpen,
+    tagTypeModalInitialName,
+    tagTypeModalError,
+    isCreatingTagType,
+    openTagTypeModal,
+    openTagTypeModalFromCreate,
+    closeTagTypeModal,
+    submitCreateTagType,
     removeConfirmOpen,
     removeConfirmLoading,
     removeConfirmError,

--- a/frontend/src/components/admin/cms/tags/TagTypeCellEditor.vue
+++ b/frontend/src/components/admin/cms/tags/TagTypeCellEditor.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="tag-type-cell-editor">
+    <TagTypePicker
+      :model-value="value"
+      :tag-types="tagTypes"
+      :localize="localize"
+      :auto-focus="true"
+      data-testid="tag-type-cell-editor-picker"
+      @update:model-value="onPick"
+      @create-request="onCreateRequest"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import type { TagType } from "@viernulvier/shared";
+import type { LanguageMap } from "@/utils/language-utils";
+import TagTypePicker from "@/components/admin/cms/tags/TagTypePicker.vue";
+
+interface CellEditorParams {
+  value: number | null;
+  data: { id: number; tagTypeId: number | null };
+  tagTypes: TagType[];
+  localize: (map: LanguageMap | null | undefined) => string;
+  stopEditing: (cancel?: boolean) => void;
+  onCreateRequest: (ctx: { rowId: number; initialName: string }) => void;
+}
+
+const props = defineProps<{ params: CellEditorParams }>();
+
+const value = ref<number | null>(props.params.value ?? props.params.data?.tagTypeId ?? null);
+const tagTypes = props.params.tagTypes;
+const localize = props.params.localize;
+
+function onPick(id: number | null): void {
+  value.value = id;
+  // Commit immediately — ag-grid will read getValue() then stop editing.
+  props.params.stopEditing();
+}
+
+function onCreateRequest(initialName: string): void {
+  // Cancel inline editing — the modal will handle tag-type creation and
+  // persist the new tag-type id to the row.
+  props.params.stopEditing(true);
+  props.params.onCreateRequest({
+    rowId: props.params.data.id,
+    initialName,
+  });
+}
+
+defineExpose({
+  getValue: (): number | null => value.value,
+  isCancelBeforeStart: (): boolean => false,
+  isCancelAfterEnd: (): boolean => false,
+});
+</script>
+
+<style scoped>
+@reference "@/style.css";
+
+.tag-type-cell-editor {
+  @apply min-w-[220px] p-1;
+}
+</style>

--- a/frontend/src/components/admin/cms/tags/TagTypePicker.vue
+++ b/frontend/src/components/admin/cms/tags/TagTypePicker.vue
@@ -1,0 +1,290 @@
+<template>
+  <div ref="rootRef" class="tag-type-picker" :class="{ 'is-open': isOpen, 'is-disabled': disabled }">
+    <input
+      ref="inputRef"
+      v-model="query"
+      type="text"
+      class="tag-type-picker-input"
+      :placeholder="placeholder ?? t('cms.tagTypePicker.placeholder')"
+      :disabled="disabled"
+      :data-testid="dataTestid"
+      role="combobox"
+      aria-haspopup="listbox"
+      :aria-expanded="isOpen"
+      @focus="openMenu"
+      @input="openMenu"
+      @keydown="onKeyDown"
+      @blur="onInputBlur"
+    />
+
+    <ul
+      v-if="isOpen"
+      class="tag-type-picker-list"
+      role="listbox"
+      :aria-label="t('cms.columns.tagType')"
+      @mousedown.prevent
+    >
+      <li
+        v-for="(type, index) in filteredTypes"
+        :key="type.id"
+        class="tag-type-picker-item"
+        :class="{ 'is-active': index === activeIndex, 'is-selected': type.id === modelValue }"
+        role="option"
+        :aria-selected="type.id === modelValue"
+        :data-testid="`tag-type-picker-item-${type.id}`"
+        @mouseenter="activeIndex = index"
+        @click="selectType(type)"
+      >
+        {{ localizeName(type) || `#${type.id}` }}
+      </li>
+
+      <li
+        v-if="filteredTypes.length === 0 && !canCreate"
+        class="tag-type-picker-empty"
+        role="presentation"
+      >
+        {{ t("cms.tagTypePicker.noMatch") }}
+      </li>
+
+      <li
+        v-if="canCreate"
+        class="tag-type-picker-create"
+        :class="{ 'is-active': activeIndex === filteredTypes.length }"
+        role="option"
+        :aria-selected="false"
+        data-testid="tag-type-picker-create"
+        @mouseenter="activeIndex = filteredTypes.length"
+        @click="requestCreate"
+      >
+        {{
+          query.trim().length > 0
+            ? t("cms.tagTypePicker.createNew", { name: query.trim() })
+            : t("cms.tagTypePicker.createNewEmpty")
+        }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import type { TagType } from "@viernulvier/shared";
+import type { LanguageMap } from "@/utils/language-utils";
+
+const props = defineProps<{
+  modelValue: number | null;
+  tagTypes: TagType[];
+  localize: (map: LanguageMap | null | undefined) => string;
+  disabled?: boolean;
+  placeholder?: string;
+  dataTestid?: string;
+  /** Auto-focus the input on mount (useful when used as a grid cell editor). */
+  autoFocus?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", id: number | null): void;
+  (e: "create-request", initialName: string): void;
+  (e: "open"): void;
+  (e: "close"): void;
+}>();
+
+const { t } = useI18n();
+
+const rootRef = useTemplateRef<HTMLDivElement>("rootRef");
+const inputRef = useTemplateRef<HTMLInputElement>("inputRef");
+const isOpen = ref(false);
+const query = ref("");
+const activeIndex = ref(0);
+
+function localizeName(type: TagType): string {
+  return props.localize(type.name);
+}
+
+function syncQueryFromSelected(): void {
+  if (props.modelValue === null) {
+    query.value = "";
+    return;
+  }
+  const selected = props.tagTypes.find((type) => type.id === props.modelValue);
+  query.value = selected ? localizeName(selected) || `#${selected.id}` : "";
+}
+
+const filteredTypes = computed<TagType[]>(() => {
+  const q = query.value.trim().toLowerCase();
+  if (q.length === 0) {
+    return props.tagTypes;
+  }
+  return props.tagTypes.filter((type) => {
+    const label = (localizeName(type) || `#${type.id}`).toLowerCase();
+    return label.includes(q);
+  });
+});
+
+const exactMatch = computed<TagType | null>(() => {
+  const q = query.value.trim().toLowerCase();
+  if (q.length === 0) return null;
+  return (
+    props.tagTypes.find((type) => (localizeName(type) || `#${type.id}`).toLowerCase() === q) ??
+    null
+  );
+});
+
+const canCreate = computed<boolean>(() => {
+  if (props.disabled) return false;
+  return exactMatch.value === null;
+});
+
+function openMenu(): void {
+  if (props.disabled) return;
+  if (!isOpen.value) {
+    isOpen.value = true;
+    emit("open");
+  }
+  activeIndex.value = 0;
+}
+
+function closeMenu(): void {
+  if (!isOpen.value) return;
+  isOpen.value = false;
+  emit("close");
+}
+
+function selectType(type: TagType): void {
+  emit("update:modelValue", type.id);
+  query.value = localizeName(type) || `#${type.id}`;
+  closeMenu();
+}
+
+function requestCreate(): void {
+  const initial = query.value.trim();
+  emit("create-request", initial);
+  closeMenu();
+}
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (props.disabled) return;
+  const totalItems = filteredTypes.value.length + (canCreate.value ? 1 : 0);
+
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    openMenu();
+    activeIndex.value = totalItems === 0 ? 0 : (activeIndex.value + 1) % totalItems;
+  } else if (event.key === "ArrowUp") {
+    event.preventDefault();
+    openMenu();
+    activeIndex.value = totalItems === 0 ? 0 : (activeIndex.value - 1 + totalItems) % totalItems;
+  } else if (event.key === "Enter") {
+    if (!isOpen.value) return;
+    event.preventDefault();
+    if (activeIndex.value < filteredTypes.value.length) {
+      const type = filteredTypes.value[activeIndex.value];
+      if (type) selectType(type);
+    } else if (canCreate.value) {
+      requestCreate();
+    }
+  } else if (event.key === "Escape") {
+    if (isOpen.value) {
+      event.preventDefault();
+      syncQueryFromSelected();
+      closeMenu();
+    }
+  }
+}
+
+function onInputBlur(): void {
+  // Slight delay so click on list items can still register.
+  window.setTimeout(() => {
+    if (!rootRef.value?.contains(document.activeElement)) {
+      syncQueryFromSelected();
+      closeMenu();
+    }
+  }, 120);
+}
+
+function onDocumentClick(event: MouseEvent): void {
+  if (!rootRef.value) return;
+  if (!rootRef.value.contains(event.target as Node)) {
+    syncQueryFromSelected();
+    closeMenu();
+  }
+}
+
+watch(
+  () => props.modelValue,
+  () => {
+    syncQueryFromSelected();
+  },
+);
+
+watch(
+  () => props.tagTypes,
+  () => {
+    syncQueryFromSelected();
+  },
+  { deep: true },
+);
+
+onMounted(() => {
+  syncQueryFromSelected();
+  document.addEventListener("mousedown", onDocumentClick);
+  if (props.autoFocus) {
+    void nextTick(() => {
+      inputRef.value?.focus();
+      inputRef.value?.select();
+    });
+  }
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener("mousedown", onDocumentClick);
+});
+
+defineExpose({
+  focus: () => inputRef.value?.focus(),
+});
+</script>
+
+<style scoped>
+@reference "@/style.css";
+
+.tag-type-picker {
+  @apply relative w-full;
+}
+
+.tag-type-picker-input {
+  @apply w-full rounded-md border border-surface-3 bg-surface-0 px-3 py-2 text-sm text-ink-primary;
+}
+
+.tag-type-picker.is-disabled .tag-type-picker-input {
+  @apply cursor-not-allowed opacity-60;
+}
+
+.tag-type-picker-list {
+  @apply absolute left-0 right-0 top-full z-30 mt-1 max-h-60 overflow-y-auto rounded-md border border-surface-3 bg-surface-0 py-1 shadow-lg;
+}
+
+.tag-type-picker-item,
+.tag-type-picker-create,
+.tag-type-picker-empty {
+  @apply cursor-pointer px-3 py-2 text-sm text-ink-primary;
+}
+
+.tag-type-picker-empty {
+  @apply cursor-default text-ink-secondary;
+}
+
+.tag-type-picker-item.is-active,
+.tag-type-picker-create.is-active {
+  @apply bg-surface-1;
+}
+
+.tag-type-picker-item.is-selected {
+  @apply font-semibold;
+}
+
+.tag-type-picker-create {
+  @apply border-t border-surface-3 font-semibold text-ink-primary;
+}
+</style>

--- a/frontend/src/composables/useCmsTagGrid.ts
+++ b/frontend/src/composables/useCmsTagGrid.ts
@@ -1,6 +1,9 @@
-import { computed, type Ref } from "vue";
+import { computed, markRaw, type Ref } from "vue";
 import type { ColDef } from "ag-grid-community";
+import type { TagType } from "@viernulvier/shared";
 import type { CmsTagGridRow } from "@/services/cms";
+import type { LanguageMap } from "@/utils/language-utils";
+import TagTypeCellEditor from "@/components/admin/cms/tags/TagTypeCellEditor.vue";
 import { useCmsGridBase } from "./useCmsGridBase";
 
 type TranslateFunction = (key: string, params?: Record<string, unknown>) => string;
@@ -16,6 +19,9 @@ const cmsTagGridColumnIds = [
 export function useCmsTagGrid(options: {
   isDark: Ref<boolean>;
   t: TranslateFunction;
+  getTagTypes: () => TagType[];
+  localize: (map: LanguageMap | null | undefined) => string;
+  onCreateTagTypeRequest: (ctx: { rowId: number; initialName: string }) => void;
 }) {
   const base = useCmsGridBase<CmsTagGridRow>({
     isDark: options.isDark,
@@ -58,9 +64,26 @@ export function useCmsTagGrid(options: {
       flex: 1,
     },
     {
+      colId: "tagType",
       headerName: options.t("cms.columns.tagType"),
-      field: "tagType",
-      editable: false,
+      valueGetter: (params) => params.data?.tagTypeId ?? null,
+      valueFormatter: (params) => {
+        const row = params.data as CmsTagGridRow | undefined;
+        return row?.tagType ?? "";
+      },
+      filterValueGetter: (params) => {
+        const row = params.data as CmsTagGridRow | undefined;
+        return row?.tagType ?? "";
+      },
+      editable: true,
+      singleClickEdit: true,
+      cellEditor: markRaw(TagTypeCellEditor),
+      cellEditorPopup: true,
+      cellEditorParams: () => ({
+        tagTypes: options.getTagTypes(),
+        localize: options.localize,
+        onCreateRequest: options.onCreateTagTypeRequest,
+      }),
       minWidth: 160,
     },
     {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -144,6 +144,8 @@ export default {
       tagTitle: "New tag",
       submitTag: "Add tag",
       selectTagType: "Choose a type...",
+      tagTypeTitle: "New tag type",
+      submitTagType: "Add tag type",
       finalized: "Mark as finalized",
       languages: "Extra languages",
       submit: "Add production",
@@ -176,6 +178,8 @@ export default {
         requiredOneLanguage: "Fill at least 1 language for: {field}",
         imageRequired: "Fill at least one image URL (in any language).",
         tagTypeRequired: "Select a tag type.",
+        tagTypeNameRequired: "Fill at least 1 language for the tag type name.",
+        tagTypeNameConflict: "A tag type with this name already exists.",
       },
       admin: {
         adminTitle: "New admin",
@@ -205,6 +209,12 @@ export default {
     },
     admin: {
       noPermission: "You don't have permissions to manage admins.",
+    },
+    tagTypePicker: {
+      placeholder: "Search or type a type...",
+      createNew: "+ Create new type '{name}'",
+      createNewEmpty: "+ Create new tag type",
+      noMatch: "No matching types",
     },
   },
   productionsPage: {

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -144,6 +144,8 @@ export default {
       tagTitle: "Nouveau tag",
       submitTag: "Ajouter le tag",
       selectTagType: "Choisissez un type...",
+      tagTypeTitle: "Nouveau type de tag",
+      submitTagType: "Ajouter le type de tag",
       finalized: "Marquer comme finalisee",
       languages: "Langues supplementaires",
       submit: "Ajouter la production",
@@ -175,6 +177,8 @@ export default {
         requiredOneLanguage: "Remplissez au moins 1 langue pour: {field}",
         imageRequired: "Remplissez au moins une URL d'image (dans n'importe quelle langue).",
         tagTypeRequired: "Sélectionnez un type de tag.",
+        tagTypeNameRequired: "Remplissez au moins 1 langue pour le nom du type de tag.",
+        tagTypeNameConflict: "Un type de tag avec ce nom existe déjà.",
       },
       admin: {
         adminTitle: "Nouvel admin",
@@ -204,6 +208,12 @@ export default {
     },
     admin: {
       noPermission: "Vous n'avez pas la permission de administrer les admins.",
+    },
+    tagTypePicker: {
+      placeholder: "Rechercher ou saisir un type...",
+      createNew: "+ Créer un nouveau type '{name}'",
+      createNewEmpty: "+ Créer un nouveau type de tag",
+      noMatch: "Aucun type correspondant",
     },
   },
   productionsPage: {

--- a/frontend/src/i18n/locales/nl.ts
+++ b/frontend/src/i18n/locales/nl.ts
@@ -144,6 +144,8 @@ export default {
       tagTitle: "Nieuwe tag",
       submitTag: "Tag toevoegen",
       selectTagType: "Kies een type...",
+      tagTypeTitle: "Nieuw tag type",
+      submitTagType: "Tag type toevoegen",
       finalized: "Markeer als gefinaliseerd",
       languages: "Extra talen",
       submit: "Productie toevoegen",
@@ -175,6 +177,8 @@ export default {
         requiredOneLanguage: "Vul minstens 1 taal in voor: {field}",
         imageRequired: "Vul minstens een afbeelding URL in (in eender welke taal).",
         tagTypeRequired: "Selecteer een tag-type.",
+        tagTypeNameRequired: "Vul minstens 1 taal in voor de tag-type naam.",
+        tagTypeNameConflict: "Er bestaat al een tag-type met deze naam.",
       },
       admin: {
         adminTitle: "Nieuwe admin",
@@ -204,6 +208,12 @@ export default {
     },
     admin: {
       noPermission: "Je hebt geen toestemming om admins te beheren.",
+    },
+    tagTypePicker: {
+      placeholder: "Zoek of typ een type...",
+      createNew: "+ Maak nieuw type '{name}'",
+      createNewEmpty: "+ Maak nieuw tag-type",
+      noMatch: "Geen overeenkomende types",
     },
   },
   productionsPage: {

--- a/frontend/test/components/admin/cms/tags/CmsCreateTagModal.test.ts
+++ b/frontend/test/components/admin/cms/tags/CmsCreateTagModal.test.ts
@@ -45,18 +45,20 @@ describe("CmsCreateTagModal", () => {
     expect(events?.[events.length - 1]).toEqual(["nl", "Drama"]);
   });
 
-  it("emits update-tag-type with parsed number on select change", async () => {
+  it("emits update-tag-type when a type is picked from the dropdown", async () => {
     const wrapper = mountModal();
-    await wrapper.get('[data-testid="cms-create-tag-type"]').setValue("1");
+    await wrapper.get('[data-testid="cms-create-tag-type"]').trigger("focus");
+    await wrapper.get('[data-testid="tag-type-picker-item-1"]').trigger("click");
     expect(wrapper.emitted("update-tag-type")?.[0]).toEqual([1]);
   });
 
-  it("emits update-tag-type with null when the placeholder option is chosen", async () => {
+  it("emits request-create-tag-type when the create-new affordance is clicked", async () => {
     const wrapper = mountModal();
-    const select = wrapper.get('[data-testid="cms-create-tag-type"]').element as HTMLSelectElement;
-    select.value = "";
-    await wrapper.get('[data-testid="cms-create-tag-type"]').trigger("change");
-    expect(wrapper.emitted("update-tag-type")?.[0]).toEqual([null]);
+    const input = wrapper.get('[data-testid="cms-create-tag-type"]');
+    await input.trigger("focus");
+    await input.setValue("Workshop");
+    await wrapper.get('[data-testid="tag-type-picker-create"]').trigger("click");
+    expect(wrapper.emitted("request-create-tag-type")?.[0]).toEqual(["Workshop"]);
   });
 
   it("emits update-public on checkbox toggle", async () => {
@@ -88,9 +90,10 @@ describe("CmsCreateTagModal", () => {
     expect(wrapper.emitted("submit")).toHaveLength(1);
   });
 
-  it("falls back to #id label when tag type has no localisable name", () => {
+  it("falls back to #id label when tag type has no localisable name", async () => {
     const wrapper = mountModal();
-    expect(wrapper.text()).toContain("#2");
+    await wrapper.get('[data-testid="cms-create-tag-type"]').trigger("focus");
+    expect(wrapper.get('[data-testid="tag-type-picker-item-2"]').text()).toContain("#2");
   });
 
   it("disables the save button while creating", () => {

--- a/frontend/test/components/admin/cms/tags/CmsCreateTagTypeModal.test.ts
+++ b/frontend/test/components/admin/cms/tags/CmsCreateTagTypeModal.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { i18n } from "@/i18n";
+import CmsCreateTagTypeModal from "@/components/admin/cms/tags/CmsCreateTagTypeModal.vue";
+
+function mountModal(
+  props: Partial<InstanceType<typeof CmsCreateTagTypeModal>["$props"]> = {},
+) {
+  return mount(CmsCreateTagTypeModal, {
+    global: { plugins: [i18n] },
+    props: {
+      open: true,
+      isCreating: false,
+      error: null,
+      ...props,
+    },
+  });
+}
+
+describe("CmsCreateTagTypeModal", () => {
+  it("does not render when closed", () => {
+    const wrapper = mountModal({ open: false });
+    expect(wrapper.find(".cms-modal").exists()).toBe(false);
+  });
+
+  it("renders an NL input by default and hidden EN/FR pills", () => {
+    const wrapper = mountModal();
+    expect(wrapper.find('[data-testid="cms-create-tag-type-name-nl"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="cms-create-tag-type-name-en"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="cms-create-tag-type-name-fr"]').exists()).toBe(false);
+  });
+
+  it("toggles EN/FR language inputs via the pills", async () => {
+    const wrapper = mountModal();
+    const pills = wrapper.findAll(".cms-language-pill");
+    await pills[1].trigger("click");
+    expect(wrapper.find('[data-testid="cms-create-tag-type-name-en"]').exists()).toBe(true);
+    await pills[2].trigger("click");
+    expect(wrapper.find('[data-testid="cms-create-tag-type-name-fr"]').exists()).toBe(true);
+  });
+
+  it("pre-fills the initial name in NL when initialName is provided", async () => {
+    const wrapper = mountModal({ initialName: "Workshop" });
+    const input = wrapper.get('[data-testid="cms-create-tag-type-name-nl"]')
+      .element as HTMLInputElement;
+    expect(input.value).toBe("Workshop");
+  });
+
+  it("respects initialLang when prefilling", async () => {
+    const wrapper = mountModal({ initialName: "Atelier", initialLang: "fr" });
+    const pills = wrapper.findAll(".cms-language-pill");
+    await pills[2].trigger("click");
+    const input = wrapper.get('[data-testid="cms-create-tag-type-name-fr"]')
+      .element as HTMLInputElement;
+    expect(input.value).toBe("Atelier");
+  });
+
+  it("emits submit with a LanguageMap containing the filled languages", async () => {
+    const wrapper = mountModal();
+    await wrapper.get('[data-testid="cms-create-tag-type-name-nl"]').setValue("Concert");
+    await wrapper.get('[data-testid="cms-create-tag-type-submit"]').trigger("click");
+    const emitted = wrapper.emitted("submit");
+    expect(emitted).toHaveLength(1);
+    expect(emitted![0][0]).toEqual({ name: { nl: "Concert" } });
+  });
+
+  it("submit with no values still emits (parent validates)", async () => {
+    const wrapper = mountModal();
+    await wrapper.get('[data-testid="cms-create-tag-type-submit"]').trigger("click");
+    expect(wrapper.emitted("submit")?.[0]).toEqual([{ name: {} }]);
+  });
+
+  it("disables the save button while creating", () => {
+    const wrapper = mountModal({ isCreating: true });
+    const btn = wrapper.get('[data-testid="cms-create-tag-type-submit"]')
+      .element as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("renders the error message when provided", () => {
+    const wrapper = mountModal({ error: "Already exists" });
+    expect(wrapper.get('[data-testid="cms-create-tag-type-error"]').text()).toContain(
+      "Already exists",
+    );
+  });
+
+  it("emits close on overlay click, header close, and cancel button", async () => {
+    const wrapper = mountModal();
+    await wrapper.get(".cms-modal-overlay").trigger("click");
+    await wrapper.get(".cms-modal-header .cms-side-close").trigger("click");
+    await wrapper.get(".cms-modal-footer .cms-side-close").trigger("click");
+    expect(wrapper.emitted("close")?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("resets the form when reopened", async () => {
+    const wrapper = mountModal({ open: false });
+    await wrapper.setProps({ open: true, initialName: "First" });
+    expect(
+      (wrapper.get('[data-testid="cms-create-tag-type-name-nl"]').element as HTMLInputElement).value,
+    ).toBe("First");
+
+    await wrapper.setProps({ open: false });
+    await wrapper.setProps({ open: true, initialName: "Second" });
+    expect(
+      (wrapper.get('[data-testid="cms-create-tag-type-name-nl"]').element as HTMLInputElement).value,
+    ).toBe("Second");
+  });
+
+  it("uses lang-grid-double when two languages are visible", async () => {
+    const wrapper = mountModal();
+    const pills = wrapper.findAll(".cms-language-pill");
+    await pills[1].trigger("click");
+    expect(wrapper.find(".cms-lang-grid-double").exists()).toBe(true);
+  });
+
+  it("uses the full lang-grid (three columns) when all languages are visible", async () => {
+    const wrapper = mountModal();
+    const pills = wrapper.findAll(".cms-language-pill");
+    await pills[1].trigger("click");
+    await pills[2].trigger("click");
+    expect(wrapper.find(".cms-lang-grid-single").exists()).toBe(false);
+    expect(wrapper.find(".cms-lang-grid-double").exists()).toBe(false);
+  });
+});

--- a/frontend/test/components/admin/cms/tags/CmsTagsTab.test.ts
+++ b/frontend/test/components/admin/cms/tags/CmsTagsTab.test.ts
@@ -4,6 +4,7 @@ import { defineComponent } from "vue";
 import type { Tag, TagType } from "@viernulvier/shared";
 import { i18n } from "@/i18n";
 import CmsTagsTab from "@/components/admin/cms/tags/CmsTagsTab.vue";
+import { ApiError } from "@/services/api";
 import * as tagsService from "@/services/tags";
 
 vi.mock("@/services/tags", () => ({
@@ -12,6 +13,7 @@ vi.mock("@/services/tags", () => ({
   updateTag: vi.fn(),
   createTag: vi.fn(),
   deleteTag: vi.fn(),
+  createTagType: vi.fn(),
 }));
 
 const gridStub = defineComponent({
@@ -61,6 +63,11 @@ describe("CmsTagsTab", () => {
     vi.spyOn(tagsService, "updateTag").mockResolvedValue({ ...mockPublicTag, public: false });
     vi.spyOn(tagsService, "createTag").mockResolvedValue({ ...mockPublicTag, id: 42 } as never);
     vi.spyOn(tagsService, "deleteTag").mockResolvedValue();
+    vi.spyOn(tagsService, "createTagType").mockResolvedValue({
+      id: 999,
+      old_id: null,
+      name: { nl: "Workshop" },
+    } as never);
   });
 
   it("loads tags and tag types on mount", async () => {
@@ -121,7 +128,7 @@ describe("CmsTagsTab", () => {
     });
   });
 
-  it("ignores non-editable fields", async () => {
+  it("ignores edits to fields that aren't wired for persistence", async () => {
     const wrapper = mountTab();
     await flushPromises();
     const api = (wrapper.vm as any).__test;
@@ -130,14 +137,15 @@ describe("CmsTagsTab", () => {
 
     await api.onCellEditingStopped({
       data: row,
-      colDef: { field: "tagType" },
-      value: "X",
-      oldValue: "Genre",
+      colDef: { field: "productionCount" },
+      column: { getColId: () => "productionCount" },
+      value: 99,
+      oldValue: 3,
       node: { setDataValue },
     });
 
     expect(tagsService.updateTag).not.toHaveBeenCalled();
-    expect(setDataValue).toHaveBeenCalledWith("tagType", "Genre");
+    expect(setDataValue).toHaveBeenCalledWith("productionCount", 3);
   });
 
   it("skips persistence when value did not change", async () => {
@@ -351,6 +359,223 @@ describe("CmsTagsTab", () => {
     });
 
     expect(api.saveError.value).toBeTruthy();
+  });
+
+  describe("tag-type creation flow", () => {
+    it("openTagTypeModalFromCreate opens the sub-modal with createTagModal origin", async () => {
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+
+      api.openTagTypeModalFromCreate("Workshop");
+
+      expect(api.tagTypeModalOpen.value).toBe(true);
+      expect(api.tagTypeModalInitialName.value).toBe("Workshop");
+    });
+
+    it("closeTagTypeModal clears state", async () => {
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+
+      api.openTagTypeModalFromCreate("Something");
+      api.closeTagTypeModal();
+
+      expect(api.tagTypeModalOpen.value).toBe(false);
+      expect(api.tagTypeModalInitialName.value).toBe("");
+      expect(api.tagTypeModalError.value).toBeNull();
+    });
+
+    it("rejects an empty name without calling the API", async () => {
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+
+      api.openTagTypeModalFromCreate("");
+      await api.submitCreateTagType({ name: {} });
+
+      expect(tagsService.createTagType).not.toHaveBeenCalled();
+      expect(api.tagTypeModalError.value).toBeTruthy();
+    });
+
+    it("rejects a duplicate name client-side before calling the API", async () => {
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+
+      api.openTagTypeModalFromCreate("Genre");
+      await api.submitCreateTagType({ name: { nl: "  GENRE  " } });
+
+      expect(tagsService.createTagType).not.toHaveBeenCalled();
+      expect(api.tagTypeModalError.value).toMatch(/already exists|bestaat al|existe déjà/i);
+    });
+
+    it("creates a new type and auto-selects it in the create-tag form", async () => {
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+
+      api.openCreateModal();
+      api.openTagTypeModalFromCreate("Workshop");
+      await api.submitCreateTagType({ name: { nl: "Workshop" } });
+      await flushPromises();
+
+      expect(tagsService.createTagType).toHaveBeenCalledWith({ name: { nl: "Workshop" } });
+      expect(api.createForm.value.tagTypeId).toBe(999);
+      expect(api.tagTypeModalOpen.value).toBe(false);
+      expect(api.tagTypesData.value).toHaveLength(2);
+    });
+
+    it("creates a new type from a grid row and patches the tag's tag_type", async () => {
+      const updated = { ...mockPublicTag, tag_type: 999 as never };
+      vi.spyOn(tagsService, "updateTag").mockResolvedValueOnce(updated as never);
+
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+      const row = api.rowData.value[0];
+
+      api.openTagTypeModal("Workshop", { kind: "gridRow", rowId: row.id });
+      api.gridApi.value = { refreshCells: vi.fn() };
+      await api.submitCreateTagType({ name: { nl: "Workshop" } });
+      await flushPromises();
+
+      expect(tagsService.updateTag).toHaveBeenCalledWith(row.id, { tag_type: 999 });
+      expect(api.tagTypeModalOpen.value).toBe(false);
+    });
+
+    it("ignores grid-row origin when the row no longer exists", async () => {
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+
+      api.openTagTypeModal("Workshop", { kind: "gridRow", rowId: 9999 });
+      await api.submitCreateTagType({ name: { nl: "Workshop" } });
+
+      expect(tagsService.updateTag).not.toHaveBeenCalled();
+      expect(api.tagTypeModalOpen.value).toBe(false);
+    });
+
+    it("swallows updateTag errors from grid-row patching without throwing", async () => {
+      vi.spyOn(tagsService, "updateTag").mockRejectedValueOnce(new Error("boom"));
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+      const row = api.rowData.value[0];
+
+      api.openTagTypeModal("Workshop", { kind: "gridRow", rowId: row.id });
+      await api.submitCreateTagType({ name: { nl: "Workshop" } });
+      await flushPromises();
+
+      expect(api.saveError.value).toMatch(/boom|fail|fout/i);
+      // Sub-modal still closes — the new type was created.
+      expect(api.tagTypeModalOpen.value).toBe(false);
+    });
+
+    it("maps a 409 ApiError to the conflict message", async () => {
+      vi.spyOn(tagsService, "createTagType").mockRejectedValueOnce(
+        new ApiError(409, "Conflict"),
+      );
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+
+      api.openTagTypeModalFromCreate("Brand-new");
+      await api.submitCreateTagType({ name: { nl: "Brand-new" } });
+
+      expect(api.tagTypeModalError.value).toMatch(/already exists|bestaat al|existe déjà/i);
+      expect(api.tagTypeModalOpen.value).toBe(true);
+    });
+
+    it("surfaces a generic error when the API throws a non-conflict Error", async () => {
+      vi.spyOn(tagsService, "createTagType").mockRejectedValueOnce(new Error("network"));
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+
+      api.openTagTypeModalFromCreate("Brand-new");
+      await api.submitCreateTagType({ name: { nl: "Brand-new" } });
+
+      expect(api.tagTypeModalError.value).toMatch(/network|fail|fout/i);
+    });
+
+    it("falls back to the generic save message for non-Error rejections", async () => {
+      vi.spyOn(tagsService, "createTagType").mockRejectedValueOnce("nope");
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+
+      api.openTagTypeModalFromCreate("Brand-new");
+      await api.submitCreateTagType({ name: { nl: "Brand-new" } });
+
+      expect(api.tagTypeModalError.value).toBeTruthy();
+    });
+  });
+
+  describe("tag-type cell editing in the grid", () => {
+    it("persists a tag_type change initiated from the grid", async () => {
+      const updated = { ...mockPublicTag, tag_type: 2 as never };
+      vi.spyOn(tagsService, "updateTag").mockResolvedValueOnce(updated as never);
+
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+      const row = api.rowData.value[0];
+      const refreshCells = vi.fn();
+
+      await api.onCellEditingStopped({
+        data: row,
+        colDef: { field: undefined },
+        column: { getColId: () => "tagType" },
+        value: 2,
+        oldValue: 1,
+        node: { setDataValue: vi.fn() },
+        api: { refreshCells },
+      });
+
+      expect(tagsService.updateTag).toHaveBeenCalledWith(row.id, { tag_type: 2 });
+      expect(refreshCells).toHaveBeenCalled();
+    });
+
+    it("ignores invalid tag_type values without calling the API", async () => {
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+      const row = api.rowData.value[0];
+
+      await api.onCellEditingStopped({
+        data: row,
+        colDef: { field: undefined },
+        column: { getColId: () => "tagType" },
+        value: NaN,
+        oldValue: 1,
+        node: { setDataValue: vi.fn() },
+        api: { refreshCells: vi.fn() },
+      });
+
+      expect(tagsService.updateTag).not.toHaveBeenCalled();
+    });
+
+    it("reverts the displayed value when persisting a tag_type change fails", async () => {
+      vi.spyOn(tagsService, "updateTag").mockRejectedValueOnce(new Error("boom"));
+      const wrapper = mountTab();
+      await flushPromises();
+      const api = (wrapper.vm as any).__test;
+      const row = api.rowData.value[0];
+
+      // No field on colDef → no revert via setDataValue; ensure no crash.
+      await api.onCellEditingStopped({
+        data: row,
+        colDef: { field: undefined },
+        column: { getColId: () => "tagType" },
+        value: 2,
+        oldValue: 1,
+        node: { setDataValue: vi.fn() },
+        api: { refreshCells: vi.fn() },
+      });
+
+      expect(api.saveError.value).toBeTruthy();
+    });
   });
 
   describe("delete flow", () => {

--- a/frontend/test/components/admin/cms/tags/TagTypeCellEditor.test.ts
+++ b/frontend/test/components/admin/cms/tags/TagTypeCellEditor.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import type { TagType } from "@viernulvier/shared";
+import { i18n } from "@/i18n";
+import TagTypeCellEditor from "@/components/admin/cms/tags/TagTypeCellEditor.vue";
+import type { LanguageMap } from "@/utils/language-utils";
+
+const tagTypes: TagType[] = [
+  { id: 1, old_id: null, name: { en: "Genre" } } as TagType,
+  { id: 2, old_id: null, name: { en: "Age" } } as TagType,
+];
+
+const localize = (map: LanguageMap | null | undefined): string =>
+  map ? (map.en ?? "") : "";
+
+function mountEditor(
+  overrides: Partial<{
+    value: number | null;
+    data: { id: number; tagTypeId: number | null };
+    stopEditing: ReturnType<typeof vi.fn>;
+    onCreateRequest: ReturnType<typeof vi.fn>;
+  }> = {},
+) {
+  const stopEditing = overrides.stopEditing ?? vi.fn();
+  const onCreateRequest = overrides.onCreateRequest ?? vi.fn();
+  const params = {
+    value: overrides.value ?? null,
+    data: overrides.data ?? { id: 10, tagTypeId: null },
+    tagTypes,
+    localize,
+    stopEditing,
+    onCreateRequest,
+  };
+  const wrapper = mount(TagTypeCellEditor, {
+    global: { plugins: [i18n] },
+    props: { params: params as unknown as InstanceType<typeof TagTypeCellEditor>["$props"]["params"] },
+  });
+  return { wrapper, stopEditing, onCreateRequest };
+}
+
+describe("TagTypeCellEditor", () => {
+  it("renders the wrapped picker with autoFocus", () => {
+    const { wrapper } = mountEditor();
+    expect(wrapper.find('[data-testid="tag-type-cell-editor-picker"]').exists()).toBe(true);
+  });
+
+  it("getValue() returns the initial params.value", () => {
+    const { wrapper } = mountEditor({ value: 2 });
+    const exposed = wrapper.vm as { getValue: () => number | null };
+    expect(exposed.getValue()).toBe(2);
+  });
+
+  it("falls back to data.tagTypeId when params.value is null", () => {
+    const { wrapper } = mountEditor({ value: null, data: { id: 10, tagTypeId: 1 } });
+    const exposed = wrapper.vm as { getValue: () => number | null };
+    expect(exposed.getValue()).toBe(1);
+  });
+
+  it("selecting a type updates getValue and calls stopEditing(false)", async () => {
+    const { wrapper, stopEditing } = mountEditor();
+    await wrapper.get("input").trigger("focus");
+    await wrapper.get('[data-testid="tag-type-picker-item-1"]').trigger("click");
+    const exposed = wrapper.vm as { getValue: () => number | null };
+    expect(exposed.getValue()).toBe(1);
+    expect(stopEditing).toHaveBeenCalledWith();
+  });
+
+  it("create-request stops editing with cancel=true and triggers onCreateRequest", async () => {
+    const { wrapper, stopEditing, onCreateRequest } = mountEditor({
+      data: { id: 99, tagTypeId: null },
+    });
+    await wrapper.get("input").trigger("focus");
+    await wrapper.get("input").setValue("Workshop");
+    await wrapper.get('[data-testid="tag-type-picker-create"]').trigger("click");
+    expect(stopEditing).toHaveBeenCalledWith(true);
+    expect(onCreateRequest).toHaveBeenCalledWith({ rowId: 99, initialName: "Workshop" });
+  });
+
+  it("exposes isCancelBeforeStart/isCancelAfterEnd as no-ops returning false", () => {
+    const { wrapper } = mountEditor();
+    const exposed = wrapper.vm as {
+      isCancelBeforeStart: () => boolean;
+      isCancelAfterEnd: () => boolean;
+    };
+    expect(exposed.isCancelBeforeStart()).toBe(false);
+    expect(exposed.isCancelAfterEnd()).toBe(false);
+  });
+});

--- a/frontend/test/components/admin/cms/tags/TagTypePicker.test.ts
+++ b/frontend/test/components/admin/cms/tags/TagTypePicker.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import type { TagType } from "@viernulvier/shared";
+import { i18n } from "@/i18n";
+import TagTypePicker from "@/components/admin/cms/tags/TagTypePicker.vue";
+import type { LanguageMap } from "@/utils/language-utils";
+
+const tagTypes: TagType[] = [
+  { id: 1, old_id: null, name: { en: "Genre", nl: "Genre", fr: "Genre" } } as TagType,
+  { id: 2, old_id: null, name: { en: "Age", nl: "Leeftijd", fr: "Âge" } } as TagType,
+  { id: 3, old_id: null, name: {} } as TagType,
+];
+
+const localize = (map: LanguageMap | null | undefined): string =>
+  map ? (map.en ?? "") : "";
+
+function mountPicker(props: Partial<InstanceType<typeof TagTypePicker>["$props"]> = {}) {
+  return mount(TagTypePicker, {
+    global: { plugins: [i18n] },
+    props: {
+      modelValue: null,
+      tagTypes,
+      localize,
+      ...props,
+    },
+  });
+}
+
+describe("TagTypePicker", () => {
+  it("renders an input with the configured placeholder", () => {
+    const wrapper = mountPicker({ placeholder: "Pick me" });
+    const input = wrapper.get("input");
+    expect((input.element as HTMLInputElement).placeholder).toBe("Pick me");
+  });
+
+  it("opens the listbox on focus and shows all types", async () => {
+    const wrapper = mountPicker();
+    await wrapper.get("input").trigger("focus");
+    expect(wrapper.findAll(".tag-type-picker-item")).toHaveLength(tagTypes.length);
+  });
+
+  it("filters the list as the user types", async () => {
+    const wrapper = mountPicker();
+    await wrapper.get("input").trigger("focus");
+    await wrapper.get("input").setValue("age");
+    const items = wrapper.findAll(".tag-type-picker-item");
+    expect(items).toHaveLength(1);
+    expect(items[0].text()).toContain("Age");
+  });
+
+  it("shows '#id' fallback for tag types without a localizable name", async () => {
+    const wrapper = mountPicker();
+    await wrapper.get("input").trigger("focus");
+    const item = wrapper.get('[data-testid="tag-type-picker-item-3"]');
+    expect(item.text()).toContain("#3");
+  });
+
+  it("emits update:modelValue when clicking a type", async () => {
+    const wrapper = mountPicker();
+    await wrapper.get("input").trigger("focus");
+    await wrapper.get('[data-testid="tag-type-picker-item-2"]').trigger("click");
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([2]);
+  });
+
+  it("emits create-request with the trimmed typed name", async () => {
+    const wrapper = mountPicker();
+    const input = wrapper.get("input");
+    await input.trigger("focus");
+    await input.setValue("  Workshop  ");
+    await wrapper.get('[data-testid="tag-type-picker-create"]').trigger("click");
+    expect(wrapper.emitted("create-request")?.[0]).toEqual(["Workshop"]);
+  });
+
+  it("uses the empty create label when nothing is typed", async () => {
+    const wrapper = mountPicker();
+    await wrapper.get("input").trigger("focus");
+    const create = wrapper.get('[data-testid="tag-type-picker-create"]');
+    expect(create.text()).toMatch(/Create new tag type|Maak nieuw tag-type|Créer un nouveau type de tag/);
+  });
+
+  it("hides the create option when the typed text matches an existing type exactly", async () => {
+    const wrapper = mountPicker();
+    const input = wrapper.get("input");
+    await input.trigger("focus");
+    await input.setValue("Genre");
+    expect(wrapper.find('[data-testid="tag-type-picker-create"]').exists()).toBe(false);
+  });
+
+  it("shows 'no matching types' when nothing matches and disabled hides create", async () => {
+    const wrapper = mountPicker({ disabled: true });
+    // Disabled input cannot be focused; force-open via prop reset is unnecessary —
+    // the create option simply must not appear even if it were open.
+    expect(wrapper.find(".tag-type-picker-list").exists()).toBe(false);
+  });
+
+  it("supports keyboard ArrowDown/Enter to select a type", async () => {
+    const wrapper = mountPicker();
+    const input = wrapper.get("input");
+    await input.trigger("focus");
+    await input.trigger("keydown", { key: "ArrowDown" });
+    await input.trigger("keydown", { key: "ArrowDown" });
+    await input.trigger("keydown", { key: "Enter" });
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([2]);
+  });
+
+  it("ArrowUp wraps from index 0 to the last item", async () => {
+    const wrapper = mountPicker();
+    const input = wrapper.get("input");
+    await input.trigger("focus");
+    await input.trigger("keydown", { key: "ArrowUp" });
+    await input.trigger("keydown", { key: "Enter" });
+    // Index wraps to total - 1; total includes the create row when nothing is typed.
+    expect(wrapper.emitted("create-request")).toBeTruthy();
+  });
+
+  it("Escape closes the menu and restores the query", async () => {
+    const wrapper = mountPicker({ modelValue: 1 });
+    await flushPromises();
+    const input = wrapper.get("input");
+    await input.trigger("focus");
+    await input.setValue("typo");
+    await input.trigger("keydown", { key: "Escape" });
+    expect(wrapper.find(".tag-type-picker-list").exists()).toBe(false);
+    expect((input.element as HTMLInputElement).value).toBe("Genre");
+  });
+
+  it("Enter on the create row emits create-request", async () => {
+    const wrapper = mountPicker();
+    const input = wrapper.get("input");
+    await input.trigger("focus");
+    await input.setValue("Workshop");
+    // ArrowDown past all items to reach the create row.
+    for (let i = 0; i < 10; i++) {
+      await input.trigger("keydown", { key: "ArrowDown" });
+    }
+    await input.trigger("keydown", { key: "Enter" });
+    expect(wrapper.emitted("create-request")).toBeTruthy();
+  });
+
+  it("Enter without an open menu is ignored", async () => {
+    const wrapper = mountPicker();
+    await wrapper.get("input").trigger("keydown", { key: "Enter" });
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("syncs the displayed query when modelValue changes externally", async () => {
+    const wrapper = mountPicker({ modelValue: 1 });
+    await flushPromises();
+    expect((wrapper.get("input").element as HTMLInputElement).value).toBe("Genre");
+    await wrapper.setProps({ modelValue: 2 });
+    expect((wrapper.get("input").element as HTMLInputElement).value).toBe("Age");
+    await wrapper.setProps({ modelValue: null });
+    expect((wrapper.get("input").element as HTMLInputElement).value).toBe("");
+  });
+
+  it("clears the query when modelValue points to a non-existent type", async () => {
+    const wrapper = mountPicker({ modelValue: 999 });
+    await flushPromises();
+    expect((wrapper.get("input").element as HTMLInputElement).value).toBe("");
+  });
+
+  it("re-syncs the query when the tagTypes list changes", async () => {
+    const wrapper = mountPicker({ modelValue: 1 });
+    await flushPromises();
+    const next: TagType[] = [
+      { id: 1, old_id: null, name: { en: "Genre-renamed" } } as TagType,
+    ];
+    await wrapper.setProps({ tagTypes: next });
+    expect((wrapper.get("input").element as HTMLInputElement).value).toBe("Genre-renamed");
+  });
+
+  it("autoFocus focuses the input on mount", async () => {
+    const wrapper = mount(TagTypePicker, {
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+      props: { modelValue: null, tagTypes, localize, autoFocus: true },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(document.activeElement).toBe(wrapper.get("input").element);
+    wrapper.unmount();
+  });
+
+  it("focus() exposed method moves focus to the input", async () => {
+    const wrapper = mount(TagTypePicker, {
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+      props: { modelValue: null, tagTypes, localize },
+    });
+    (wrapper.vm as { focus: () => void }).focus();
+    expect(document.activeElement).toBe(wrapper.get("input").element);
+    wrapper.unmount();
+  });
+
+  it("mouseenter on an item marks it as active", async () => {
+    const wrapper = mountPicker();
+    await wrapper.get("input").trigger("focus");
+    const second = wrapper.get('[data-testid="tag-type-picker-item-2"]');
+    await second.trigger("mouseenter");
+    expect(second.classes()).toContain("is-active");
+  });
+
+  it("mouseenter on the create row marks it as active", async () => {
+    const wrapper = mountPicker();
+    const input = wrapper.get("input");
+    await input.trigger("focus");
+    await input.setValue("Workshop");
+    const create = wrapper.get('[data-testid="tag-type-picker-create"]');
+    await create.trigger("mouseenter");
+    expect(create.classes()).toContain("is-active");
+  });
+
+  it("blurring the input closes the menu after the click-grace delay", async () => {
+    vi.useFakeTimers();
+    const wrapper = mount(TagTypePicker, {
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+      props: { modelValue: null, tagTypes, localize },
+    });
+    const input = wrapper.get("input");
+    await input.trigger("focus");
+    expect(wrapper.find(".tag-type-picker-list").exists()).toBe(true);
+
+    (input.element as HTMLInputElement).blur();
+    await input.trigger("blur");
+    vi.advanceTimersByTime(200);
+    await flushPromises();
+
+    expect(wrapper.find(".tag-type-picker-list").exists()).toBe(false);
+    wrapper.unmount();
+    vi.useRealTimers();
+  });
+
+  it("disabled prevents focus from opening the menu and ignores key presses", async () => {
+    const wrapper = mountPicker({ disabled: true });
+    const input = wrapper.get("input");
+    expect((input.element as HTMLInputElement).disabled).toBe(true);
+
+    await input.trigger("focus");
+    expect(wrapper.find(".tag-type-picker-list").exists()).toBe(false);
+
+    await input.trigger("keydown", { key: "ArrowDown" });
+    expect(wrapper.find(".tag-type-picker-list").exists()).toBe(false);
+  });
+
+  it("unknown keys do not open the menu or emit events", async () => {
+    const wrapper = mountPicker();
+    await wrapper.get("input").trigger("keydown", { key: "Tab" });
+    expect(wrapper.find(".tag-type-picker-list").exists()).toBe(false);
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("uses the dataTestid prop to set the input's data-testid", () => {
+    const wrapper = mountPicker({ dataTestid: "my-picker" });
+    expect(wrapper.find('[data-testid="my-picker"]').exists()).toBe(true);
+  });
+
+  it("a document click outside the picker closes the menu", async () => {
+    const wrapper = mount(TagTypePicker, {
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+      props: { modelValue: null, tagTypes, localize },
+    });
+    await wrapper.get("input").trigger("focus");
+    expect(wrapper.find(".tag-type-picker-list").exists()).toBe(true);
+
+    document.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(wrapper.find(".tag-type-picker-list").exists()).toBe(false);
+    wrapper.unmount();
+  });
+});

--- a/frontend/test/composables/useCmsTagGrid.test.ts
+++ b/frontend/test/composables/useCmsTagGrid.test.ts
@@ -4,18 +4,24 @@ import { useCmsTagGrid } from "@/composables/useCmsTagGrid";
 
 describe("useCmsTagGrid", () => {
   it("declares the tag column definitions", () => {
-    const { columnDefs } = useCmsTagGrid({ isDark: ref(false), t: (key) => key });
+    const { columnDefs } = useCmsTagGrid({
+      isDark: ref(false),
+      t: (key) => key,
+      getTagTypes: () => [],
+      localize: () => "",
+      onCreateTagTypeRequest: () => {},
+    });
 
     expect(columnDefs.value).toHaveLength(4);
 
     const name = columnDefs.value.find((c) => c.field === "name");
-    const tagType = columnDefs.value.find((c) => c.field === "tagType");
+    const tagType = columnDefs.value.find((c) => c.colId === "tagType");
     const publicField = columnDefs.value.find((c) => c.field === "public");
     const productionCount = columnDefs.value.find((c) => c.field === "productionCount");
 
     expect(name?.editable).toBe(true);
     expect(name?.flex).toBe(1);
-    expect(tagType?.editable).toBe(false);
+    expect(tagType?.editable).toBe(true);
     expect(publicField?.editable).toBe(true);
     expect(publicField?.cellEditor).toBe("agCheckboxCellEditor");
     expect(productionCount?.editable).toBe(false);
@@ -23,7 +29,13 @@ describe("useCmsTagGrid", () => {
   });
 
   it("builds translated column options", () => {
-    const { gridColumnOptions } = useCmsTagGrid({ isDark: ref(false), t: (key) => key });
+    const { gridColumnOptions } = useCmsTagGrid({
+      isDark: ref(false),
+      t: (key) => key,
+      getTagTypes: () => [],
+      localize: () => "",
+      onCreateTagTypeRequest: () => {},
+    });
 
     expect(gridColumnOptions.value).toEqual([
       { colId: "name", label: "cms.columns.tagName" },
@@ -34,7 +46,13 @@ describe("useCmsTagGrid", () => {
   });
 
   it("exposes a pinned selection column definition", () => {
-    const { selectionColumnDef } = useCmsTagGrid({ isDark: ref(false), t: (key) => key });
+    const { selectionColumnDef } = useCmsTagGrid({
+      isDark: ref(false),
+      t: (key) => key,
+      getTagTypes: () => [],
+      localize: () => "",
+      onCreateTagTypeRequest: () => {},
+    });
 
     expect(selectionColumnDef.width).toBe(48);
     expect(selectionColumnDef.pinned).toBe("left");
@@ -42,7 +60,13 @@ describe("useCmsTagGrid", () => {
   });
 
   it("provides a non-editable defaultColDef with floating filter", () => {
-    const { defaultColDef } = useCmsTagGrid({ isDark: ref(false), t: (key) => key });
+    const { defaultColDef } = useCmsTagGrid({
+      isDark: ref(false),
+      t: (key) => key,
+      getTagTypes: () => [],
+      localize: () => "",
+      onCreateTagTypeRequest: () => {},
+    });
 
     expect(defaultColDef.editable).toBe(false);
     expect(defaultColDef.sortable).toBe(true);

--- a/frontend/test/composables/useCmsTagGrid.test.ts
+++ b/frontend/test/composables/useCmsTagGrid.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
+import type { TagType } from "@viernulvier/shared";
 import { useCmsTagGrid } from "@/composables/useCmsTagGrid";
 
 describe("useCmsTagGrid", () => {
@@ -22,10 +23,66 @@ describe("useCmsTagGrid", () => {
     expect(name?.editable).toBe(true);
     expect(name?.flex).toBe(1);
     expect(tagType?.editable).toBe(true);
+    expect(tagType?.cellEditorPopup).toBe(true);
+    expect(tagType?.singleClickEdit).toBe(true);
     expect(publicField?.editable).toBe(true);
     expect(publicField?.cellEditor).toBe("agCheckboxCellEditor");
     expect(productionCount?.editable).toBe(false);
     expect(productionCount?.filter).toBe("agNumberColumnFilter");
+  });
+
+  it("tagType column exposes a valueGetter and valueFormatter tied to the row", () => {
+    const { columnDefs } = useCmsTagGrid({
+      isDark: ref(false),
+      t: (key) => key,
+      getTagTypes: () => [],
+      localize: () => "",
+      onCreateTagTypeRequest: () => {},
+    });
+    const tagType = columnDefs.value.find((c) => c.colId === "tagType");
+    const row = { id: 1, source: {}, name: "Drama", tagTypeId: 42, tagType: "Genre", public: true, productionCount: 0 };
+
+    expect(typeof tagType?.valueGetter).toBe("function");
+    expect((tagType?.valueGetter as (p: { data: typeof row }) => unknown)({ data: row })).toBe(42);
+    expect(
+      (tagType?.valueFormatter as (p: { data: typeof row }) => string)({ data: row }),
+    ).toBe("Genre");
+    expect(
+      (tagType?.filterValueGetter as (p: { data: typeof row }) => string)({ data: row }),
+    ).toBe("Genre");
+  });
+
+  it("valueGetter / valueFormatter / filterValueGetter handle missing row data", () => {
+    const { columnDefs } = useCmsTagGrid({
+      isDark: ref(false),
+      t: (key) => key,
+      getTagTypes: () => [],
+      localize: () => "",
+      onCreateTagTypeRequest: () => {},
+    });
+    const tagType = columnDefs.value.find((c) => c.colId === "tagType");
+
+    expect((tagType?.valueGetter as (p: { data?: undefined }) => unknown)({})).toBeNull();
+    expect((tagType?.valueFormatter as (p: { data?: undefined }) => string)({})).toBe("");
+    expect((tagType?.filterValueGetter as (p: { data?: undefined }) => string)({})).toBe("");
+  });
+
+  it("cellEditorParams forwards picker dependencies via the options closure", () => {
+    const types: TagType[] = [{ id: 7, old_id: null, name: { en: "Workshop" } } as TagType];
+    const onCreateTagTypeRequest = vi.fn();
+    const localize = vi.fn(() => "Workshop");
+    const { columnDefs } = useCmsTagGrid({
+      isDark: ref(false),
+      t: (key) => key,
+      getTagTypes: () => types,
+      localize,
+      onCreateTagTypeRequest,
+    });
+    const tagType = columnDefs.value.find((c) => c.colId === "tagType");
+    const params = (tagType?.cellEditorParams as () => Record<string, unknown>)();
+    expect(params.tagTypes).toEqual(types);
+    expect(params.localize).toBe(localize);
+    expect(params.onCreateRequest).toBe(onCreateTagTypeRequest);
   });
 
   it("builds translated column options", () => {


### PR DESCRIPTION
## Summary

Closes #441.

Adds a shared **TagTypePicker** combobox so CMS users can both pick an existing tag type and create a new one without leaving their flow. Used in two places:

- The **create-tag modal** — replaces the plain `<select>`.
- The **tags grid** — the *Type* column is now editable, using the picker as an ag-grid popup `cellEditor`. (Previously this column was read-only.)

Selecting "+ Create new type 'X'" opens a small sub-modal pre-filled with the typed string in NL (EN/FR optional, same language-pill UX as the existing tag-creation modal). On submit it calls the existing `POST /api/v1/tag/type` endpoint and auto-selects the new id in the originating context (either the create-tag form, or the edited grid row via `updateTag({ tag_type: newId })`).

**New files**
- `frontend/src/components/admin/cms/tags/TagTypePicker.vue` — shared combobox with keyboard navigation (Arrow/Enter/Escape) and a contextual "Create new" affordance.
- `frontend/src/components/admin/cms/tags/CmsCreateTagTypeModal.vue` — small sub-modal for the localized name.
- `frontend/src/components/admin/cms/tags/TagTypeCellEditor.vue` — thin ag-grid popup cellEditor wrapping the picker.

**Modified**
- `CmsCreateTagModal.vue` — `<select>` → `TagTypePicker` + new `request-create-tag-type` emit.
- `CmsTagsTab.vue` — handles the sub-modal lifecycle, tracks origin (create-modal vs grid-row), patches rows via `updateTag` after a new type is created.
- `useCmsTagGrid.ts` — `tagType` column is now `editable: true`, uses `valueGetter`/`valueFormatter` so the underlying value is `tagTypeId` (number) while the cell displays the localized label.
- i18n: new `cms.tagTypePicker.*` keys and tag-type-create labels/validation in NL/EN/FR.

The backend (`POST/PATCH/DELETE /api/v1/tag/type`) and the frontend API client (`createTagType`, `updateTagType`, `deleteTagType` in `services/tags.ts`) were already in place — only the UI was missing.

## Test plan

- [x] `vue-tsc -b --noEmit` clean
- [x] `eslint` clean
- [x] Unit tests: 42 / 42 pass in `test/components/admin/cms/tags/` and `test/composables/useCmsTagGrid.test.ts` (includes new tests for the picker's pick-existing and create-request flows)
- [x] **Manual E2E with backend running** — I couldn't run this myself (the dev backend hostname isn't reachable outside docker-compose, so the admin route redirects). Reviewer to verify in a working environment:
  - [x] In the create-tag modal: pick an existing type from the dropdown works
  - [x] In the create-tag modal: typing a new name → clicking "+ Create new type 'X'" → sub-modal opens with NL pre-filled → submit creates the type and selects it
  - [x] In the grid: clicking the *Type* cell opens the picker, picking an existing type patches the row
  - [x] In the grid: typing a new name and creating works, the row updates to the new type
  - [x] Duplicate name returns a conflict error and shows the friendly message