### PR TITLE
normalize production detail HTML and trim excessive breaks

### DIFF
--- a/frontend/src/components/production/DetailsSection.vue
+++ b/frontend/src/components/production/DetailsSection.vue
@@ -1,4 +1,4 @@
-<!-- eslint-disable vue/no-v-html -- All v-html bindings in this file render strings produced by parseAndSanitizeContent, which routes HTML through DOMPurify. -->
+<!-- eslint-disable vue/no-v-html -- v-html strings come from parseAndSanitizeContent (DOMPurify). Quote lines use normalizePlainText + text interpolation. -->
 <template>
   <div class="bg-surface-1 text-ink-primary">
     <div class="mx-auto max-w-7xl px-6 py-24 md:px-12">
@@ -21,12 +21,12 @@
             >
               <div
                 v-if="teaser"
-                class="font-serif text-base italic leading-relaxed text-ink-primary md:text-lg"
+                class="detail-rich-text font-serif text-base italic leading-relaxed text-ink-primary md:text-lg"
                 v-html="teaser"
               />
               <div
                 v-if="description_extra"
-                class="font-serif text-sm leading-relaxed text-ink-secondary"
+                class="detail-rich-text font-serif text-sm leading-relaxed text-ink-secondary"
                 :class="{ 'mt-3': teaser }"
                 v-html="description_extra"
               />
@@ -94,7 +94,7 @@
           <!-- Lead paragraph — drop cap on first letter, justified -->
           <div
             v-if="description"
-            class="article-lead font-serif text-lg leading-[1.7] text-ink-primary md:text-xl whitespace-pre-line text-justify hyphens-auto"
+            class="article-lead detail-rich-text font-serif text-lg leading-[1.7] text-ink-primary md:text-xl text-justify hyphens-auto"
             v-html="description"
           />
 
@@ -141,7 +141,7 @@
           <!-- Continuation — slightly smaller, secondary ink, like an addendum -->
           <div
             v-if="description_2"
-            class="font-serif text-base leading-[1.7] text-ink-secondary whitespace-pre-line text-justify hyphens-auto"
+            class="detail-rich-text font-serif text-base leading-[1.7] text-ink-secondary text-justify hyphens-auto"
             v-html="description_2"
           />
         </div>
@@ -157,7 +157,7 @@
                 {{ t("production.details.extraInfo") }}
               </h3>
               <div
-                class="font-serif text-sm leading-[1.7] text-ink-secondary whitespace-pre-line"
+                class="detail-rich-text font-serif text-sm leading-[1.7] text-ink-secondary"
                 v-html="info"
               />
             </div>
@@ -170,7 +170,7 @@
                 {{ t("production.details.programme") }}
               </h3>
               <div
-                class="font-serif text-sm leading-[1.7] text-ink-primary whitespace-pre-line"
+                class="detail-rich-text font-serif text-sm leading-[1.7] text-ink-primary"
                 v-html="programme"
               />
             </div>
@@ -188,7 +188,7 @@ import type { ProductionWithBackwardsRefs } from "@viernulvier/shared";
 import { computed, ref } from "vue";
 import { localizeOrEmpty, type LanguageMap } from "@/utils/language-utils";
 import { useI18n } from "vue-i18n";
-import { normalizeQuote, parseAndSanitizeContent } from "@/utils/parsers";
+import { normalizeQuote, parseAndSanitizeContent, normalizePlainText } from "@/utils/parsers";
 import ProductionDetailSidebarEvents from "@/components/production/ProductionDetailSidebarEvents.vue";
 import type { EnrichedEvent } from "@/composables/useProductionEvents";
 
@@ -228,8 +228,12 @@ const teaser = computed(() => parseField(props.production.teaser));
 const description = computed(() => parseField(props.production.description));
 const description_extra = computed(() => parseField(props.production.description_extra));
 const description_2 = computed(() => parseField(props.production.description_2));
-const quote = computed(() => normalizeQuote(parseField(props.production.quote)));
-const quote_source = computed(() => parseField(props.production.quote_source));
+const quote = computed(() =>
+  normalizeQuote(normalizePlainText(tProd(props.production.quote))),
+);
+const quote_source = computed(() =>
+  normalizePlainText(tProd(props.production.quote_source)),
+);
 const programme = computed(() => parseField(props.production.programme));
 const info = computed(() => parseField(props.production.info));
 
