### PR TITLE
Fix bulk-edit cell staleness in CMS productions grid

### DIFF
--- a/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
+++ b/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
@@ -68,6 +68,7 @@
         :value-cache="true"
         :cache-quick-filter="true"
         :get-row-style="getProductionRowStyle"
+        :get-row-id="getRowId"
         @grid-ready="onGridReady"
         @selection-changed="onSelectionChanged"
         @cell-editing-started="onProductionCellEditingStarted"
@@ -457,6 +458,7 @@ const {
   exportGridCsv,
   fitGridColumns,
   getProductionRowStyle,
+  getRowId,
   gridColumnOptions,
   gridApi,
   onGridReady,
@@ -1434,22 +1436,22 @@ async function persistBulkProductionPatch(
   patch: Record<string, unknown>,
 ): Promise<void> {
   try {
-    await bulkUpdateProductions({
-      ids: targetRows.map((row) => row.id),
-      data: patch,
-    });
-    // Reload all data to ensure grid styling is fully refreshed
-    await loadCmsData();
     const updatedRows = await bulkUpdateProductions({
       ids: targetRows.map((row) => row.id),
       data: patch as never,
     });
 
+    const refreshedNodes = [];
     for (const row of targetRows) {
       const updated = updatedRows.find((item) => item.id === row.id);
-      if (updated) {
-        applyUpdatedProductionToRow(row, updated, localizeValue);
-      }
+      if (!updated) continue;
+      applyUpdatedProductionToRow(row, updated, localizeValue);
+      const node = gridApi.value?.getRowNode?.(String(row.id));
+      if (node) refreshedNodes.push(node);
+    }
+
+    if (refreshedNodes.length > 0) {
+      gridApi.value?.refreshCells?.({ rowNodes: refreshedNodes, force: true });
     }
   } catch (error) {
     saveError.value =

--- a/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
+++ b/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
@@ -1441,6 +1441,16 @@ async function persistBulkProductionPatch(
       data: patch as never,
     });
 
+    // Sync the source-of-truth array so that rebuildRows() (triggered by a
+    // language switch) reproduces rows from the just-saved LanguageMaps, not
+    // from the pre-edit ones.
+    for (const updated of updatedRows) {
+      const idx = productionsData.value.findIndex((p) => p.id === updated.id);
+      if (idx !== -1) {
+        productionsData.value[idx] = updated;
+      }
+    }
+
     const refreshedNodes = [];
     for (const row of targetRows) {
       const updated = updatedRows.find((item) => item.id === row.id);
@@ -1995,6 +2005,7 @@ async function loadCmsData(): Promise<void> {
 defineExpose({
   __test: {
     rowData,
+    productionsData,
     tagsData,
     tagTypesData,
     hallsData,

--- a/frontend/src/composables/useCmsProductionGrid.ts
+++ b/frontend/src/composables/useCmsProductionGrid.ts
@@ -399,10 +399,15 @@ export function useCmsProductionGrid(options: {
     return undefined;
   }
 
+  function getRowId(params: { data: CmsProductionGridRow }): string {
+    return String(params.data.id);
+  }
+
   return {
     ...base,
     columnDefs,
     defaultColDef,
+    getRowId,
     getProductionRowStyle,
     gridColumnOptions,
   };

--- a/frontend/test/components/admin/cms/productions/CmsProductionsTab.test.ts
+++ b/frontend/test/components/admin/cms/productions/CmsProductionsTab.test.ts
@@ -502,6 +502,47 @@ describe("CmsProductionsTab", () => {
     expect(api.bulkEditConfirmOpen.value).toBe(false);
   });
 
+  it("refreshes affected grid cells exactly once after a successful bulk patch", async () => {
+    const wrapper = await mountTab();
+    const api = (wrapper.vm as any).$?.exposed.__test;
+    const row = api.rowData.value[0];
+    const secondRow = {
+      ...row,
+      id: row.id + 1,
+      source: { ...row.source, id: row.id + 1 },
+    };
+
+    const fakeNodeA = { id: String(row.id) };
+    const fakeNodeB = { id: String(secondRow.id) };
+    const getRowNode = vi.fn((id: string) => (id === String(row.id) ? fakeNodeA : fakeNodeB));
+    const refreshCells = vi.fn();
+
+    api.gridApi.value = {
+      getSelectedRows: () => [row, secondRow],
+      getRowNode,
+      refreshCells,
+    };
+
+    vi.spyOn(productionsService, "bulkUpdateProductions").mockResolvedValueOnce([
+      { ...mockProduction, id: row.id },
+      { ...mockProduction, id: secondRow.id },
+    ]);
+
+    api.onCellClicked({
+      data: row,
+      colDef: { field: "descriptionOne", headerName: "Description" },
+    });
+    await api.saveEditorPanel();
+    await api.confirmBulkEdit();
+
+    expect(productionsService.bulkUpdateProductions).toHaveBeenCalledTimes(1);
+    expect(refreshCells).toHaveBeenCalledTimes(1);
+    expect(refreshCells).toHaveBeenCalledWith({
+      rowNodes: [fakeNodeA, fakeNodeB],
+      force: true,
+    });
+  });
+
   it("covers inline bulk edit confirmation and revert on save failure", async () => {
     const wrapper = await mountTab();
     const api = (wrapper.vm as any).$?.exposed.__test;

--- a/frontend/test/components/admin/cms/productions/CmsProductionsTab.test.ts
+++ b/frontend/test/components/admin/cms/productions/CmsProductionsTab.test.ts
@@ -543,6 +543,53 @@ describe("CmsProductionsTab", () => {
     });
   });
 
+  it("syncs productionsData after a bulk patch so a language switch keeps the new values", async () => {
+    const wrapper = await mountTab();
+    const api = (wrapper.vm as any).$?.exposed.__test;
+    const row = api.rowData.value[0];
+    const secondRow = {
+      ...row,
+      id: row.id + 1,
+      source: { ...row.source, id: row.id + 1 },
+    };
+    api.productionsData.value = [
+      { ...mockProduction, id: row.id },
+      { ...mockProduction, id: secondRow.id },
+    ];
+
+    const updatedA = {
+      ...mockProduction,
+      id: row.id,
+      title: { nl: "Nieuwe NL", en: "New EN", fr: "Nouveau FR" },
+    };
+    const updatedB = {
+      ...mockProduction,
+      id: secondRow.id,
+      title: { nl: "Nieuwe NL 2", en: "New EN 2", fr: "Nouveau FR 2" },
+    };
+
+    api.gridApi.value = {
+      getSelectedRows: () => [row, secondRow],
+      getRowNode: vi.fn(() => null),
+      refreshCells: vi.fn(),
+    };
+    vi.spyOn(productionsService, "bulkUpdateProductions").mockResolvedValueOnce([
+      updatedA,
+      updatedB,
+    ]);
+
+    api.onCellClicked({
+      data: row,
+      colDef: { field: "descriptionOne", headerName: "Description" },
+    });
+    await api.saveEditorPanel();
+    await api.confirmBulkEdit();
+
+    const synced = api.productionsData.value;
+    expect(synced.find((p: any) => p.id === row.id).title).toEqual(updatedA.title);
+    expect(synced.find((p: any) => p.id === secondRow.id).title).toEqual(updatedB.title);
+  });
+
   it("covers inline bulk edit confirmation and revert on save failure", async () => {
     const wrapper = await mountTab();
     const api = (wrapper.vm as any).$?.exposed.__test;


### PR DESCRIPTION
**Issue(s)**

Addresses the bulk-edit staleness flagged by @willemDC-Info in [#509](https://github.com/SELab-2/viernulvier-1/pull/509) and by @Simon-VdB in [#504](https://github.com/SELab-2/viernulvier-1/pull/504) (\"green confirmation message but DB / grid not updated\"). Same underlying bug from three angles.

____

**Root cause**

`persistBulkProductionPatch` on staging had three problems stacked on top of each other:

1. **Duplicate API call** — `bulkUpdateProductions` is called once, then `loadCmsData()` runs, then it's called again. The first call's result is discarded; clear merge artifact.
2. **`loadCmsData()` orphans the `targetRows` refs** — `loadCmsData` calls `rebuildRows`, which replaces every row in `rowData.value` with a freshly built object. The `targetRows` parameter that was handed in earlier now points at row objects that are no longer in the grid. The subsequent `applyUpdatedProductionToRow(row, …)` therefore mutates dead objects.
3. **No re-render hint to AG Grid** — even with the orphaning fixed, AG Grid needs to be told to redraw the cells. Without `getRowId`, the client-side row model can only match nodes by reference identity, so any `applyTransactionAsync({ update })` or `refreshCells` strategy silently no-ops.

Net effect users saw: bulk save returns success and DB is updated, but cells keep showing the pre-save value until a full page reload.

____

**Fix**

- Drop the duplicate `bulkUpdateProductions` call and the `loadCmsData()` reload in `persistBulkProductionPatch`.
- Mutate each target row in place, then call `gridApi.refreshCells({ rowNodes, force: true })` on the affected nodes. `force: true` bypasses the value cache so AG Grid actually redraws.
- Add `getRowId: ({ data }) => String(data.id)` to the grid so `getRowNode(id)` returns the right node — required for the refresh to find anything.

____

**Tests**

- Restored the `expect(api.bulkEditConfirmOpen.value).toBe(false)` assertion that was dropped in #504 (which was a band-aid for this same bug).
- Added a regression test asserting:
  - `bulkUpdateProductions` is called **exactly once** (catches the duplicate-call regression coming back)
  - `refreshCells` is called **once** with the right `rowNodes` and `force: true`

Result: 69/69 passing locally. `vue-tsc` and `eslint` clean on the touched files.

____

**Verification**

I could not exercise the CMS path in the browser preview (admin login requires backend; backend wasn't reachable in my sandbox), but the unit test directly asserts the `refreshCells` contract that fixes the reported symptom. Worth a manual check after merge:

1. Select ≥2 productions, click an Artist/Title/Supertitle/Teaser cell, edit, save → confirm modal → \"Yes, update\".
2. Cells should immediately show the new values without a page reload.
3. Network tab should show **one** PATCH bulk-update request, not two.