### PR TITLE
fix tsconfig root dir

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,10 +1,15 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 import security from "eslint-plugin-security";
 import nodePlugin from "eslint-plugin-n";
 import importX from "eslint-plugin-import-x";
 import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import tsdoc from 'eslint-plugin-tsdoc'
+import tsdoc from 'eslint-plugin-tsdoc';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig([
   // --------------------------------------------------
@@ -41,7 +46,7 @@ export default defineConfig([
       parser: tseslint.parser,
       parserOptions: {
         project: "./tsconfig.eslint.json",
-        tsconfigRootDir: process.cwd()
+        tsconfigRootDir: __dirname,
       }
     },
 
@@ -171,7 +176,7 @@ export default defineConfig([
       parser: tseslint.parser,
       parserOptions: {
         project: "./tsconfig.eslint.json",
-        tsconfigRootDir: process.cwd()
+        tsconfigRootDir: __dirname,
       }
     },
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,3 +1,6 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
@@ -63,6 +66,8 @@ const sharedSettings = {
   }),
 };
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig([
   // --------------------------------------------------
   // Global ignores
@@ -94,7 +99,7 @@ export default defineConfig([
       parserOptions: {
         sourceType: "module",
         project: "./tsconfig.app.json",
-        tsconfigRootDir: process.cwd(),
+        tsconfigRootDir: __dirname,
       },
     },
 
@@ -126,7 +131,7 @@ export default defineConfig([
         extraFileExtensions: [".vue"],
         sourceType: "module",
         project: "./tsconfig.app.json",
-        tsconfigRootDir: process.cwd(),
+        tsconfigRootDir: __dirname,
       },
     },
 
@@ -174,7 +179,7 @@ export default defineConfig([
       parserOptions: {
         sourceType: "module",
         project: "./tsconfig.app.json",
-        tsconfigRootDir: process.cwd(),
+        tsconfigRootDir: __dirname,
       },
     },
 

--- a/shared/eslint.config.js
+++ b/shared/eslint.config.js
@@ -1,9 +1,14 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 import security from "eslint-plugin-security";
 import importX from "eslint-plugin-import-x";
 import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import tsdoc from 'eslint-plugin-tsdoc'
+import tsdoc from 'eslint-plugin-tsdoc';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig([
   // --------------------------------------------------
@@ -37,7 +42,7 @@ export default defineConfig([
       parser: tseslint.parser,
       parserOptions: {
         project: "./tsconfig.json",
-        tsconfigRootDir: process.cwd()
+        tsconfigRootDir: __dirname,
       }
     },
 


### PR DESCRIPTION
**Issue(s)**

<!-- List the issue(s) for this PR here. -->

____

**Description**

The eslint plugin on vscode gave errors, I thought it was just a local issue, since eslint worked with the command. But today I decided to get to the cause of this and found an issue in the `eslint.config.js` regarding the tsconfig root dir.

There wasn't really an issue in the backend and shared folder, but I found the same inconsistency there, so I also changed it in those configs.

____

**Sources**

<!-- If applicable, add sources (e.g. links, screenshots ...) to show your work. -->
