### PR TITLE
add url query for the selected view

### DIFF
--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -643,6 +643,9 @@ const TO_QUERY_KEY = "to";
 const SORT_BY_QUERY_KEY = "sortBy";
 const SORT_DIR_QUERY_KEY = "sortDir";
 
+/** Present only when the grid layout is selected; list remains the canonical default (no param). */
+const VIEW_QUERY_KEY = "view";
+
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
@@ -799,6 +802,13 @@ function readSortDirFromRoute(): ProductionSortDir {
   return value === "asc" ? "asc" : "desc";
 }
 
+function readLayoutFromQuery(q: LocationQuery): ProductionsLayoutMode {
+  const raw = q[VIEW_QUERY_KEY];
+  const s = Array.isArray(raw) ? raw[0] : raw;
+  if (s === undefined || s === null || s === "") return "list";
+  return String(s).trim().toLowerCase() === "grid" ? "grid" : "list";
+}
+
 function queryForPage0WithBase(
   page0: number,
   baseQuery: LocationQuery,
@@ -842,6 +852,11 @@ function queryForPage0WithBase(
     q[SORT_BY_QUERY_KEY] = sortBy.value;
     q[SORT_DIR_QUERY_KEY] = sortDir.value;
   }
+  if (layoutMode.value === "grid") {
+    q[VIEW_QUERY_KEY] = "grid";
+  } else {
+    delete q[VIEW_QUERY_KEY];
+  }
   return q;
 }
 
@@ -860,6 +875,20 @@ function urlNeedsSyncForPage0(page0: number): boolean {
     return cur !== undefined && cur !== "";
   }
   return cur !== want;
