### PR TITLE
Fix hero kicker overflow on production page

### DIFF
--- a/frontend/src/components/production/HeroSection.vue
+++ b/frontend/src/components/production/HeroSection.vue
@@ -27,12 +27,12 @@
           class="mb-6 flex items-center justify-center gap-3 text-xs font-bold uppercase tracking-[0.25em] text-ink-secondary"
         >
           <span
-            class="h-px w-8 bg-ink-tertiary opacity-50"
+            class="h-px w-8 shrink-0 bg-ink-tertiary opacity-50"
             aria-hidden="true"
           />
-          <span class="whitespace-nowrap">{{ kicker }}</span>
+          <span class="min-w-0 break-words text-center">{{ kicker }}</span>
           <span
-            class="h-px w-8 bg-ink-tertiary opacity-50"
+            class="h-px w-8 shrink-0 bg-ink-tertiary opacity-50"
             aria-hidden="true"
           />
         </div>


### PR DESCRIPTION
## Summary
- The kicker line (`supertitle · genre · year`) on the production hero card forced a single line via `whitespace-nowrap`, so long combinations overflowed the letterpress card horizontally (issue #422).
- Removed `whitespace-nowrap`, added `min-w-0 break-words text-center` to the middle span so it can shrink and wrap, and added `shrink-0` to the two decorative rules so they keep their 32px width.

Closes #422

## Test plan
- [x] `vitest run test/components/production/HeroSection.test.ts` — all 13 tests pass
- [x] Manually verified in the dev preview: a synthetic long kicker now wraps inside the card; the same string with the previous classes overflows the card right edge.