### PR TITLE
Fixed navbar overlap on half screen

### DIFF
--- a/frontend/src/assets/stylesheets/navbar.css
+++ b/frontend/src/assets/stylesheets/navbar.css
@@ -20,12 +20,12 @@
 
 /* ===== NAV LEFT ===== */
 .nav-left { @apply flex items-center; }
-.nav-links { @apply hidden sm:flex items-center gap-6; }
+.nav-links { @apply hidden lg:flex items-center gap-6; }
 .logo { @apply h-6 w-auto; }
 
 /* ===== HAMBURGER ===== */
 .hamburger {
-  @apply flex sm:hidden flex-col gap-[5px] cursor-pointer p-1;
+  @apply flex lg:hidden flex-col gap-[5px] cursor-pointer p-1;
   background: none;
   border: none;
 }

--- a/frontend/src/components/nav/AdminNavbar.vue
+++ b/frontend/src/components/nav/AdminNavbar.vue
@@ -19,7 +19,7 @@
     </RouterLink>
 
     <div class="nav-right">
-      <div class="hidden sm:flex items-center gap-2">
+      <div class="hidden lg:flex items-center gap-2">
         <NavControls :is-dark="isDark" @toggle-dark="$emit('toggle-dark')" />
         <div ref="profileWrapper" class="relative">
           <button class="profile-btn" @click="profileOpen = !profileOpen">

--- a/frontend/src/components/nav/AppNavbar.vue
+++ b/frontend/src/components/nav/AppNavbar.vue
@@ -19,7 +19,7 @@
       <img src="@/assets/images/logo.svg" alt="VierNulVier" width="102" height="32" class="logo" />
     </RouterLink>
 
-    <div class="hidden sm:block">
+    <div class="hidden lg:block">
       <NavControls :is-dark="isDark" @toggle-dark="$emit('toggle-dark')" />
     </div>
   </nav>


### PR DESCRIPTION
**Issue(s)**

#491

____

**Description**

Fixed #491 by changing the requirements for the hamburger to appear from `sm` (640 px) to `lg` (1024 px).
The overlap would also be fixed with around 880 px, but I found the standardized 1024 px in the `DESIGN.md` and it gives us a bit more buffer when adding new links in the navbar.
____

**Sources**

<!-- If applicable, add sources (e.g. links, screenshots ...) to show your work. -->
