### PR TITLE
Small fixes blogpost detail

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -389,9 +389,11 @@ export default {
     loading: "Loading blogpost",
     notFound: "Blogpost not found",
     notFoundDescription: "This blogpost does not exist or is no longer available.",
-    errorGeneric: "Something went wrong while loading this blogpost.",
+    errorGenericKicker: "Oops!",
+    errorGenericTitle: "Something went wrong",
+    errorGenericDescription: "We couldn't load this blogpost. Please try again later.",
     publishedOn: "Published on {date}",
-    backToHome: "Back to home",
+    backToBlog: "Back to all blog posts",
     relatedProductions: "Related productions",
   },
   errors: {

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -389,9 +389,11 @@ export default {
     loading: "Chargement de l'article",
     notFound: "Article introuvable",
     notFoundDescription: "Cet article n'existe pas ou n'est plus disponible.",
-    errorGeneric: "Une erreur s'est produite lors du chargement de cet article.",
+    errorGenericKicker: "Oups !",
+    errorGenericTitle: "Une erreur est survenue",
+    errorGenericDescription: "Nous n'avons pas pu charger cet article. Veuillez réessayer plus tard.",
     publishedOn: "Publié le {date}",
-    backToHome: "Retour à l'accueil",
+    backToBlog: "Retour à tous les articles",
     relatedProductions: "Productions associées",
   },
   errors: {

--- a/frontend/src/i18n/locales/nl.ts
+++ b/frontend/src/i18n/locales/nl.ts
@@ -389,9 +389,11 @@ export default {
     loading: "Blogpost laden",
     notFound: "Blogpost niet gevonden",
     notFoundDescription: "Deze blogpost bestaat niet of is niet meer beschikbaar.",
-    errorGeneric: "Er is iets misgegaan bij het laden van deze blogpost.",
+    errorGenericKicker: "Oeps!",
+    errorGenericTitle: "Er ging iets mis",
+    errorGenericDescription: "We konden deze blogpost helaas niet laden. Probeer het later opnieuw.",
     publishedOn: "Gepubliceerd op {date}",
-    backToHome: "Terug naar home",
+    backToBlog: "Terug naar alle blogposts",
     relatedProductions: "Gerelateerde producties",
   },
   errors: {

--- a/frontend/src/views/BlogPostDetailView.vue
+++ b/frontend/src/views/BlogPostDetailView.vue
@@ -94,14 +94,14 @@ const loadingProductions = ref<boolean>(false);
 const title = computed(() => 
   localizeWithFallback(
     post.value?.title, 
-    (map) => localizeOrEmpty(map, currentLang.value)
-  )
+    (map) => localizeOrEmpty(map, currentLang.value),
+  ),
 );
 
 const bodyHtml = computed(() => {
   const rawMarkdown = localizeWithFallback(
     post.value?.content, 
-    (map) => localizeOrEmpty(map, currentLang.value)
+    (map) => localizeOrEmpty(map, currentLang.value),
   );
   return parseAndSanitizeMd(rawMarkdown);
 });

--- a/frontend/src/views/BlogPostDetailView.vue
+++ b/frontend/src/views/BlogPostDetailView.vue
@@ -2,8 +2,8 @@
   <div class="flex min-h-screen flex-col bg-surface-0 transition-colors duration-300">
     <AppNavbar :is-dark="isDark" @toggle-dark="toggleDark" />
 
-    <main class="mx-auto w-full max-w-3xl flex-1 px-6 py-12">
-      <!-- Loading state -->
+    <main v-if="loading || post" class="mx-auto w-full max-w-3xl flex-1 px-6 py-12">
+      
       <div v-if="loading" class="flex min-h-[40vh] items-center justify-center" role="status" aria-live="polite">
         <div class="flex items-center gap-1">
           <span class="text-[10px] font-black uppercase tracking-[0.3em] text-ink-secondary">
@@ -17,39 +17,11 @@
         </div>
       </div>
 
-      <!-- Not found state -->
-      <div v-else-if="error === 'not-found'" class="post-error" role="alert">
-        <h1 class="mb-3 text-2xl font-bold text-ink-primary">
-          {{ t("blogpost.notFound") }}
-        </h1>
-        <p class="mb-6 text-ink-secondary">{{ t("blogpost.notFoundDescription") }}</p>
-        <RouterLink
-          :to="{ name: RouteNames.HOME, params: { lang: currentLang } }"
-          class="back-link"
-        >
-          {{ t("blogpost.backToHome") }}
-        </RouterLink>
-      </div>
-
-      <!-- Generic error state -->
-      <div v-else-if="error === 'generic'" class="post-error" role="alert">
-        <p class="mb-6 text-ink-secondary">{{ t("blogpost.errorGeneric") }}</p>
-        <RouterLink
-          :to="{ name: RouteNames.HOME, params: { lang: currentLang } }"
-          class="back-link"
-        >
-          {{ t("blogpost.backToHome") }}
-        </RouterLink>
-      </div>
-
-      <!-- Happy path -->
       <article v-else-if="post" class="animate-fade-up">
-
         <header class="mb-16">
           <div v-if="formattedPublishedAt" class="mb-6 text-[10px] font-black uppercase tracking-[0.3em] text-ink-tertiary">
             {{ formattedPublishedAt }}
           </div>
-          
           <h1 class="font-serif text-5xl font-black italic uppercase leading-[1.05] text-ink-primary lg:text-7xl">
             {{ title }}
           </h1>
@@ -63,9 +35,28 @@
           :date-ranges="dateRangeByProductionId" 
           :is-loading="loadingProductions" 
         />
-
       </article>
+
     </main>
+
+    <template v-else>
+      <NotFound 
+        v-if="error === 'not-found'"
+        :title="t('blogpost.notFound')"
+        :description="t('blogpost.notFoundDescription')"
+        :button-link="`/${currentLang}/blog`"
+        :button-label="t('blogpost.backToBlog')"
+      />
+
+      <NotFound 
+        v-else-if="error === 'generic'"
+        :kicker="t('blogpost.errorGenericKicker')"
+        :title="t('blogpost.errorGenericTitle')"
+        :description="t('blogpost.errorGenericDescription')"
+        :button-link="`/${currentLang}/blog`"
+        :button-label="t('blogpost.backToBlog')"
+      />
+    </template>
 
     <AppFooter />
   </div>
@@ -73,17 +64,16 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from "vue";
-import { RouterLink } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { useDarkMode } from "@/composables/useDarkMode";
 import { i18n, type SupportedLang } from "@/i18n";
-import { RouteNames } from "@/router/routeNames";
 import { getBlogPost } from "@/services/blogposts";
 import { ApiError } from "@/services/api";
 import AppNavbar from "@/components/nav/AppNavbar.vue";
 import AppFooter from "@/components/AppFooter.vue";
+import NotFound from "@/components/NotFound.vue";
 import type { BlogPostWithBackwardsRefs, ProductionWithBackwardsRefs } from "@viernulvier/shared";
-import { localizeOrEmpty } from "@/utils/language-utils";
+import { localizeOrEmpty, localizeWithFallback } from "@/utils/language-utils";
 import { parseAndSanitizeMd } from "@/utils/parsers";
 import { getProduction } from "@/services/productions";
 import LinkedProductionsCarousel from "@/components/blogpost/LinkedProductionsCarousel.vue";
@@ -101,9 +91,18 @@ const loading = ref<boolean>(true);
 const error = ref<"not-found" | "generic" | null>(null);
 const loadingProductions = ref<boolean>(false);
 
-const title = computed(() => localizeOrEmpty(post.value?.title ?? {}, currentLang.value));
+const title = computed(() => 
+  localizeWithFallback(
+    post.value?.title, 
+    (map) => localizeOrEmpty(map, currentLang.value)
+  )
+);
+
 const bodyHtml = computed(() => {
-  const rawMarkdown = localizeOrEmpty(post.value?.content ?? {}, currentLang.value);
+  const rawMarkdown = localizeWithFallback(
+    post.value?.content, 
+    (map) => localizeOrEmpty(map, currentLang.value)
+  );
   return parseAndSanitizeMd(rawMarkdown);
 });
 

--- a/frontend/test/views/BlogPostDetailView.test.ts
+++ b/frontend/test/views/BlogPostDetailView.test.ts
@@ -154,15 +154,27 @@ describe("BlogPostDetailView.vue", () => {
     wrapper.unmount();
   });
 
+  it("falls back to the next non-empty translation if active locale key is empty string", async () => {
+    i18n.global.locale.value = "nl";
+    vi.mocked(getBlogPost).mockResolvedValue(
+      makePost({ title: { nl: "", en: "English fallback title" } }),
+    );
+    const wrapper = await mountView();
+    await flushPromises();
+
+    expect(wrapper.find("h1").text()).toBe("English fallback title");
+    wrapper.unmount();
+  });
+
   // ── Error states ───────────────────────────────────────────────────────────
   it("shows the not-found error when the API returns 404", async () => {
     vi.mocked(getBlogPost).mockRejectedValue(new ApiError(404, "Not Found"));
     const wrapper = await mountView();
     await flushPromises();
 
-    const alert = wrapper.find('[role="alert"]');
-    expect(alert.exists()).toBe(true);
-    expect(alert.text()).toContain(i18n.global.t("blogpost.notFound"));
+    const notFoundComponent = wrapper.findComponent({ name: "NotFound" });
+    expect(notFoundComponent.exists()).toBe(true);
+    expect(notFoundComponent.props("title")).toBe(i18n.global.t("blogpost.notFound"));
     expect(wrapper.find("article").exists()).toBe(false);
     wrapper.unmount();
   });
@@ -172,10 +184,10 @@ describe("BlogPostDetailView.vue", () => {
     const wrapper = await mountView();
     await flushPromises();
 
-    const alert = wrapper.find('[role="alert"]');
-    expect(alert.exists()).toBe(true);
-    expect(alert.text()).toContain(i18n.global.t("blogpost.errorGeneric"));
-    expect(alert.text()).not.toContain(i18n.global.t("blogpost.notFound"));
+    const notFoundComponent = wrapper.findComponent({ name: "NotFound" });
+    expect(notFoundComponent.exists()).toBe(true);
+    expect(notFoundComponent.props("title")).toBe(i18n.global.t("blogpost.errorGenericTitle"));
+    expect(notFoundComponent.props("title")).not.toBe(i18n.global.t("blogpost.notFound"));
     wrapper.unmount();
   });
 
@@ -184,19 +196,20 @@ describe("BlogPostDetailView.vue", () => {
     const wrapper = await mountView();
     await flushPromises();
 
-    expect(wrapper.find('[role="alert"]').exists()).toBe(true);
-    expect(wrapper.find('[role="alert"]').text()).toContain(i18n.global.t("blogpost.errorGeneric"));
+    const notFoundComponent = wrapper.findComponent({ name: "NotFound" });
+    expect(notFoundComponent.exists()).toBe(true);
+    expect(notFoundComponent.props("title")).toBe(i18n.global.t("blogpost.errorGenericTitle"));
     wrapper.unmount();
   });
 
-  it("renders a back-to-home link in the error state", async () => {
+  it("renders a back-to-all-blogposts link in the error state", async () => {
     vi.mocked(getBlogPost).mockRejectedValue(new ApiError(404, "Not Found"));
     const wrapper = await mountView();
     await flushPromises();
 
-    const link = wrapper.find('[role="alert"] a');
-    expect(link.exists()).toBe(true);
-    expect(link.text()).toBe(i18n.global.t("blogpost.backToHome"));
+    const notFoundComponent = wrapper.findComponent({ name: "NotFound" });
+    expect(notFoundComponent.exists()).toBe(true);
+    expect(notFoundComponent.props("buttonLabel")).toBe(i18n.global.t("blogpost.backToBlog"));
     wrapper.unmount();
   });
 
@@ -204,9 +217,9 @@ describe("BlogPostDetailView.vue", () => {
     const wrapper = await mountView("abc");
     await flushPromises();
 
-    const alert = wrapper.find('[role="alert"]');
-    expect(alert.exists()).toBe(true);
-    expect(alert.text()).toContain(i18n.global.t("blogpost.notFound"));
+    const notFoundComponent = wrapper.findComponent({ name: "NotFound" });
+    expect(notFoundComponent.exists()).toBe(true);
+    expect(notFoundComponent.props("title")).toBe(i18n.global.t("blogpost.notFound"));
     expect(wrapper.find("article").exists()).toBe(false);
     expect(getBlogPost).not.toHaveBeenCalled();
     wrapper.unmount();
@@ -216,9 +229,9 @@ describe("BlogPostDetailView.vue", () => {
     const wrapper = await mountView("0");
     await flushPromises();
 
-    const alert = wrapper.find('[role="alert"]');
-    expect(alert.exists()).toBe(true);
-    expect(alert.text()).toContain(i18n.global.t("blogpost.notFound"));
+    const notFoundComponent = wrapper.findComponent({ name: "NotFound" });
+    expect(notFoundComponent.exists()).toBe(true);
+    expect(notFoundComponent.props("title")).toBe(i18n.global.t("blogpost.notFound"));
     expect(wrapper.find("article").exists()).toBe(false);
     expect(getBlogPost).not.toHaveBeenCalled();
     wrapper.unmount();


### PR DESCRIPTION
…lback

**Issue(s)**

<!-- List the issue(s) for this PR here. -->

____

**Description**

The blog post detail page now uses the notFound component for consistent not found states across the application. Additionally, when a language map contained an empty string, that empty value was previously displayed. It now falls back to the first available non-empty translation instead.
____

**Sources**

<!-- If applicable, add sources (e.g. links, screenshots ...) to show your work. -->
