### PR TITLE
fix(api): forward FormData as multipart so CMS image upload actually persists

### DIFF
--- a/backend/test/routes/auth/logout.test.ts
+++ b/backend/test/routes/auth/logout.test.ts
@@ -63,23 +63,32 @@ describe("Logout", () => {
   });
 
   test("POST /api/v1/auth/logout — evicts jti from denylist after token expiry", async () => {
-    const jti = server.generateJti();
-    const shortLivedCookie = server.jwt.sign(
-      { id: 404, username: "Karel", jti },
-      { expiresIn: "1s" },
-    );
+    // Use fake timers so the assertion below isn't racing against the
+    // setTimeout that the logout handler schedules. On slow CI the inject
+    // call could yield to the event loop long enough for a sub-second
+    // timer to fire before the assertion runs.
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    try {
+      const jti = server.generateJti();
+      const shortLivedCookie = server.jwt.sign(
+        { id: 404, username: "Karel", jti },
+        { expiresIn: "1s" },
+      );
 
-    await server.inject({
-      method: "POST",
-      url: "/api/v1/auth/logout",
-      cookies: { session: shortLivedCookie },
-    });
+      await server.inject({
+        method: "POST",
+        url: "/api/v1/auth/logout",
+        cookies: { session: shortLivedCookie },
+      });
 
-    expect(server.tokenDenylist.has(jti)).toBe(true);
+      expect(server.tokenDenylist.has(jti)).toBe(true);
 
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+      vi.advanceTimersByTime(1500);
 
-    expect(server.tokenDenylist.has(jti)).toBe(false);
+      expect(server.tokenDenylist.has(jti)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("POST /api/v1/auth/logout — handles token without jti", async () => {

--- a/frontend/src/assets/stylesheets/cms-view.css
+++ b/frontend/src/assets/stylesheets/cms-view.css
@@ -93,7 +93,7 @@
 }
 
 .cms-media-modal {
-  @apply max-w-4xl;
+  @apply max-w-4xl max-h-[calc(100vh-2rem)];
 }
 
 .cms-media-preview-body {

--- a/frontend/src/components/admin/cms/productions/CmsCreateProductionModal.vue
+++ b/frontend/src/components/admin/cms/productions/CmsCreateProductionModal.vue
@@ -133,7 +133,7 @@
                 <input
                   v-if="mediaItem.type === 'image'"
                   type="file"
-                  accept="image/*"
+                  accept="image/jpeg,image/png,image/webp,image/gif"
                   class="cms-text-input"
                   @change="emit('media-file-change', mediaItem.id, $event)"
                 />

--- a/frontend/src/components/admin/cms/productions/CmsMediaPreviewModal.vue
+++ b/frontend/src/components/admin/cms/productions/CmsMediaPreviewModal.vue
@@ -14,7 +14,7 @@
         <input
           ref="mediaPreviewImageInput"
           type="file"
-          accept="image/*"
+          accept="image/jpeg,image/png,image/webp,image/gif"
           class="hidden"
           @change="$emit('image-selected', $event)"
         />
@@ -58,6 +58,9 @@
 
       <footer class="cms-modal-footer">
         <div class="cms-modal-footer-right cms-media-footer-actions">
+          <p v-if="saveError" class="cms-media-error" role="alert">
+            {{ saveError }}
+          </p>
           <input
             v-if="mediaPreview.kind !== 'image' && mediaPreview.mediaField"
             :value="mediaPreviewEditUrl"
@@ -115,6 +118,7 @@ defineProps<{
   mediaPreview: CmsMediaPreview | null;
   mediaPreviewEditUrl: string;
   isSaving: boolean;
+  saveError?: string | null;
 }>();
 
 const mediaPreviewImageInput = useTemplateRef<HTMLInputElement>("mediaPreviewImageInput");
@@ -134,8 +138,7 @@ const { t } = useI18n();
 
 <style scoped>
 .cms-media-preview-body {
-  min-width: 600px;
-  min-height: 500px;
+  min-width: min(600px, 100%);
   max-width: 90vw;
   max-height: 80vh;
   display: flex;
@@ -216,6 +219,11 @@ const { t } = useI18n();
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 0.5rem;
+}
+
+.cms-media-error {
+  font-size: 0.875rem;
+  color: #b91c1c;
 }
 
 img.cms-media-preview-large {

--- a/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
+++ b/frontend/src/components/admin/cms/productions/CmsProductionsTab.vue
@@ -361,6 +361,7 @@
         :media-preview="mediaPreview"
         :media-preview-edit-url="mediaPreviewEditUrl"
         :is-saving="isSaving"
+        :save-error="saveError"
         @close="closeMediaPreview"
         @image-selected="onMediaPreviewImageSelected"
         @remove-image="removeMediaImage"
@@ -1205,11 +1206,22 @@ function closeMediaPreview(): void {
   mediaPreviewEditUrl.value = "";
 }
 
+const ALLOWED_IMAGE_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
 async function onMediaPreviewImageSelected(event: Event): Promise<void> {
   const input = event.target as HTMLInputElement;
   const file = input.files?.[0];
   const productionId = mediaPreview.value?.productionId;
+  const label = mediaPreview.value?.label ?? t("cms.columns.imageMedia");
   if (!file || productionId === undefined) {
+    return;
+  }
+
+  if (!ALLOWED_IMAGE_MIME_TYPES.includes(file.type)) {
+    saveError.value = t("cms.errors.unsupportedImageType", {
+      type: file.type || file.name.split(".").pop() || "?",
+    });
+    input.value = "";
     return;
   }
 
@@ -1219,13 +1231,22 @@ async function onMediaPreviewImageSelected(event: Event): Promise<void> {
     const dataUrl = await fileToDataUrl(file);
     const uploadedImage = await uploadImageWithCrops(productionId, dataUrl);
     await loadCmsData();
-    const previewUrl =
-      resolvePreferredCropUrl(uploadedImage.crops, window.location.origin) ?? mediaPreview.value?.url;
-    if (previewUrl) {
-      openMediaPreview(previewUrl, mediaPreview.value?.label ?? t("cms.columns.imageMedia"), {
-        imageId: uploadedImage.id,
-        productionId,
-      });
+
+    // The lazy image fetch inside loadCmsData has not completed yet, so
+    // re-fetch images for this production directly to rebuild the gallery
+    // with the existing images plus the new one.
+    const refreshedImages = await getImagesByProduction(productionId);
+    const galleryImages = refreshedImages
+      .map((img) => {
+        const url = resolvePreferredCropUrl(img.crops, window.location.origin);
+        return url ? { id: img.id, url } : null;
+      })
+      .filter((img): img is { id: number; url: string } => img !== null);
+
+    openImageGalleryPreview(galleryImages, label, productionId);
+    const focusIndex = galleryImages.findIndex((img) => img.id === uploadedImage.id);
+    if (focusIndex > 0) {
+      syncGalleryPreview(focusIndex);
     }
     showSaveSuccess(t("cms.feedback.mediaAddSuccess"));
   } catch (error) {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -257,6 +257,7 @@ export default {
       loadGeneric: "Could not load CMS data.",
       saveFailed: "Save failed: {message}",
       saveGeneric: "Save failed.",
+      unsupportedImageType: "Unsupported image type ({type}). Use JPG, PNG, WebP or GIF.",
     },
     feedback: {
       saveSuccess: "Changes saved successfully",

--- a/frontend/src/i18n/locales/fr.ts
+++ b/frontend/src/i18n/locales/fr.ts
@@ -255,6 +255,7 @@ export default {
       loadGeneric: "Impossible de charger les donnees CMS.",
       saveFailed: "Echec de l'enregistrement: {message}",
       saveGeneric: "Echec de l'enregistrement.",
+      unsupportedImageType: "Type d'image non pris en charge ({type}). Utilisez JPG, PNG, WebP ou GIF.",
     },
     feedback: {
       saveSuccess: "Modifications enregistrees",

--- a/frontend/src/i18n/locales/nl.ts
+++ b/frontend/src/i18n/locales/nl.ts
@@ -254,6 +254,7 @@ export default {
       loadGeneric: "Kon CMS-gegevens niet laden.",
       saveFailed: "Opslaan mislukt: {message}",
       saveGeneric: "Opslaan mislukt.",
+      unsupportedImageType: "Niet-ondersteund afbeeldingstype ({type}). Gebruik JPG, PNG, WebP of GIF.",
     },
     feedback: {
       saveSuccess: "Wijzigingen opgeslagen",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -107,14 +107,35 @@ export class ApiError extends Error {
  * `RequestInit` extended with a typed `body` that is automatically serialised
  * to JSON. The native `body: BodyInit` is replaced so callers can pass any
  * value without manual `JSON.stringify`.
+ *
+ * Native `BodyInit` values (`FormData`, `Blob`, `URLSearchParams`,
+ * `ArrayBuffer`, `ArrayBufferView`, `ReadableStream`) are forwarded to
+ * `fetch` as-is — the browser sets `Content-Type` with the correct
+ * multipart boundary, and we do not call `JSON.stringify` on them.
  */
 type ApiFetchOptions = Omit<RequestInit, "body"> & {
   /**
-   * Request payload — serialised with `JSON.stringify` before sending.
-   * Omit this field entirely for requests without a body (GET, DELETE, …).
+   * Request payload — serialised with `JSON.stringify` before sending,
+   * unless it is a native `BodyInit` value, in which case it is forwarded
+   * unchanged. Omit this field entirely for requests without a body.
    */
   body?: unknown;
 };
+
+/**
+ * Returns `true` for body values that `fetch` accepts directly and that
+ * must NOT be passed through `JSON.stringify`.
+ */
+function isNativeBodyInit(body: unknown): body is BodyInit {
+  return (
+    body instanceof FormData ||
+    body instanceof Blob ||
+    body instanceof URLSearchParams ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body) ||
+    (typeof ReadableStream !== "undefined" && body instanceof ReadableStream)
+  );
+}
 
 /**
  * Fetch wrapper for all `/api/v1/*` calls.
@@ -149,13 +170,20 @@ export async function apiFetch<T>(
 ): Promise<T> {
   const { body, headers, ...rest } = options;
 
+  const native = body !== undefined && isNativeBodyInit(body);
+  const requestBody: BodyInit | undefined =
+    body === undefined ? undefined : native ? (body as BodyInit) : JSON.stringify(body);
+
   const response = await fetch(`${API_BASE}${path}`, {
     credentials: "include",
     headers: {
-      ...(body !== undefined ? { "Content-Type": "application/json" } : {}), // no content header if there's no body
+      // Only set JSON content-type for JSON-serialised bodies. For native
+      // BodyInit (FormData, Blob, …) let the browser set the correct header
+      // including any multipart boundary.
+      ...(body !== undefined && !native ? { "Content-Type": "application/json" } : {}),
       ...(headers as Record<string, string>),
     },
-    body: body !== undefined ? JSON.stringify(body) : undefined,
+    body: requestBody,
     ...rest,
   });
 

--- a/frontend/test/components/admin/cms/productions/CmsCreateProductionModal.test.ts
+++ b/frontend/test/components/admin/cms/productions/CmsCreateProductionModal.test.ts
@@ -89,7 +89,7 @@ describe("CmsCreateProductionModal.vue", () => {
       }),
     });
 
-    await wrapper.get('input[type="file"][accept="image/*"]').trigger("change");
+    await wrapper.get('input[type="file"]').trigger("change");
     await wrapper.get(".cms-modal-overlay").trigger("click.self");
     await wrapper.get(".cms-side-save").trigger("click");
 

--- a/frontend/test/components/admin/cms/productions/CmsProductionsTab.test.ts
+++ b/frontend/test/components/admin/cms/productions/CmsProductionsTab.test.ts
@@ -1054,7 +1054,10 @@ describe("CmsProductionsTab", () => {
         value: "upload.png",
       },
     } as never);
-    expect(api.mediaPreview.value?.url).toBe("");
+    // After upload the preview is rebuilt as a gallery; with no images mocked
+    // it falls back to the placeholder image.
+    expect(api.mediaPreview.value?.kind).toBe("image");
+    expect(api.mediaPreview.value?.url).toMatch(/^data:image\/svg\+xml/);
 
     api.mediaPreview.value = {
       kind: "iframe",

--- a/frontend/test/services/api.test.ts
+++ b/frontend/test/services/api.test.ts
@@ -155,6 +155,67 @@ describe("apiFetch", () => {
     expect(call[1].body).toBeUndefined();
   });
 
+  // ── Native BodyInit (FormData, Blob, …) ─────────────────────────────────────
+  // These must NOT be JSON-stringified and must NOT get an explicit
+  // Content-Type header (the browser sets it with the multipart boundary).
+
+  it("forwards FormData bodies without serialising or setting Content-Type", async () => {
+    const formData = new FormData();
+    formData.append("image", new Blob(["x"], { type: "image/jpeg" }), "image.jpg");
+
+    await apiFetch("/production/1/image", { method: "POST", body: formData });
+
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(call[1].body).toBe(formData);
+    expect(call[1].headers).not.toHaveProperty("Content-Type");
+  });
+
+  it("forwards Blob bodies without serialising", async () => {
+    const blob = new Blob(["binary"], { type: "application/octet-stream" });
+
+    await apiFetch("/upload", { method: "POST", body: blob });
+
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(call[1].body).toBe(blob);
+    expect(call[1].headers).not.toHaveProperty("Content-Type");
+  });
+
+  it("forwards URLSearchParams bodies without serialising", async () => {
+    const params = new URLSearchParams({ key: "value" });
+
+    await apiFetch("/form", { method: "POST", body: params });
+
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(call[1].body).toBe(params);
+    expect(call[1].headers).not.toHaveProperty("Content-Type");
+  });
+
+  it("allows callers to set their own Content-Type on FormData requests", async () => {
+    const formData = new FormData();
+
+    await apiFetch("/x", {
+      method: "POST",
+      body: formData,
+      headers: { "X-Custom": "value" },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-Custom": "value" }),
+      }),
+    );
+  });
+
   it("merges extra headers with defaults when body is provided", async () => {
     await apiFetch("/production", {
       method: "POST",


### PR DESCRIPTION
Closes #533

## Root cause

`apiFetch` in [frontend/src/services/api.ts](frontend/src/services/api.ts) called `JSON.stringify` on every body and set `Content-Type: application/json` whenever a body was present. The CMS media upload in [frontend/src/services/cms/media-upload.ts](frontend/src/services/cms/media-upload.ts) passes a `FormData` (image blob + crop blobs) to `apiFetch`. `JSON.stringify(formData)` returns `\"{}\"`, so the backend handler at [backend/src/routes/media/handlers/create.ts](backend/src/routes/media/handlers/create.ts) — which requires `multipart/form-data` — received an empty JSON body and rejected the request.

The error was caught and only `console.error`'d in `submitCreateProduction` (CmsProductionsTab.vue:1417-1423), and rendered as a non-blocking toast in `onMediaPreviewImageSelected`, so users saw no clear feedback — matching the issue: \"I add an image, but it doesn't get actually added\".

The existing media-upload tests didn't catch this because they mock `apiFetch`, never exercising the real fetch path.

## Fix

Detect native `BodyInit` values (`FormData`, `Blob`, `URLSearchParams`, `ArrayBuffer`, `ArrayBufferView`, `ReadableStream`) in `apiFetch` and forward them to `fetch` unchanged. Skip the JSON `Content-Type` header for these so the browser sets the correct header (including the multipart boundary).

## Test plan

- [x] `npx vitest run test/services/api.test.ts` — new FormData/Blob/URLSearchParams test cases all green
- [x] `npx vitest run` — full suite 1577/1577 ✅
- [x] `npm run lint` ✅
- [x] `npx vue-tsc --noEmit` ✅
- [ ] Manueel met draaiende backend: in CMS productions tab een nieuwe productie aanmaken mét image → image verschijnt in de image kolom na opslaan
- [ ] Manueel: op image kolom van een bestaande productie klikken → \"Add image\" → image wordt zichtbaar in de gallery