### PR TITLE
fix(cms): make teaser and genres columns clickable in productions tab

### DIFF
--- a/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
+++ b/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
@@ -615,7 +615,7 @@ const inlineFieldToApi: Record<InlineEditableField, InlineEditableField> = {
   teaser: "teaser",
 }
 
-type longGridFieldIds = "descriptionOne" | "descriptionTwo" | "media" | "performer" | "artist" | "title" | "producer";
+type longGridFieldIds = "descriptionOne" | "descriptionTwo" | "media" | "performer" | "artist" | "title" | "producer" | "teaser";
 
 const longGridFieldToApi: Record<longGridFieldIds, ProductionLongField> = {
   descriptionOne: "description",
@@ -625,6 +625,7 @@ const longGridFieldToApi: Record<longGridFieldIds, ProductionLongField> = {
   title: "title",
   artist: "artist",
   producer: "supertitle",
+  teaser: "teaser",
 };
 
 const genreTagTypeIds = computed(

--- a/frontend/src/composables/useCmsProductionGrid.ts
+++ b/frontend/src/composables/useCmsProductionGrid.ts
@@ -325,7 +325,8 @@ export function useCmsProductionGrid(options: {
     {
       headerName: options.t("cms.columns.genres"),
       field: "genres",
-      editable: false,
+      editable: true,
+      singleClickEdit: true,
       cellEditor: "agSelectCellEditor",
       cellEditorParams: () => {
         // If labels-only provider exists, return labels array for backward

--- a/frontend/src/services/cms/types.ts
+++ b/frontend/src/services/cms/types.ts
@@ -99,7 +99,7 @@ export interface CreateBlogPostFormState {
   productions: number[];
 }
 
-export type ProductionLongField = "artist" | "title" | "supertitle" | "description" | "description_2" | "video_1";
+export type ProductionLongField = "artist" | "title" | "supertitle" | "teaser" | "description" | "description_2" | "video_1";
 export type BlogPostLongField = "title" | "content";
 export type TagsLongField = "name";
 export type TagTypeLongField = "name";

--- a/frontend/test/composables/useCmsProductionGrid.test.ts
+++ b/frontend/test/composables/useCmsProductionGrid.test.ts
@@ -83,16 +83,23 @@ describe("useCmsProductionGrid", () => {
       ).toContain("cms.create.media.imageCountOther");
     });
 
-    it("keeps production cells non-editable so clicks only use the side-panel flow", () => {
+    it("keeps long-form production cells non-editable so clicks only use the side-panel flow", () => {
       const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key, currentLang: ref('nl') });
-      const inlineFields = ["performer", "title", "producer", "teaser", "genres"];
+      const sidePanelFields = ["performer", "title", "producer", "teaser"];
 
-      for (const field of inlineFields) {
+      for (const field of sidePanelFields) {
         const column = grid.columnDefs.value.find((c) => c.field === field);
         expect(column?.editable).toBe(false);
       }
+    });
 
-      expect(grid.columnDefs.value.find((c) => c.field === "genres")?.singleClickEdit).toBeUndefined();
+    it("keeps the genres cell editable with a single-click select editor", () => {
+      const grid = useCmsProductionGrid({ isDark: ref(false), t: (key) => key, currentLang: ref('nl') });
+      const genresColumn = grid.columnDefs.value.find((c) => c.field === "genres");
+
+      expect(genresColumn?.editable).toBe(true);
+      expect(genresColumn?.singleClickEdit).toBe(true);
+      expect(genresColumn?.cellEditor).toBe("agSelectCellEditor");
     });
 
     it("uses primary tag labels as genre editor values with empty fallback", () => {


### PR DESCRIPTION
Closes #537

## Summary
- **teaser**: voeg toe aan `longGridFieldToApi` + `ProductionLongField` zodat een klik op de cel de meertalige text side panel opent (zoals descriptionOne/descriptionTwo).
- **genres**: zet `editable: true` + `singleClickEdit: true` terug op de kolom zodat de bestaande `agSelectCellEditor` weer start bij een klik. De volledige persist-logica in `onCellEditingStopped` was nog aanwezig maar werd nooit getriggerd.

## Achtergrond
Commit d3624de (\"disabled inline editing\") zette `editable: false` op alle productions kolommen met de bedoeling om alles via de side-panel flow te laten verlopen. teaser werd echter niet toegevoegd aan `longGridFieldToApi`, en genres heeft een eigen editor-flow (geen tekst side panel) — beide kolommen waren daardoor niet meer aanpasbaar.

## Test plan
- [x] `npx vitest run test/composables/useCmsProductionGrid.test.ts` (22/22 ✅)
- [x] `npx vitest run test/components/admin/cms/productions/` (139/139 ✅)
- [x] `npm run lint` ✅
- [x] `npx vue-tsc --noEmit` ✅
- [x] Manueel: klik op een teaser cel → side panel met meertalige tekst editor opent
- [x] Manueel: klik op een genre tag cel → select dropdown opent inline en wijziging persist