@@ -269,6 +273,63 @@ const mainContentClass = computed(() => {
 
 :deep(a:hover) {
   text-decoration-thickness: 2px;
+}
+
+/*
+ * Wrapper: `white-space: normal` so literal `\n` only between tags does not add
+ * phantom bands (we minify those in the parser). `pre-line` on p/li keeps rare
+ * in-flow line breaks from the CMS.
+ *
+ * Preflight zeros margins on p/ul/li outside `.prose`; this block is not
+ * `.prose`, so we must restore vertical rhythm between paragraphs and lists.
+ */
+.detail-rich-text {
+  white-space: normal;
+}
+
+.detail-rich-text :deep(p),
+.detail-rich-text :deep(li) {
+  white-space: pre-line;
+}
+
+.detail-rich-text :deep(> p) {
+  @apply mb-6;
+}
+
+.detail-rich-text :deep(> p:last-child) {
+  @apply mb-0;
+}
+
+.detail-rich-text :deep(> ul),
+.detail-rich-text :deep(> ol) {
+  @apply mb-6 list-disc pl-6;
+}
+
+.detail-rich-text :deep(> ol) {
+  list-style: decimal;
+}
+
+.detail-rich-text :deep(> ul:last-child),
+.detail-rich-text :deep(> ol:last-child) {
+  @apply mb-0;
+}
+
+.detail-rich-text :deep(li) {
+  @apply mb-1.5;
+}
+
+.detail-rich-text :deep(li:last-child) {
+  @apply mb-0;
+}
+
+/*
+ * Inter-tag `\r\n` used to show as blank bands under `whitespace-pre-line`; the
+ * parser minifies those away. `<hr>` does not participate in newline “runs”,
+ * but Preflight often leaves `<hr>` with no vertical margin, so the gap below
+ * the rule must come from CSS (same band as paragraph spacing).
+ */
+.detail-rich-text :deep(> hr) {
+  @apply my-6 w-full border-0 border-t border-surface-3;
 }
 
 /*

--- a/frontend/src/utils/parsers.ts
+++ b/frontend/src/utils/parsers.ts
@@ -1,15 +1,78 @@
 import MarkdownIt from "markdown-it";
 import DOMPurify from "dompurify";
 
+/**
+ * Max length of a single run of `\r` / `\n` in plain source before `normalize()`.
+ * `2` -> at most `\n\n` = one blank line. Longer runs collapse to this.
+ */
+const MAX_PLAIN_LINE_BREAK_RUN = 2;
+
 function normalize(input: string): string {
   return input
     .replace(/\\r\\n/g, "\n")
     .replace(/\\n/g, "\n")
     .replace(/\r\n/g, "\n")
     .replace(/^\s*\\\s*$/gm, "")
-    .replace(/[\r\n]{3,}/g, "\n\n")
+    .replace(/[\r\n]+/g, (run) =>
+      run.length <= MAX_PLAIN_LINE_BREAK_RUN
+        ? run
+        : "\n".repeat(MAX_PLAIN_LINE_BREAK_RUN),
+    )
     .replace(/\\+$/gm, "")
     .trim();
+}
+
+/**
+ * Same newline / escape cleanup as description HTML input, for fields rendered
+ * with `{{ }}` (no HTML wrapper / DOMPurify).
+ */
+export function normalizePlainText(input: string | null | undefined): string {
+  if (input === null || input === undefined || input === "") return "";
+  return normalize(input);
+}
+
+function escapeHtmlPlainText(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Non-HTML fields: paragraphs separated by `\n\n` (after normalize, at most
+ * one blank line between blocks). Single `\n` inside a paragraph -> `<br>`.
+ */
+function plainNormalizedToSanitizedDisplayHtml(normalized: string): string {
+  const blocks = normalized.split(/\n\n+/).filter((b) => b.trim().length > 0);
+  if (blocks.length === 0) return "";
+  const html = blocks
+    .map((block) => {
+      const inner = escapeHtmlPlainText(block.trim()).replace(/\n/g, "<br />");
+      return `<p>${inner}</p>`;
+    })
+    .join("");
+  return sanitizeHtmlForDisplay(html);
+}
+
+/**
+ * `<br>` tags are often chained. Cap runs at two (one blank line)
+ * so v-html blocks don’t grow huge empty bands. Literal `\r`/`\n` in the same
+ * string are cleaned in `normalize()` before we branch on HTML.
+ */
+function collapseHtmlBreakRuns(html: string): string {
+  const maxBr = Math.max(1, MAX_PLAIN_LINE_BREAK_RUN);
+  const replacement = maxBr >= 2 ? "<br><br>" : "<br>";
+  let out = html;
+  let prev: string;
+  do {
+    prev = out;
+    out = out.replace(
+      new RegExp(`(?:\\s*<br\\s*\\/?>\\s*){${maxBr + 1},}`, "gi"),
+      replacement,
+    );
+  } while (out !== prev);
+  return out;
 }
 
 function isHtml(input: string): boolean {
@@ -25,7 +88,7 @@ DOMPurify.addHook("uponSanitizeElement", (node, data) => {
 
       const isYouTube =
         (url.hostname === "www.youtube.com" ||
-         url.hostname === "www.youtube-nocookie.com") &&
+          url.hostname === "www.youtube-nocookie.com") &&
         url.pathname.startsWith("/embed/");
 
       if (!isYouTube) {
@@ -54,6 +117,33 @@ function sanitizeHtml(input: string): string {
   });
 }
 
+/**
+ * CMS often closes a paragraph with `<br><br></p>` before the next `<p>`. Those
+ * breaks stack with the next paragraph’s margin and read as double spacing.
+ * Remove `<br>` runs that sit directly before `</p>`.
+ */
+function stripTrailingBrBeforeParagraphClose(html: string): string {
+  return html.replace(/(?:<br\s*\/?>\s*)+(?=<\/p\b)/gi, "");
+}
+
+/**
+ * Remove whitespace-only gaps between tags when they contain a line break. This
+ * keeps HTML compact  and avoids extra bands if any parent still uses `white-space:
+ * pre-line`. Spaces only (`</a> <a>`) are kept.
+ */
+function stripIntertagLinebreakWhitespace(html: string): string {
+  return html.replace(/>(\s+)</g, (full, ws: string) =>
+    /\n|\r/.test(ws) ? "><" : full,
+  );
+}
+
+function sanitizeHtmlForDisplay(input: string): string {
+  const sanitized = sanitizeHtml(input);
+  const collapsed = collapseHtmlBreakRuns(sanitized);
+  const noTrailingBrP = stripTrailingBrBeforeParagraphClose(collapsed);
+  return stripIntertagLinebreakWhitespace(noTrailingBrP);
+}
+
 export function parseAndSanitizeContent(
   input: string | null | undefined,
 ): string {
@@ -64,10 +154,10 @@ export function parseAndSanitizeContent(
   if (!normalized) return "";
 
   if (isHtml(normalized)) {
-    return sanitizeHtml(normalized);
+    return sanitizeHtmlForDisplay(normalized);
   }
 
-  return normalized;
+  return plainNormalizedToSanitizedDisplayHtml(normalized);
 }
 
 export function normalizeQuote(input: string): string {
@@ -89,5 +179,5 @@ export function parseAndSanitizeMd(input: string | null | undefined): string {
 
   const rawHtml = md.render(input);
 
-  return sanitizeHtml(rawHtml);
+  return sanitizeHtmlForDisplay(rawHtml);
 }

--- a/frontend/test/utils/parsers.test.ts
+++ b/frontend/test/utils/parsers.test.ts
@@ -15,20 +15,25 @@ describe("parseAndSanitizeContent", () => {
     expect(parseAndSanitizeContent("")).toBe("");
   });
 
-  it("normalizes \\n escapes", () => {
+  it("normalizes \\n escapes in plain text to <br> inside a paragraph", () => {
     const input = "Hello\\nWorld";
 
     const result = parseAndSanitizeContent(input);
 
-    expect(result).toBe("Hello\nWorld");
+    expect(result).toMatch(/<p>/);
+    expect(result).toContain("Hello");
+    expect(result).toContain("World");
+    expect(result).toMatch(/<br\s*\/?>/i);
   });
 
-  it("normalizes Windows line endings", () => {
+  it("normalizes Windows line endings in plain text to <br>", () => {
     const input = "Hello\r\nWorld";
 
     const result = parseAndSanitizeContent(input);
 
-    expect(result).toBe("Hello\nWorld");
+    expect(result).toMatch(/<p>/);
+    expect(result).toContain("Hello");
+    expect(result).toContain("World");
   });
 
   it("removes standalone backslash lines (legacy CSV noise)", () => {
@@ -36,23 +41,26 @@ describe("parseAndSanitizeContent", () => {
 
     const result = parseAndSanitizeContent(input);
 
-    expect(result).toBe("Hello\n\nWorld");
+    expect(result).toMatch(/<p>/);
+    expect(result).toContain("Hello");
+    expect(result).toContain("World");
   });
 
-  it("trims whitespace", () => {
+  it("trims outer whitespace in plain text", () => {
     const input = "   hello world   ";
 
     const result = parseAndSanitizeContent(input);
 
-    expect(result).toBe("hello world");
+    expect(result).toContain("hello world");
+    expect(result).toMatch(/<p>/);
   });
 
-  it("returns plain text when no HTML is present", () => {
+  it("wraps plain text in a paragraph when no HTML is present", () => {
     const input = "Simple text";
 
     const result = parseAndSanitizeContent(input);
 
-    expect(result).toBe("Simple text");
+    expect(result).toMatch(/<p>\s*Simple text\s*<\/p>/);
   });
 
   it("returns sanitized HTML when HTML is detected", () => {
@@ -80,6 +88,53 @@ describe("parseAndSanitizeContent", () => {
 
     expect(result).toContain("<b>");
     expect(result).toContain("Hello\nWorld");
+  });
+
+  it("collapses long runs of literal newlines in plain text to at most one empty line between paragraphs", () => {
+    const input = "One\n\n\n\nTwo";
+
+    const result = parseAndSanitizeContent(input);
+
+    expect(result).toMatch(/<p>[^<]*One/);
+    expect(result).toMatch(/Two/);
+    expect(result.match(/<\/p>\s*<p>/)).toBeTruthy();
+  });
+
+  it("collapses long runs of <br> tags in HTML to at most two (one blank line)", () => {
+    const input = "<p>a</p><br/><br /><br/><br/>";
+
+    const result = parseAndSanitizeContent(input);
+
+    expect(result).toMatch(/<br\s*\/?>\s*<br\s*\/?>/i);
+    expect(result.match(/<br/gi)?.length).toBe(2);
+  });
+
+  it("strips trailing <br> before </p> so the next <p> margin is not doubled", () => {
+    const input =
+      "<p>Intro line.<br><br></p>\n<p>Next section</p>";
+
+    const result = parseAndSanitizeContent(input);
+
+    expect(result).not.toMatch(/\.<br>/);
+    expect(result).toContain("<p>Intro line.</p>");
+    expect(result).toContain("Next section");
+  });
+
+  it("minifies newline-only gaps between block tags in sanitized HTML", () => {
+    const input = "<p>Intro</p>\n<ul>\n<li>One</li>\n</ul>";
+
+    const result = parseAndSanitizeContent(input);
+
+    expect(result).toContain("</p><ul>");
+    expect(result).toContain("<li>One</li>");
+  });
+
+  it("keeps a single space between inline tags (no line break in the gap)", () => {
+    const input = "<p><a href=\"#a\">A</a> <a href=\"#b\">B</a></p>";
+
+    const result = parseAndSanitizeContent(input);
+
+    expect(result).toMatch(/<\/a> <a /);
   });
 
   it("allows YouTube embed iframes", () => {


### PR DESCRIPTION
**Issue(s)**


____

**Description**

Tightened how production detail text is normalized and how it is styled. In `parsers.ts`, parseAndSanitizeContent now caps long runs of literal newlines, collapses excessive \<br> chains, strips trailing \<br> before \</p> (so breaks don’t stack with block margins), minifies newline-only whitespace between HTML tags, and converts plain (non-HTML) copy into safe \<p> / \<br /> HTML before sanitizing. 
In `DetailsSection.vue`, rich blocks use a shared layout: wrapper white-space: normal (so inter-tag newlines don’t fake extra gaps), pre-line only on p/li for in-flow line breaks, explicit margins for paragraphs, lists, and \<hr> (Preflight had removed default spacing outside .prose), plus description_2 aligned with the same pattern as the main body. Together this removes exaggerated empty bands from CMS noise while keeping intentional paragraph and section rhythm.

Some examples:

Before:
<img width="2680" height="1580" alt="image" src="https://github.com/user-attachments/assets/9ba35112-6446-4918-a609-9a810a1618e2" />
<img width="2484" height="2214" alt="image" src="https://github.com/user-attachments/assets/c6172060-3010-46c5-841f-8d41224523e3" />
After:
<img width="2432" height="1456" alt="image" src="https://github.com/user-attachments/assets/176b7798-e186-444c-9bb8-de2e3ac7bebc" />
<img width="2444" height="1920" alt="image" src="https://github.com/user-attachments/assets/cc2114a2-f461-4e36-9a00-28b791251b0c" />

____

**Sources**
