### PR TITLE
Fix CMS tags tab: show linked production IDs

### DIFF
--- a/frontend/src/components/admin/cms/tags/CmsTagsTab.vue
+++ b/frontend/src/components/admin/cms/tags/CmsTagsTab.vue
@@ -337,7 +337,10 @@ async function loadTagsData(): Promise<void> {
   loadError.value = null;
 
   try {
-    const [tags, tagTypes] = await Promise.all([getAllTags(), getTagTypes()]);
+    const [tags, tagTypes] = await Promise.all([
+      getAllTags(undefined, { includeProductions: true }),
+      getTagTypes(),
+    ]);
     tagsData.value = tags;
     tagTypesData.value = tagTypes;
     rebuildRows();

--- a/frontend/src/composables/useCmsTagGrid.ts
+++ b/frontend/src/composables/useCmsTagGrid.ts
@@ -10,7 +10,7 @@ const cmsTagGridColumnIds = [
   "name",
   "tagType",
   "public",
-  "productionCount",
+  "productions",
 ] as const;
 
 export function useCmsTagGrid(options: {
@@ -46,7 +46,7 @@ export function useCmsTagGrid(options: {
     { colId: "name", label: options.t("cms.columns.tagName") },
     { colId: "tagType", label: options.t("cms.columns.tagType") },
     { colId: "public", label: options.t("cms.columns.public") },
-    { colId: "productionCount", label: options.t("cms.columns.productionCount") },
+    { colId: "productions", label: options.t("cms.columns.productions") },
   ] as const);
 
   const columnDefs = computed<ColDef<CmsTagGridRow>[]>(() => [
@@ -73,12 +73,11 @@ export function useCmsTagGrid(options: {
       maxWidth: 140,
     },
     {
-      headerName: options.t("cms.columns.productionCount"),
-      field: "productionCount",
+      headerName: options.t("cms.columns.productions"),
+      field: "productions",
       editable: false,
-      minWidth: 140,
-      maxWidth: 180,
-      filter: "agNumberColumnFilter",
+      minWidth: 200,
+      flex: 1,
     },
   ]);
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -83,7 +83,7 @@ export default {
       tagName: "Name",
       tagType: "Type",
       public: "Public",
-      productionCount: "Productions",
+      productions: "Productions",
       admin: {
         username: "Username",
         profilePicture: "Profile picture",

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -83,7 +83,7 @@ export default {
       tagName: "Nom",
       tagType: "Type",
       public: "Public",
-      productionCount: "Productions",
+      productions: "Productions",
       admin: {
         username: "Nom d'utilisateur",
         profilePicture: "Photo de profil",

--- a/frontend/src/i18n/locales/nl.ts
+++ b/frontend/src/i18n/locales/nl.ts
@@ -83,7 +83,7 @@ export default {
       tagName: "Naam",
       tagType: "Type",
       public: "Publiek",
-      productionCount: "Aantal producties",
+      productions: "Producties",
       admin: {
         username: "Gebruikersnaam",
         profilePicture: "Profielfoto",

--- a/frontend/src/services/cms/grid.ts
+++ b/frontend/src/services/cms/grid.ts
@@ -137,7 +137,7 @@ export function buildTagGridRow(
 ): CmsTagGridRow {
   const tagTypeId = Number(tag.tag_type);
   const tagType = tagTypeById.get(tagTypeId);
-  const productionIds = Array.isArray(tag.productions) ? tag.productions : [];
+  const productionIds = Array.isArray(tag.productions) ? (tag.productions as number[]) : [];
 
   return {
     id: tag.id,

--- a/frontend/src/services/cms/grid.ts
+++ b/frontend/src/services/cms/grid.ts
@@ -146,7 +146,7 @@ export function buildTagGridRow(
     tagTypeId,
     tagType: tagType ? localize(tagType.name) || `#${tagTypeId}` : `#${tagTypeId}`,
     public: tag.public,
-    productionCount: productionIds.length,
+    productions: productionIds,
   };
 }
 

--- a/frontend/src/services/cms/types.ts
+++ b/frontend/src/services/cms/types.ts
@@ -57,7 +57,7 @@ export interface CmsTagGridRow {
   tagTypeId: number;
   tagType: string;
   public: boolean;
-  productionCount: number;
+  productions: number[];
 }
 
 export type TagInlineEditableField = "name" | "tagType" | "public";

--- a/frontend/src/services/tags.ts
+++ b/frontend/src/services/tags.ts
@@ -127,11 +127,20 @@ export async function getTag(id: number): Promise<Tag> {
  * Fetches all tags (including hidden ones).
  * Can be filtered by production ID.
  * @param productionId - Optional ID to get all tags for a specific production.
+ * @param options.includeProductions - When true, each tag includes a `productions` id list.
+ * @param options.includeProductionCount - When true, each tag includes `production_count`.
  * @throws {ApiError} 401 — unauthenticated.
  */
-export async function getAllTags(productionId?: number): Promise<Tag[]> {
-  const url = productionId ? `/tag/all?production=${productionId}` : "/tag/all";
-  return await apiFetch<Tag[]>(url);
+export async function getAllTags(
+  productionId?: number,
+  options?: { includeProductions?: boolean; includeProductionCount?: boolean },
+): Promise<Tag[]> {
+  const params = new URLSearchParams();
+  if (productionId !== undefined) params.set("production", String(productionId));
+  if (options?.includeProductions) params.set("includeProductions", "true");
+  if (options?.includeProductionCount) params.set("includeProductionCount", "true");
+  const qs = params.toString();
+  return await apiFetch<Tag[]>(qs ? `/tag/all?${qs}` : "/tag/all");
 }
 
 /**

--- a/frontend/test/composables/useCmsTagGrid.test.ts
+++ b/frontend/test/composables/useCmsTagGrid.test.ts
@@ -11,15 +11,14 @@ describe("useCmsTagGrid", () => {
     const name = columnDefs.value.find((c) => c.field === "name");
     const tagType = columnDefs.value.find((c) => c.field === "tagType");
     const publicField = columnDefs.value.find((c) => c.field === "public");
-    const productionCount = columnDefs.value.find((c) => c.field === "productionCount");
+    const productions = columnDefs.value.find((c) => c.field === "productions");
 
     expect(name?.editable).toBe(true);
     expect(name?.flex).toBe(1);
     expect(tagType?.editable).toBe(false);
     expect(publicField?.editable).toBe(true);
     expect(publicField?.cellEditor).toBe("agCheckboxCellEditor");
-    expect(productionCount?.editable).toBe(false);
-    expect(productionCount?.filter).toBe("agNumberColumnFilter");
+    expect(productions?.editable).toBe(false);
   });
 
   it("builds translated column options", () => {
@@ -29,7 +28,7 @@ describe("useCmsTagGrid", () => {
       { colId: "name", label: "cms.columns.tagName" },
       { colId: "tagType", label: "cms.columns.tagType" },
       { colId: "public", label: "cms.columns.public" },
-      { colId: "productionCount", label: "cms.columns.productionCount" },
+      { colId: "productions", label: "cms.columns.productions" },
     ]);
   });
 

--- a/frontend/test/services/cms/tag-grid.test.ts
+++ b/frontend/test/services/cms/tag-grid.test.ts
@@ -25,14 +25,14 @@ function makeTag(overrides: Partial<Tag> = {}): Tag {
 const knownType: TagType = { id: 10, old_id: null, name: { en: "Genre" } } as TagType;
 
 describe("tag grid builders", () => {
-  it("builds a row with resolved tag type and production count", () => {
+  it("builds a row with resolved tag type and production ids", () => {
     const row = buildTagGridRow(
       makeTag({ productions: [1, 2, 3] as never }),
       new Map([[10, knownType]]),
       localize,
     );
     expect(row.tagType).toBe("Genre");
-    expect(row.productionCount).toBe(3);
+    expect(row.productions).toEqual([1, 2, 3]);
     expect(row.name).toBe("Drama");
   });
 
@@ -47,13 +47,13 @@ describe("tag grid builders", () => {
     expect(row.tagType).toBe("#10");
   });
 
-  it("treats non-array productions as zero", () => {
+  it("treats non-array productions as empty list", () => {
     const row = buildTagGridRow(
       makeTag({ productions: undefined as never }),
       new Map([[10, knownType]]),
       localize,
     );
-    expect(row.productionCount).toBe(0);
+    expect(row.productions).toEqual([]);
   });
 
   it("uses empty string when tag name is missing", () => {

--- a/frontend/test/services/tags.test.ts
+++ b/frontend/test/services/tags.test.ts
@@ -103,6 +103,12 @@ describe("getAllTags", () => {
     await getAllTags(42);
     expect(lastCall()[0]).toBe("/api/v1/tag/all?production=42");
   });
+
+  it("GETs /api/v1/tag/all?includeProductions=true when requested", async () => {
+    vi.stubGlobal("fetch", mockOk([tagPayload]));
+    await getAllTags(undefined, { includeProductions: true });
+    expect(lastCall()[0]).toBe("/api/v1/tag/all?includeProductions=true");
+  });
 });
 
 describe("getTagAdmin", () => {


### PR DESCRIPTION
## Summary
- Fixes the tags tab showing `0 productions` for every tag — the frontend now passes `?includeProductions=true` to `GET /tag/all` so the backend actually returns the linked production list.
- Replaces the `productionCount` column with a `productions` column that lists the production IDs (same approach Noah used for the blogpost tab in `feat/blogpost-cms-tab`).
- Updates types, i18n labels (nl/en/fr), and the affected unit tests.

Closes #457

## Test plan
- [x] `vue-tsc --noEmit` passes
- [x] `vitest` passes for `useCmsTagGrid`, `tag-grid` builders, `tags` service, and `CmsTagsTab`
- [x] With the backend running, open `/admin/cms` → Tags tab and verify the "Producties" column shows the list of linked production IDs instead of `0`