### PR TITLE
"select all" checkbox now selects on active filters

### DIFF
--- a/frontend/src/composables/useCmsGridBase.ts
+++ b/frontend/src/composables/useCmsGridBase.ts
@@ -42,6 +42,7 @@ export function useCmsGridBase<TRow>(options: UseCmsGridBaseOptions) {
     checkboxes: true,
     headerCheckbox: true,
     enableClickSelection: false,
+    selectAll: "filtered" as const,
   };
 
   const agThemeVars = computed<Record<string, string>>(() => {


### PR DESCRIPTION
**Issue(s)**


____

**Description**

Fixing a bug where when selecting all productions in the cms it selected all prodution regardless of the current filters that had been set up causing the user to possibly edit more productions then wanted


____

**Sources**