+}
+
+/** True when `view` should be omitted (list) vs `view=grid`, or stray `view=…` should be stripped. */
+function urlNeedsSyncForView(): boolean {
+  const raw = route.query[VIEW_QUERY_KEY];
+  const cur =
+    raw === undefined || raw === null || raw === ""
+      ? undefined
+      : String(Array.isArray(raw) ? raw[0] : raw).trim().toLowerCase();
+  const wantGrid = layoutMode.value === "grid";
+  if (wantGrid) {
+    return cur !== "grid";
+  }
+  return cur !== undefined;
 }
 
 /**
@@ -894,7 +923,7 @@ const appliedSearchTerms = ref<string[]>([]);
 const searchDraft = ref("");
 const sortBy = ref<ProductionSortBy>("date");
 const sortDir = ref<ProductionSortDir>("desc");
-const layoutMode = ref<ProductionsLayoutMode>("list");
+const layoutMode = ref<ProductionsLayoutMode>(readLayoutFromQuery(route.query));
 /**
  * Total matching the current list query; updated on each successful fetch.
  * While search/filter list loads we keep the previous value so the results line
@@ -1501,7 +1530,11 @@ onMounted(async () => {
       }
     }
 
-    if (syncRouteAfterExclusiveTimeFilter || urlNeedsSyncForPage0(page0)) {
+    if (
+      syncRouteAfterExclusiveTimeFilter ||
+      urlNeedsSyncForPage0(page0) ||
+      urlNeedsSyncForView()
+    ) {
       await replaceRouteForPage0(page0);
     }
   } catch (err) {
@@ -1510,6 +1543,23 @@ onMounted(async () => {
     loading.value = false;
   }
 });
+
+watch(layoutMode, async () => {
+  if (loading.value) return;
+  await replaceRouteForPage0(currentPage.value);
+});
+
+watch(
+  () => ({
+    layout: readLayoutFromQuery(route.query),
+    rawView: route.query[VIEW_QUERY_KEY],
+  }),
+  ({ layout }) => {
+    if (loading.value) return;
+    if (layout === layoutMode.value) return;
+    layoutMode.value = layout;
+  },
+);
 
 /** Refetch when `?page=` changes (browser back/forward or programmatic `router.replace`). */
 watch(

--- a/frontend/src/views/ProductionsView.vue
+++ b/frontend/src/views/ProductionsView.vue
@@ -403,7 +403,7 @@
         >
           <div
             v-if="layoutMode === 'grid'"
-            class="grid grid-cols-1 gap-6 sm:grid-cols-2 md:gap-8 lg:grid-cols-3"
+            class="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 md:mt-8 md:gap-8 lg:grid-cols-3"
           >
             <ProductionGridCardSkeleton v-for="n in PAGE_SIZE" :key="n" />
           </div>
@@ -431,7 +431,7 @@
             <template v-if="listLoading && productions.length === 0">
               <div
                 v-if="layoutMode === 'grid'"
-                class="grid grid-cols-1 gap-6 sm:grid-cols-2 md:gap-8 lg:grid-cols-3"
+                class="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 md:mt-8 md:gap-8 lg:grid-cols-3"
               >
                 <ProductionGridCardSkeleton v-for="n in PAGE_SIZE" :key="n" />
               </div>
@@ -450,7 +450,7 @@
             <div v-else>
               <div
                 v-if="layoutMode === 'grid'"
-                class="grid grid-cols-1 gap-6 sm:grid-cols-2 md:gap-8 lg:grid-cols-3"
+                class="mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2 md:mt-8 md:gap-8 lg:grid-cols-3"
               >
                 <ProductionGridCard
                   v-for="(p, idx) in productions"

--- a/frontend/test/views/ProductionsView.test.ts
+++ b/frontend/test/views/ProductionsView.test.ts
@@ -1024,4 +1024,48 @@ describe("ProductionsView.vue", () => {
     expect(router.currentRoute.value.query.page).toBeUndefined();
     wrapper.unmount();
   });
+
+  it("uses view=grid from the URL so grid layout stays selected after load", async () => {
+    const { wrapper, router } = await mountView("/nl/productions?view=grid");
+    const gridBtn = wrapper.find('[aria-label="Rasterweergave"]');
+    expect(gridBtn.attributes("aria-pressed")).toBe("true");
+    expect(router.currentRoute.value.query.view).toBe("grid");
+    wrapper.unmount();
+  });
+
+  it("adds view=grid to the URL when toggling to grid layout", async () => {
+    const { wrapper, router } = await mountView();
+    await wrapper.find('[aria-label="Rasterweergave"]').trigger("click");
+    await flushPromises();
+    expect(router.currentRoute.value.query.view).toBe("grid");
+    wrapper.unmount();
+  });
+
+  it("removes view from the URL when switching back to list", async () => {
+    const { wrapper, router } = await mountView("/nl/productions?view=grid");
+    await flushPromises();
+    await wrapper.find('[aria-label="Lijstweergave"]').trigger("click");
+    await flushPromises();
+    expect(router.currentRoute.value.query.view).toBeUndefined();
+    wrapper.unmount();
+  });
+
+  it("drops view=list after load since list uses the canonical URL without view", async () => {
+    const { wrapper, router } = await mountView("/nl/productions?view=list");
+    await flushPromises();
+    expect(router.currentRoute.value.query.view).toBeUndefined();
+    const listBtn = wrapper.find('[aria-label="Lijstweergave"]');
+    expect(listBtn.attributes("aria-pressed")).toBe("true");
+    wrapper.unmount();
+  });
+
+  it("switches layout to list when view is cleared from the URL after load", async () => {
+    const { wrapper, router } = await mountView("/nl/productions?view=grid");
+    await flushPromises();
+    await router.replace({ path: "/nl/productions", query: {} });
+    await flushPromises();
+    const listBtn = wrapper.find('[aria-label="Lijstweergave"]');
+    expect(listBtn.attributes("aria-pressed")).toBe("true");
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
**Issue(s)**

____

**Description**

There is now a `?view=` query added to the url, which saves the layout of the productions page. List is still the default, so only for grid will `?view=grid` be visible in the url. 

Another completely unrelated change, but a bit dumb to make a pr for this; added padding above the first row of productions cards in grid view, because they otherwise sit too close to the collapsed genre row (list cards sat at same distance, but these have padding on top within the cards themselves, which makes it look like there is more space between).

____

**Sources**
