### PR TITLE
Fix dark mode contrast on CMS buttons + Cancel label on bulk-edit modal

### DIFF
--- a/frontend/src/assets/stylesheets/cms-create-modal.css
+++ b/frontend/src/assets/stylesheets/cms-create-modal.css
@@ -57,7 +57,7 @@
 }
 
 .cms-language-pill.active {
-  @apply border-transparent bg-surface-inv text-ink-on-inv;
+  @apply border-transparent bg-accent-dark text-surface-0;
 }
 
 /* ---- Checkbox toggle row (public flag, super-admin flag, etc.) ---- */
@@ -72,5 +72,5 @@
  * (The global .cms-side-save is full-width with larger padding, meant for side panels.)
  */
 .cms-form-submit {
-  @apply rounded-md bg-surface-inv px-4 py-2 text-sm font-semibold text-ink-on-inv transition hover:bg-surface-inv-raised disabled:cursor-not-allowed disabled:opacity-60;
+  @apply rounded-md bg-accent-dark px-4 py-2 text-sm font-semibold text-surface-0 transition hover:bg-accent-dark-hover disabled:cursor-not-allowed disabled:opacity-60;
 }

--- a/frontend/src/assets/stylesheets/cms-view.css
+++ b/frontend/src/assets/stylesheets/cms-view.css
@@ -5,7 +5,7 @@
  */
 
 .cms-add-button {
-  @apply inline-flex w-fit items-center rounded-full border border-transparent bg-surface-inv px-5 py-2.5 text-sm font-semibold text-ink-on-inv transition hover:bg-surface-inv-raised;
+  @apply inline-flex w-fit items-center rounded-full border border-transparent bg-accent-dark px-5 py-2.5 text-sm font-semibold text-surface-0 transition hover:bg-accent-dark-hover;
 }
 
 .cms-remove-button {
@@ -65,7 +65,7 @@
 }
 
 .cms-side-save {
-  @apply inline-flex w-full items-center justify-center rounded-md bg-surface-inv px-4 py-3 text-sm font-semibold text-ink-on-inv shadow-sm transition hover:bg-surface-inv-raised focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink-primary disabled:cursor-not-allowed disabled:opacity-60;
+  @apply inline-flex w-full items-center justify-center rounded-md bg-accent-dark px-4 py-3 text-sm font-semibold text-surface-0 shadow-sm transition hover:bg-accent-dark-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ink-primary disabled:cursor-not-allowed disabled:opacity-60;
 }
 
 .cms-modal-overlay {
@@ -155,5 +155,5 @@ css used for adding/editing lists (of IDs)
 }
 
 .cms-list-add {
-  @apply rounded-md bg-surface-inv px-4 py-2 text-sm font-semibold text-ink-on-inv transition hover:bg-surface-inv-raised;
+  @apply rounded-md bg-accent-dark px-4 py-2 text-sm font-semibold text-surface-0 transition hover:bg-accent-dark-hover;
 }

--- a/frontend/src/components/admin/cms/productions/CmsCreateEventModal.vue
+++ b/frontend/src/components/admin/cms/productions/CmsCreateEventModal.vue
@@ -189,6 +189,6 @@ function onTextInput(field: "startsAt" | "endsAt" | "doorsAt" | "infoNl", event:
 }
 
 .cms-side-save {
-  @apply rounded-md bg-surface-inv px-4 py-2 text-sm font-semibold text-ink-on-inv transition hover:bg-surface-inv-raised disabled:cursor-not-allowed disabled:opacity-60;
+  @apply rounded-md bg-accent-dark px-4 py-2 text-sm font-semibold text-surface-0 transition hover:bg-accent-dark-hover disabled:cursor-not-allowed disabled:opacity-60;
 }
 </style>

