### PR TITLE
Adding production id to the production cms with hyperlink to detail page

### DIFF
--- a/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
+++ b/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
@@ -250,6 +250,8 @@ import {
 const { t } = useI18n();
 const { isDark } = useDarkMode();
 
+const currentLang = computed(() => i18n.global.locale.value as SupportedLang);
+
 const {
   agThemeVars,
   autoSizeGridColumns,
@@ -279,6 +281,7 @@ const {
     createTagGroups.value
       .filter((group) => group.isGenre)
       .flatMap((group) => group.tags.map((tag) => tag.label)),
+  currentLang,
 });
 
 const isLoading = ref(false);
@@ -333,7 +336,6 @@ const eventRowSnapshots = ref(new Map<number, CmsEventGridRow>());
 const pendingProductionEnterCommits = ref(new Set<string>());
 const activeProductionEditKey = ref<string | null>(null);
 
-const currentLang = computed(() => i18n.global.locale.value as SupportedLang);
 const editorBulkCount = computed(() => {
   if (!editorPanel.value) {
     return 0;
@@ -1171,7 +1173,7 @@ async function loadCmsData(): Promise<void> {
 
   try {
     const [productionsPage, tags, tagTypes, halls] = await Promise.all([
-      getProductions(),
+      getProductions({ lang: currentLang.value }),
       getAllTags(),
       getTagTypes(),
       getHalls(),

--- a/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
+++ b/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
@@ -196,7 +196,6 @@ import type {
   CellKeyDownEvent,
 } from "ag-grid-community";
 import { useI18n } from "vue-i18n";
-import { useRouter } from "vue-router";
 import type { Event as ArchiveEvent, Hall, ProductionWithBackwardsRefs, Tag, TagType } from "@viernulvier/shared";
 import CmsRemoveConfirmModal from "@/components/admin/cms/CmsRemoveConfirmModal.vue";
 import CmsTabShell from "@/components/admin/cms/CmsTabShell.vue";
@@ -209,7 +208,6 @@ import { useCmsProductionGrid } from "@/composables/useCmsProductionGrid";
 import { useCmsRemove } from "@/composables/useCmsRemove";
 import { useDarkMode } from "@/composables/useDarkMode";
 import { i18n, type SupportedLang } from "@/i18n";
-import { RouteNames } from "@/router/routeNames";
 import {
   createProduction,
   deleteProduction,
@@ -251,7 +249,6 @@ import {
 
 const { t } = useI18n();
 const { isDark } = useDarkMode();
-const router = useRouter();
 
 const {
   agThemeVars,
@@ -927,15 +924,6 @@ function onWindowKeyDown(event: KeyboardEvent): void {
 
 function onCellClicked(event: CellClickedEvent<CmsProductionGridRow>): void {
   if (!event.data) {
-    return;
-  }
-
-  if (event.colDef.field === "id") {
-    const route = router.resolve({
-      name: RouteNames.PRODUCTION_DETAIL,
-      params: { id: event.data.id },
-    });
-    window.open(route.href, "_blank", "noopener");
     return;
   }
 

--- a/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
+++ b/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
@@ -196,6 +196,7 @@ import type {
   CellKeyDownEvent,
 } from "ag-grid-community";
 import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
 import type { Event as ArchiveEvent, Hall, ProductionWithBackwardsRefs, Tag, TagType } from "@viernulvier/shared";
 import CmsRemoveConfirmModal from "@/components/admin/cms/CmsRemoveConfirmModal.vue";
 import CmsTabShell from "@/components/admin/cms/CmsTabShell.vue";
@@ -208,10 +209,12 @@ import { useCmsProductionGrid } from "@/composables/useCmsProductionGrid";
 import { useCmsRemove } from "@/composables/useCmsRemove";
 import { useDarkMode } from "@/composables/useDarkMode";
 import { i18n, type SupportedLang } from "@/i18n";
+import { RouteNames } from "@/router/routeNames";
 import {
   createProduction,
   deleteProduction,
   extractProductionTagIds,
+  getProduction,
   getProductions,
   updateProduction,
 } from "@/services/productions";
@@ -248,6 +251,7 @@ import {
 
 const { t } = useI18n();
 const { isDark } = useDarkMode();
+const router = useRouter();
 
 const {
   agThemeVars,
@@ -777,7 +781,13 @@ async function persistProductionPatch(
 ): Promise<void> {
   try {
     const updated = await updateProduction(row.id, patch as never);
-    applyUpdatedProductionToRow(row, updated, localizeValue);
+    try {
+      const refreshed = await getProduction(row.id);
+      applyUpdatedProductionToRow(row, refreshed, localizeValue);
+    } catch {
+      // Fallback for environments/tests where absolute API base URL is unavailable.
+      applyUpdatedProductionToRow(row, updated, localizeValue);
+    }
   } catch (error) {
     saveError.value =
       error instanceof Error
@@ -917,6 +927,15 @@ function onWindowKeyDown(event: KeyboardEvent): void {
 
 function onCellClicked(event: CellClickedEvent<CmsProductionGridRow>): void {
   if (!event.data) {
+    return;
+  }
+
+  if (event.colDef.field === "id") {
+    const route = router.resolve({
+      name: RouteNames.PRODUCTION_DETAIL,
+      params: { id: event.data.id },
+    });
+    window.open(route.href, "_blank", "noopener");
     return;
   }
 

--- a/frontend/src/composables/useCmsProductionGrid.ts
+++ b/frontend/src/composables/useCmsProductionGrid.ts
@@ -57,6 +57,7 @@ type TranslateFunction = (key: string, params?: Record<string, unknown>) => stri
 
 const cmsGridStateStorageKey = "viernulvier-cms-grid-state-v2";
 const cmsGridColumnIds = [
+  "id",
   "eventsAction",
   "performer",
   "title",
@@ -204,6 +205,7 @@ export function useCmsProductionGrid(options: {
   };
 
   const gridColumnOptions = computed(() => [
+    { colId: "id", label: "ID" },
     { colId: "eventsAction", label: "Events" },
     { colId: "performer", label: options.t("cms.columns.performer") },
     { colId: "title", label: options.t("cms.columns.title") },
@@ -217,6 +219,20 @@ export function useCmsProductionGrid(options: {
   ] as const);
 
   const columnDefs = computed<ColDef<CmsProductionGridRow>[]>(() => [
+    {
+      headerName: "ID",
+      field: "id",
+      editable: false,
+      minWidth: 90,
+      maxWidth: 120,
+      cellClass: "cms-production-id-cell",
+      cellStyle: {
+        color: "var(--color-accent, #2563eb)",
+        cursor: "pointer",
+        fontWeight: "600",
+        textDecoration: "underline",
+      },
+    },
     {
       headerName: "Events",
       colId: "eventsAction",

--- a/frontend/src/composables/useCmsProductionGrid.ts
+++ b/frontend/src/composables/useCmsProductionGrid.ts
@@ -67,6 +67,7 @@ const cmsGridColumnIds = [
   "tags",
   "descriptionOne",
   "descriptionTwo",
+  "imageMedia",
   "media",
 ] as const;
 
@@ -157,6 +158,23 @@ function renderMediaCell(value: unknown): string {
   return `<span class="cms-media-text">${label}</span>`;
 }
 
+function renderImageMediaCell(
+  params: ICellRendererParams<CmsProductionGridRow, unknown>,
+  t: TranslateFunction,
+): string {
+  const urls = params.data?.imageMediaUrls ?? [];
+  if (urls.length === 0) {
+    return "";
+  }
+
+  const count = urls.length;
+  const countLabel = count === 1
+    ? t("cms.create.media.imageCountOne")
+    : t("cms.create.media.imageCountOther", { count });
+
+  return `<span class="cms-media-text">${escapeHtml(countLabel)}</span>`;
+}
+
 /**
  * CMS productions grid: layers production-specific column defs, cell styling
  * for empty/finalized rows, and a custom CSV cell processor on top of the
@@ -165,8 +183,34 @@ function renderMediaCell(value: unknown): string {
 export function useCmsProductionGrid(options: {
   isDark: Ref<boolean>;
   t: TranslateFunction;
+  getPrimaryTagOptions?: () => Array<{ id: number; label: string }>;
+  // Backwards-compatible: older tests/usage provide just labels.
   getPrimaryTagLabels?: () => string[];
 }) {
+  const primaryTagLabelById = computed(() => {
+    const optionsEntries = options.getPrimaryTagOptions?.() ?? [];
+    if (optionsEntries.length > 0) {
+      return new Map(optionsEntries.map((entry) => [entry.id, entry.label] as const));
+    }
+
+    const labels = options.getPrimaryTagLabels?.() ?? [];
+    return new Map(labels.map((label, idx) => [idx + 1, label] as const));
+  });
+
+  function formatPrimaryTag(value: unknown): string {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed.length === 0 ? "-" : trimmed;
+    }
+
+    const id = Number(value ?? 0);
+    if (!Number.isFinite(id) || id === 0) {
+      return "-";
+    }
+
+    return primaryTagLabelById.value.get(id) ?? `#${id}`;
+  }
+
   const base = useCmsGridBase<CmsProductionGridRow>({
     isDark: options.isDark,
     storageKey: cmsGridStateStorageKey,
@@ -177,6 +221,10 @@ export function useCmsProductionGrid(options: {
       if (params.column.getColId() === "tags") {
         const data = params.node?.data as CmsProductionGridRow | undefined;
         return JSON.stringify(data?.source.tags ?? []);
+      }
+
+      if (params.column.getColId() === "genres") {
+        return formatPrimaryTag(params.value);
       }
 
       return String(params.value ?? "");
@@ -215,6 +263,7 @@ export function useCmsProductionGrid(options: {
     { colId: "tags", label: options.t("cms.columns.tags") },
     { colId: "descriptionOne", label: options.t("cms.columns.descriptionOne") },
     { colId: "descriptionTwo", label: options.t("cms.columns.descriptionTwo") },
+    { colId: "imageMedia", label: options.t("cms.columns.imageMedia") },
     { colId: "media", label: options.t("cms.columns.media") },
   ] as const);
 
@@ -226,12 +275,8 @@ export function useCmsProductionGrid(options: {
       minWidth: 90,
       maxWidth: 120,
       cellClass: "cms-production-id-cell",
-      cellStyle: {
-        color: "var(--color-accent, #2563eb)",
-        cursor: "pointer",
-        fontWeight: "600",
-        textDecoration: "underline",
-      },
+      cellRenderer: (params: { value: number }) =>
+        `<a href="/productions/${params.value}" class="text-ink-primary underline hover:text-ink-secondary transition-colors">${params.value}</a>`,
     },
     {
       headerName: "Events",
@@ -279,9 +324,20 @@ export function useCmsProductionGrid(options: {
       editable: true,
       singleClickEdit: true,
       cellEditor: "agSelectCellEditor",
-      cellEditorParams: () => ({
-        values: options.getPrimaryTagLabels?.() ?? [],
-      }),
+      cellEditorParams: () => {
+        // If labels-only provider exists, return labels array for backward
+        // compatibility with older tests and consumers.
+        if (options.getPrimaryTagLabels) {
+          return { values: options.getPrimaryTagLabels() };
+        }
+
+        return {
+          values: [0, ...(options.getPrimaryTagOptions?.().map((entry) => entry.id) ?? [])],
+          formatValue: formatPrimaryTag,
+        };
+      },
+      valueFormatter: ({ value }) => formatPrimaryTag(value),
+      filterValueGetter: (params) => formatPrimaryTag(params.data?.genres),
       minWidth: 120,
     },
     {
@@ -308,6 +364,14 @@ export function useCmsProductionGrid(options: {
       wrapText: true,
       autoHeight: true,
       valueFormatter: ({ value }) => truncateValue(String(value ?? "")),
+    },
+    {
+      headerName: options.t("cms.columns.imageMedia"),
+      field: "imageMedia",
+      editable: false,
+      minWidth: 150,
+      cellClass: "cms-truncate-cell",
+      cellRenderer: (params: ICellRendererParams<CmsProductionGridRow, unknown>) => renderImageMediaCell(params, options.t),
     },
     {
       headerName: options.t("cms.columns.media"),

--- a/frontend/src/composables/useCmsProductionGrid.ts
+++ b/frontend/src/composables/useCmsProductionGrid.ts
@@ -186,6 +186,7 @@ export function useCmsProductionGrid(options: {
   getPrimaryTagOptions?: () => Array<{ id: number; label: string }>;
   // Backwards-compatible: older tests/usage provide just labels.
   getPrimaryTagLabels?: () => string[];
+  currentLang?: Ref<string>;
 }) {
   const primaryTagLabelById = computed(() => {
     const optionsEntries = options.getPrimaryTagOptions?.() ?? [];
@@ -275,8 +276,11 @@ export function useCmsProductionGrid(options: {
       minWidth: 90,
       maxWidth: 120,
       cellClass: "cms-production-id-cell",
-      cellRenderer: (params: { value: number }) =>
-        `<a href="/productions/${params.value}" class="text-ink-primary underline hover:text-ink-secondary transition-colors">${params.value}</a>`,
+      cellRenderer: (params: { value: number }) => {
+        const lang = options.currentLang?.value ?? "";
+        const prefix = lang ? `/${lang}` : "";
+        return `<a href="${prefix}/productions/${params.value}" class="text-ink-primary underline hover:text-ink-secondary transition-colors">${params.value}</a>`;
+      },
     },
     {
       headerName: "Events",

--- a/frontend/src/services/cms/grid.ts
+++ b/frontend/src/services/cms/grid.ts
@@ -81,6 +81,8 @@ export function buildProductionGridRow(
     tags: additionalLabels.join(", ") || "-",
     descriptionOne: localize(production.description) || "",
     descriptionTwo: localize(production.description_2) || "",
+    imageMedia: "",
+    imageMediaUrls: [],
     media: localize(production.video_1) || localize(production.video_2) || "",
     events: eventIds,
   };
@@ -122,6 +124,8 @@ export function applyUpdatedProductionToRow(
   row.teaser = localize(updated.teaser) || "";
   row.descriptionOne = localize(updated.description) || "";
   row.descriptionTwo = localize(updated.description_2) || "";
+  row.imageMedia = "";
+  row.imageMediaUrls = [];
   row.media = localize(updated.video_1) || localize(updated.video_2) || "";
 }
 

--- a/frontend/src/services/cms/types.ts
+++ b/frontend/src/services/cms/types.ts
@@ -34,6 +34,8 @@ export interface CmsProductionGridRow {
   tags: string;
   descriptionOne: string;
   descriptionTwo: string;
+  imageMedia: string;
+  imageMediaUrls: string[];
   media: string;
   events: number[];
 }

--- a/frontend/test/components/admin/cms/productions/CmsCreateEventModal.test.ts
+++ b/frontend/test/components/admin/cms/productions/CmsCreateEventModal.test.ts
@@ -17,6 +17,8 @@ function buildProduction(overrides: Partial<CmsProductionGridRow> = {}): CmsProd
     tags: "",
     descriptionOne: "",
     descriptionTwo: "",
+    imageMedia: "",
+    imageMediaUrls: [],
     media: "",
     events: [],
     ...overrides,

--- a/frontend/test/components/admin/cms/productions/CmsEventsDrawer.test.ts
+++ b/frontend/test/components/admin/cms/productions/CmsEventsDrawer.test.ts
@@ -17,6 +17,8 @@ function buildProduction(overrides: Partial<CmsProductionGridRow> = {}): CmsProd
     tags: "",
     descriptionOne: "",
     descriptionTwo: "",
+    imageMedia: "",
+    imageMediaUrls: [],
     media: "",
     events: [],
     ...overrides,

--- a/frontend/test/components/admin/cms/productions/CmsProductionsTab.test.ts
+++ b/frontend/test/components/admin/cms/productions/CmsProductionsTab.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/services/productions", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/services/productions")>();
   return {
     ...actual,
+    getProduction: vi.fn(),
     getProductions: vi.fn(),
     createProduction: vi.fn(),
     updateProduction: vi.fn(),
@@ -127,6 +128,7 @@ const mockHall = {
 describe("CmsProductionsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(productionsService, "getProduction").mockResolvedValue(mockProduction);
     vi.spyOn(productionsService, "getProductions").mockResolvedValue({ items: [mockProduction], total: 1 });
     vi.spyOn(productionsService, "createProduction").mockResolvedValue(mockProduction);
     vi.spyOn(productionsService, "updateProduction").mockResolvedValue(mockProduction);

--- a/frontend/test/composables/useCmsProductionGrid.test.ts
+++ b/frontend/test/composables/useCmsProductionGrid.test.ts
@@ -9,13 +9,13 @@ describe("useCmsProductionGrid", () => {
   });
 
   describe("column definitions", () => {
-    it("declares ten production columns including the events action", () => {
+    it("declares eleven production columns including id and events action", () => {
       const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key });
 
-      expect(grid.columnDefs.value).toHaveLength(10);
-      expect(grid.gridColumnOptions.value).toHaveLength(10);
+      expect(grid.columnDefs.value).toHaveLength(11);
+      expect(grid.gridColumnOptions.value).toHaveLength(11);
 
-      const eventsValueGetter = grid.columnDefs.value[0]?.valueGetter as
+      const eventsValueGetter = grid.columnDefs.value.find((def) => def.colId === "eventsAction")?.valueGetter as
         | ((params: unknown) => string)
         | undefined;
       expect(eventsValueGetter?.({})).toBe("View");

--- a/frontend/test/composables/useCmsProductionGrid.test.ts
+++ b/frontend/test/composables/useCmsProductionGrid.test.ts
@@ -10,7 +10,7 @@ describe("useCmsProductionGrid", () => {
 
   describe("column definitions", () => {
     it("declares twelve production columns including id and events action", () => {
-      const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key });
+      const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key, currentLang: ref('nl') });
 
       expect(grid.columnDefs.value).toHaveLength(12);
       expect(grid.gridColumnOptions.value).toHaveLength(12);
@@ -18,7 +18,7 @@ describe("useCmsProductionGrid", () => {
       const idRenderer = grid.columnDefs.value[0]?.cellRenderer as
         | ((params: { value: number }) => string)
         | undefined;
-      expect(idRenderer?.({ value: 42 })).toContain('/productions/42');
+      expect(idRenderer?.({ value: 42 })).toContain('/nl/productions/42');
 
       const eventsValueGetter = grid.columnDefs.value.find((def) => def.colId === "eventsAction")?.valueGetter as
         | ((params: unknown) => string)
@@ -27,7 +27,7 @@ describe("useCmsProductionGrid", () => {
     });
 
     it("truncates long teaser and description values via valueFormatter", () => {
-      const defs = useCmsProductionGrid({ isDark: ref(false), t: (key) => key }).columnDefs.value;
+      const defs = useCmsProductionGrid({ isDark: ref(false), t: (key) => key, currentLang: ref('nl') }).columnDefs.value;
 
       const teaser = defs.find((d) => d.field === "teaser")?.valueFormatter as
         | ((params: { value: unknown }) => string)
@@ -48,7 +48,7 @@ describe("useCmsProductionGrid", () => {
     });
 
     it("renders media cells as escaped truncated text and hides empty values", () => {
-      const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key });
+      const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key, currentLang: ref('nl') });
 
       const mediaRenderer = grid.columnDefs.value.find((c) => c.field === "media")?.cellRenderer as
         | ((params: { value: unknown }) => string)
@@ -80,6 +80,7 @@ describe("useCmsProductionGrid", () => {
       const withLabels = useCmsProductionGrid({
         isDark: ref(false),
         t: (key) => key,
+        currentLang: ref('nl'),
         getPrimaryTagLabels: () => ["Genre A", "Genre B"],
       });
       const withParams = withLabels.columnDefs.value.find((c) => c.field === "genres")?.cellEditorParams as
@@ -87,7 +88,7 @@ describe("useCmsProductionGrid", () => {
         | undefined;
       expect(withParams?.().values).toEqual(["Genre A", "Genre B"]);
 
-      const withoutLabels = useCmsProductionGrid({ isDark: ref(false), t: (key) => key });
+      const withoutLabels = useCmsProductionGrid({ isDark: ref(false), t: (key) => key, currentLang: ref('nl') });
       const withoutParams = withoutLabels.columnDefs.value.find((c) => c.field === "genres")?.cellEditorParams as
         | (() => { values: string[] })
         | undefined;
@@ -98,6 +99,7 @@ describe("useCmsProductionGrid", () => {
       const grid = useCmsProductionGrid({
         isDark: ref(false),
         t: (key) => key,
+        currentLang: ref('nl'),
         getPrimaryTagOptions: () => [
           { id: 7, label: "Genre Seven" },
           { id: 9, label: "Genre Nine" },
@@ -130,7 +132,7 @@ describe("useCmsProductionGrid", () => {
 
   describe("defaultColDef cellStyle", () => {
     it("highlights empty cells and leaves non-empty cells untouched", () => {
-      const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key });
+      const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key, currentLang: ref('nl') });
 
       const cellStyle = grid.defaultColDef.cellStyle as
         | ((params: { value: unknown }) => Record<string, string> | null)
@@ -163,6 +165,7 @@ describe("useCmsProductionGrid", () => {
       const grid = useCmsProductionGrid({
         isDark: ref(false),
         t: (key) => key,
+        currentLang: ref('nl'),
         getPrimaryTagOptions: () => [{ id: 7, label: "Genre A" }],
       });
       grid.gridApi.value = { exportDataAsCsv } as never;
@@ -206,7 +209,7 @@ describe("useCmsProductionGrid", () => {
         sizeColumnsToFit: vi.fn(),
       };
       localStorage.setItem("viernulvier-cms-grid-state-v2", JSON.stringify({ a: 1 }));
-      const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key });
+      const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key, currentLang: ref('nl') });
 
       grid.onGridReady({ api } as never);
 

--- a/frontend/test/composables/useCmsProductionGrid.test.ts
+++ b/frontend/test/composables/useCmsProductionGrid.test.ts
@@ -9,11 +9,16 @@ describe("useCmsProductionGrid", () => {
   });
 
   describe("column definitions", () => {
-    it("declares eleven production columns including id and events action", () => {
+    it("declares twelve production columns including id and events action", () => {
       const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key });
 
-      expect(grid.columnDefs.value).toHaveLength(11);
-      expect(grid.gridColumnOptions.value).toHaveLength(11);
+      expect(grid.columnDefs.value).toHaveLength(12);
+      expect(grid.gridColumnOptions.value).toHaveLength(12);
+
+      const idRenderer = grid.columnDefs.value[0]?.cellRenderer as
+        | ((params: { value: number }) => string)
+        | undefined;
+      expect(idRenderer?.({ value: 42 })).toContain('/productions/42');
 
       const eventsValueGetter = grid.columnDefs.value.find((def) => def.colId === "eventsAction")?.valueGetter as
         | ((params: unknown) => string)
@@ -49,6 +54,10 @@ describe("useCmsProductionGrid", () => {
         | ((params: { value: unknown }) => string)
         | undefined;
 
+      const imageRenderer = grid.columnDefs.value.find((c) => c.field === "imageMedia")?.cellRenderer as
+        | ((params: { data?: { imageMediaUrls?: string[] } }) => string)
+        | undefined;
+
       expect(mediaRenderer?.({ value: "https://example.com/cover.jpg" } as never)).toContain("cms-media-text");
       expect(
         mediaRenderer?.({ value: `https://example.com/a & b<'">.jpg` } as never),
@@ -56,6 +65,15 @@ describe("useCmsProductionGrid", () => {
       expect(mediaRenderer?.({ value: "" } as never)).toBe("");
       expect(mediaRenderer?.({ value: "   " } as never)).toBe("");
       expect(mediaRenderer?.({ value: null } as never)).toBe("");
+
+      expect(imageRenderer?.({ data: undefined })).toBe("");
+      expect(imageRenderer?.({ data: { imageMediaUrls: [] } })).toBe("");
+      expect(imageRenderer?.({ data: { imageMediaUrls: ["https://example.com/a.jpg"] } })).toContain(
+        "cms.create.media.imageCountOne",
+      );
+      expect(
+        imageRenderer?.({ data: { imageMediaUrls: ["a", "b"] } }),
+      ).toContain("cms.create.media.imageCountOther");
     });
 
     it("uses primary tag labels as genre editor values with empty fallback", () => {
@@ -73,7 +91,40 @@ describe("useCmsProductionGrid", () => {
       const withoutParams = withoutLabels.columnDefs.value.find((c) => c.field === "genres")?.cellEditorParams as
         | (() => { values: string[] })
         | undefined;
-      expect(withoutParams?.().values).toEqual([]);
+      expect(withoutParams?.().values).toEqual([0]);
+    });
+
+    it("uses primary tag options for genre formatting and editor values", () => {
+      const grid = useCmsProductionGrid({
+        isDark: ref(false),
+        t: (key) => key,
+        getPrimaryTagOptions: () => [
+          { id: 7, label: "Genre Seven" },
+          { id: 9, label: "Genre Nine" },
+        ],
+      });
+
+      const genreColumn = grid.columnDefs.value.find((c) => c.field === "genres");
+      const params = genreColumn?.cellEditorParams as
+        | (() => { values: number[]; formatValue: (value: unknown) => string })
+        | undefined;
+
+      expect(params?.().values).toEqual([0, 7, 9]);
+      expect(params?.().formatValue(7)).toBe("Genre Seven");
+      expect(params?.().formatValue(0)).toBe("-");
+      expect(params?.().formatValue("  ")).toBe("-");
+      expect(params?.().formatValue("Custom" as never)).toBe("Custom");
+      expect(params?.().formatValue(99)).toBe("#99");
+
+      const formatter = genreColumn?.valueFormatter as
+        | ((params: { value: unknown }) => string)
+        | undefined;
+      const filterGetter = genreColumn?.filterValueGetter as
+        | ((params: { data?: { genres?: unknown } }) => string)
+        | undefined;
+
+      expect(formatter?.({ value: 9 })).toBe("Genre Nine");
+      expect(filterGetter?.({ data: { genres: 7 } })).toBe("Genre Seven");
     });
   });
 
@@ -109,7 +160,11 @@ describe("useCmsProductionGrid", () => {
   describe("CSV export specifics", () => {
     it("excludes the events action column and serializes tag arrays", () => {
       const exportDataAsCsv = vi.fn();
-      const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key });
+      const grid = useCmsProductionGrid({
+        isDark: ref(false),
+        t: (key) => key,
+        getPrimaryTagOptions: () => [{ id: 7, label: "Genre A" }],
+      });
       grid.gridApi.value = { exportDataAsCsv } as never;
 
       grid.exportGridCsv();
@@ -124,6 +179,13 @@ describe("useCmsProductionGrid", () => {
         value: "ignored",
       });
       expect(serializedTags).toBe("[1,2]");
+
+      const serializedGenre = arg.processCellCallback({
+        column: { getColId: () => "genres" },
+        node: null,
+        value: 7,
+      });
+      expect(serializedGenre).toBe("Genre A");
 
       const plainValue = arg.processCellCallback({
         column: { getColId: () => "title" },


### PR DESCRIPTION
**Issue(s)**

solves:

#476 
#450 
____

**Description**

Adding production id's to the cms to link to the production details page for ease of use.
Also fixing some small bugs in production cms when updating production in a different language then your currently selected one.
____

**Sources**

