### PR TITLE
Fix/swagger static files prod

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -54,8 +54,8 @@ COPY --from=build /app/backend/migrations ./migrations
 COPY backend/docker-entrypoint.sh /docker-entrypoint.sh
 
 # This is needed so swagger ui can serve its static files.
-RUN mkdir -p ./backend/static
-RUN cp -r ./node_modules/@fastify/swagger-ui/static/* ./backend/static/
+RUN mkdir -p ./dist/backend/static
+RUN cp -r ./node_modules/@fastify/swagger-ui/static/* ./static/
 
 RUN chmod +x /docker-entrypoint.sh
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -54,8 +54,8 @@ COPY --from=build /app/backend/migrations ./migrations
 COPY backend/docker-entrypoint.sh /docker-entrypoint.sh
 
 # This is needed so swagger ui can serve its static files.
-RUN mkdir -p ./backend/static
-RUN cp -r ./node_modules/@fastify/swagger-ui/static/* ./backend/static/
+RUN mkdir -p ./static
+RUN cp -r ./node_modules/@fastify/swagger-ui/static/* ./static/
 
 RUN chmod +x /docker-entrypoint.sh
 


### PR DESCRIPTION
**Description**

Swap the directory where static is located to the root as /backend is not correct. This was my mistake as I assumed it worked the same as in our dev env.