--- a/frontend/src/components/admin/cms/productions/CmsCreateProductionModal.vue
+++ b/frontend/src/components/admin/cms/productions/CmsCreateProductionModal.vue
@@ -297,7 +297,7 @@ function onTagToggle(tagId: number, selected: boolean): void {
 }
 
 .cms-language-pill.active {
-  @apply border-transparent bg-surface-inv text-ink-on-inv;
+  @apply border-transparent bg-accent-dark text-surface-0;
 }
 
 .cms-upload-controls {
@@ -349,6 +349,6 @@ function onTagToggle(tagId: number, selected: boolean): void {
 }
 
 .cms-side-save {
-  @apply rounded-md bg-surface-inv px-4 py-2 text-sm font-semibold text-ink-on-inv transition hover:bg-surface-inv-raised disabled:cursor-not-allowed disabled:opacity-60;
+  @apply rounded-md bg-accent-dark px-4 py-2 text-sm font-semibold text-surface-0 transition hover:bg-accent-dark-hover disabled:cursor-not-allowed disabled:opacity-60;
 }
 </style>

--- a/frontend/src/components/admin/cms/productions/CmsEventsDrawer.vue
+++ b/frontend/src/components/admin/cms/productions/CmsEventsDrawer.vue
@@ -217,7 +217,7 @@ function confirmRemoveEvent(): void {
 }
 
 .cms-side-save {
-  @apply rounded-md bg-surface-inv px-4 py-2 text-sm font-semibold text-ink-on-inv transition hover:bg-surface-inv-raised disabled:cursor-not-allowed disabled:opacity-60;
+  @apply rounded-md bg-accent-dark px-4 py-2 text-sm font-semibold text-surface-0 transition hover:bg-accent-dark-hover disabled:cursor-not-allowed disabled:opacity-60;
 }
 
 .cms-text-input {

--- a/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
+++ b/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
@@ -184,7 +184,7 @@
 
           <footer class="cms-modal-footer">
             <button type="button" class="cms-side-close" :disabled="bulkEditConfirmLoading" @click="closeBulkEditConfirm">
-              {{ t("cms.panel.close") }}
+              {{ t("general.cancel") }}
             </button>
             <button type="button" class="cms-side-save" :disabled="bulkEditConfirmLoading" @click="confirmBulkEdit">
               {{ bulkEditConfirmLoading ? t("cms.panel.saving") : t("cms.actions.confirmBulkEditSubmit") }}

--- a/frontend/src/components/admin/cms/tags/CmsCreateTagModal.vue
+++ b/frontend/src/components/admin/cms/tags/CmsCreateTagModal.vue
@@ -199,7 +199,7 @@ function parseTagTypeValue(raw: string): number | null {
 }
 
 .cms-language-pill.active {
-  @apply border-transparent bg-surface-inv text-ink-on-inv;
+  @apply border-transparent bg-accent-dark text-surface-0;
 }
 
 .cms-lang-label {
@@ -219,6 +219,6 @@ function parseTagTypeValue(raw: string): number | null {
 }
 
 .cms-side-save {
-  @apply rounded-md bg-surface-inv px-4 py-2 text-sm font-semibold text-ink-on-inv transition hover:bg-surface-inv-raised disabled:cursor-not-allowed disabled:opacity-60;
+  @apply rounded-md bg-accent-dark px-4 py-2 text-sm font-semibold text-surface-0 transition hover:bg-accent-dark-hover disabled:cursor-not-allowed disabled:opacity-60;
 }
 </style>


### PR DESCRIPTION
**Issue(s)**

Closes #507
Closes #508

____

**Description**

Two small UI fixes in the CMS:

1. **Dark mode contrast** (#507) — Primary CMS buttons (`Yes, update`, `Add`, `Save`, language pills, ...) used `bg-surface-inv text-ink-on-inv`. In dark mode `--surface-inv` resolves to `#1C1A17` which is **identical to** `--surface-0` (the page background), so the buttons were invisible. Swapped to `bg-accent-dark text-surface-0 hover:bg-accent-dark-hover` — the same pattern already used in `ChangePasswordModal.vue`. The `--accent-dark` token swaps properly per theme (dark in light mode, light in dark mode), giving high contrast in both.

   Touched classes: `cms-side-save`, `cms-add-button`, `cms-list-add`, `cms-form-submit`, `cms-language-pill.active` — across `cms-view.css`, `cms-create-modal.css`, and the four components with per-component duplicates of `.cms-side-save`/`.cms-language-pill.active`.

2. **Duplicate Close labels** (#508) — The bulk-edit confirm modal had two buttons labelled "Close" (header X and footer dismiss). The footer button now uses the existing `general.cancel` key → "Cancel" / "Annuleer" / "Annuler".

____

**Verification**

- `npm run lint` → 0 errors (only pre-existing v-html warnings)
- `CmsProductionsTab.test.ts` → 38/38 passing
- Dark mode computed styles checked in the browser preview: all touched button classes now render `background #EDE8DF` on page bg `#1C1A17` — full contrast.
- Light mode unchanged: `--accent-dark` is `#2B2826` in light mode, same as the old `--surface-inv`, so the look is identical.

Larger inverted-surface sections (footer, navbar, hero) keep `bg-surface-inv` — that's a separate design discussion out of scope.